### PR TITLE
Darkpool: Emit NotePosted after insertion into merkle tree

### DIFF
--- a/src/darkpool/Darkpool.sol
+++ b/src/darkpool/Darkpool.sol
@@ -815,7 +815,10 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         );
 
         // 4. Commit the note into the merkle tree
-        _commitNote(statement.noteCommitment);
+        merkleTree.insertLeaf(statement.noteCommitment, hasher);
+
+        // 5. Emit the event
+        emit NotePosted(statement.noteCommitment);
     }
 
     /// @notice Redeem a fee that has been paid offline into a wallet
@@ -877,12 +880,5 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         assembly {
             value := mload(add(data, 32))
         }
-    }
-
-    /// @notice Insert a note commitment into the Merkle tree and emit `NotePosted`
-    /// @param noteCommitment The note commitment as a BN254.ScalarField
-    function _commitNote(BN254.ScalarField noteCommitment) internal {
-        merkleTree.insertLeaf(noteCommitment, hasher);
-        emit NotePosted(noteCommitment);
     }
 }

--- a/src/darkpool/Darkpool.sol
+++ b/src/darkpool/Darkpool.sol
@@ -66,6 +66,7 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
     event ExternalMatchFeeChanged(address indexed asset, uint256 newFee);
     event PubkeyRotated(uint256 newPubkeyX, uint256 newPubkeyY);
     event ExternalFeeCollectionAddressChanged(address indexed newAddress);
+    event NotePosted(BN254.ScalarField indexed noteCommitment);
 
     /// @notice The protocol fee rate for the darkpool
     /// @dev This is the fixed point representation of a real number between 0 and 1.
@@ -814,7 +815,7 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         );
 
         // 4. Commit the note into the merkle tree
-        merkleTree.insertLeaf(statement.noteCommitment, hasher);
+        _commitNote(statement.noteCommitment);
     }
 
     /// @notice Redeem a fee that has been paid offline into a wallet
@@ -876,5 +877,12 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         assembly {
             value := mload(add(data, 32))
         }
+    }
+
+    /// @notice Insert a note commitment into the Merkle tree and emit `NotePosted`
+    /// @param noteCommitment The note commitment as a BN254.ScalarField
+    function _commitNote(BN254.ScalarField noteCommitment) internal {
+        merkleTree.insertLeaf(noteCommitment, hasher);
+        emit NotePosted(noteCommitment);
     }
 }

--- a/src/darkpool/Darkpool.sol
+++ b/src/darkpool/Darkpool.sol
@@ -66,7 +66,7 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
     event ExternalMatchFeeChanged(address indexed asset, uint256 newFee);
     event PubkeyRotated(uint256 newPubkeyX, uint256 newPubkeyY);
     event ExternalFeeCollectionAddressChanged(address indexed newAddress);
-    event NotePosted(BN254.ScalarField indexed noteCommitment);
+    event NotePosted(uint256 indexed noteCommitment);
 
     /// @notice The protocol fee rate for the darkpool
     /// @dev This is the fixed point representation of a real number between 0 and 1.
@@ -818,7 +818,7 @@ contract Darkpool is Initializable, Ownable2Step, Pausable {
         merkleTree.insertLeaf(statement.noteCommitment, hasher);
 
         // 5. Emit the event
-        emit NotePosted(statement.noteCommitment);
+        emit NotePosted(BN254.ScalarField.unwrap(statement.noteCommitment));
     }
 
     /// @notice Redeem a fee that has been paid offline into a wallet

--- a/src/libraries/interfaces/IDarkpool.sol
+++ b/src/libraries/interfaces/IDarkpool.sol
@@ -53,6 +53,9 @@ interface IDarkpool {
     /// @notice Emitted when a nullifier is spent
     /// @param nullifier The nullifier that was spent
     event NullifierSpent(BN254.ScalarField nullifier);
+    /// @notice Emitted when a note commitment is inserted into the Merkle tree
+    /// @param noteCommitment The commitment inserted
+    event NotePosted(BN254.ScalarField indexed noteCommitment);
 
     /// @notice Initialize the darkpool
     /// @param initialOwner The initial owner of the contract

--- a/src/libraries/interfaces/IDarkpool.sol
+++ b/src/libraries/interfaces/IDarkpool.sol
@@ -55,7 +55,7 @@ interface IDarkpool {
     event NullifierSpent(BN254.ScalarField nullifier);
     /// @notice Emitted when a note commitment is inserted into the Merkle tree
     /// @param noteCommitment The commitment inserted
-    event NotePosted(BN254.ScalarField indexed noteCommitment);
+    event NotePosted(uint256 indexed noteCommitment);
 
     /// @notice Initialize the darkpool
     /// @param initialOwner The initial owner of the contract


### PR DESCRIPTION
### Purpose
This PR adds the `NotePosted` event and emits it after successful insertion into the merkle tree during offline fee settlement. We use the `BN254.ScalarField` type as the indexed parameter in `NotePosted` to avoid manually unwrapping the value, which should be safe since UDVTs have identical ABI representation to their underlying types.

### Testing
- [x] Test suite passes