### PR TITLE
Darkpool, ExternalTransfer: emit ExternalTransfer event

### DIFF
--- a/src/libraries/darkpool/ExternalTransfers.sol
+++ b/src/libraries/darkpool/ExternalTransfers.sol
@@ -12,6 +12,7 @@ import { PublicRootKey, publicKeyToUints, publicKeyToUints } from "renegade-lib/
 
 import { DarkpoolConstants } from "renegade-lib/darkpool/Constants.sol";
 import { WalletOperations } from "renegade-lib/darkpool/WalletOperations.sol";
+import { IDarkpool } from "../interfaces/IDarkpool.sol";
 import { IPermit2 } from "permit2-lib/interfaces/IPermit2.sol";
 import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { ISignatureTransfer } from "permit2-lib/interfaces/ISignatureTransfer.sol";
@@ -77,6 +78,7 @@ library ExternalTransferLib {
         // Check that the balance after the transfer equals the expected balance
         uint256 balanceAfter = getDarkpoolBalance(transfer.mint);
         require(balanceAfter == expectedBalance, "Balance after transfer does not match expected balance");
+        emit IDarkpool.ExternalTransfer(transfer.account, transfer.mint, !isDeposit, transfer.amount);
     }
 
     /// @notice Execute a batch of simple ERC20 transfers

--- a/src/libraries/interfaces/IDarkpool.sol
+++ b/src/libraries/interfaces/IDarkpool.sol
@@ -53,6 +53,12 @@ interface IDarkpool {
     /// @notice Emitted when a nullifier is spent
     /// @param nullifier The nullifier that was spent
     event NullifierSpent(BN254.ScalarField nullifier);
+    /// @notice Emitted when an external transfer is executed
+    /// @param account The account that the transfer is executed for
+    /// @param mint The mint of the token that is transferred
+    /// @param isWithdrawal Whether the transfer is a withdrawal
+    /// @param amount The amount of the token that is transferred
+    event ExternalTransfer(address indexed account, address indexed mint, bool indexed isWithdrawal, uint256 amount);
     /// @notice Emitted when a note commitment is inserted into the Merkle tree
     /// @param noteCommitment The commitment inserted
     event NotePosted(uint256 indexed noteCommitment);


### PR DESCRIPTION
### Purpose
This PR adds the ExternalTransfer event and emits it after a successful deposit / withdraw. This mimics the Arbitrum event found [here](https://github.com/renegade-fi/renegade-contracts/blob/bc11c982177c8c407d3f3d77cb8be59741c0bfff/contracts-stylus/src/utils/solidity.rs/#L83).

### Testing
- [x] Ran tests locally