### PR TITLE
abi: deduplicate selectors when combining

### DIFF
--- a/abi/ICombined.json
+++ b/abi/ICombined.json
@@ -7407,29 +7407,6 @@
   },
   {
     "type": "function",
-    "name": "initialize",
-    "inputs": [
-      {
-        "name": "initialOwner",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "darkpool_",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "uniswapXReactor_",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "isWhitelistedSolver",
     "inputs": [
       {
@@ -7443,19 +7420,6 @@
         "name": "",
         "type": "bool",
         "internalType": "bool"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "owner",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
       }
     ],
     "stateMutability": "view"

--- a/abi/generate_abis.sh
+++ b/abi/generate_abis.sh
@@ -11,11 +11,18 @@ forge inspect ../src/libraries/interfaces/IGasSponsor.sol:IGasSponsor abi --json
 echo "Generating IDarkpool ABI..."
 forge inspect ../src/libraries/interfaces/IDarkpool.sol:IDarkpool abi --json > IDarkpool.json
 
-echo "Generating IDarkpoolExecutor ABI..."
-forge inspect ../src/libraries/interfaces/IDarkpoolExecutor.sol:IDarkpoolExecutor abi --json > IDarkpoolExecutor.json
+echo "Generating IDarkpoolExecutor ABI (filtering duplicates)..."
+# Generate full ABI then strip the two signatures that are already
+# present in other interfaces (owner() and initialize(address,address,address))
+#
+# This is necessary because the ABI crate will not build if the combined ABI
+# contains duplicate selectors.
+forge inspect ../src/libraries/interfaces/IDarkpoolExecutor.sol:IDarkpoolExecutor abi --json \
+  | jq '[ .[] | select( (.name != "owner") and ((.name == "initialize" and ((.inputs|map(.type)|join(",")) == "address,address,address")) | not) ) ]' \
+  > IDarkpoolExecutor.json
 
-# Combine the ABI files
 echo "Combining ABI files into ICombined.json..."
+
 jq -s 'add' IGasSponsor.json IDarkpool.json IDarkpoolExecutor.json > ICombined.json
 
 # Clean up individual ABI files


### PR DESCRIPTION
### Purpose
This PR ensures we deduplicate selectors when combining ABIs. This became an issue when the DarkpoolExecutor was added because it had functions with identical signatures as functions in the GasSponor and Darkpool contracts.

We opt for a more manual, hard-coded approach to removing the duplicate signatures rather than a more dynamic one for simplicity, as the `jq` query to deduplicate was long and resulted in a significantly larger diff in the resulting combined ABI.

### Testing
- [x] `abi` crate builds, will defer testing until the `DarkpoolExecutorClient` is built