### PR TITLE
scripts, tools: Add Darkpool Implementation deploy command

### DIFF
--- a/script/DeployDarkpoolImplementation.s.sol
+++ b/script/DeployDarkpoolImplementation.s.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Script.sol";
+import "./utils/DeployUtils.sol";
+
+/// @notice Deploys only the Darkpool implementation contract. Use this when upgrading the proxy.
+contract DeployDarkpoolImplementationScript is Script {
+    function run() public {
+        vm.startBroadcast();
+        DeployUtils.deployDarkpoolImplementation(vm);
+        vm.stopBroadcast();
+    }
+}

--- a/script/utils/DeployUtils.sol
+++ b/script/utils/DeployUtils.sol
@@ -161,6 +161,14 @@ library DeployUtils {
         return address(darkpoolProxy);
     }
 
+    /// @dev Deploy only the Darkpool implementation contract for proxy upgrades
+    function deployDarkpoolImplementation(Vm vm) internal returns (address implAddr) {
+        Darkpool darkpool = new Darkpool();
+        writeDeployment(vm, "Darkpool", address(darkpool));
+        console.log("Darkpool implementation deployed at:", address(darkpool));
+        return address(darkpool);
+    }
+
     /// @dev Write a deployment address to the deployments.json file
     /// @param vm The VM to run the commands with
     /// @param contractName The name of the contract being deployed


### PR DESCRIPTION
### Purpose
This PR adds a script to deploy the darkpool implementation contract without deploying a proxy contract. This will be used to deploy new versions of the darkpool contract prioir to upgrading the proxy contract to point to these new deployments.

### Testing
- [x] Test against locally running `anvil` node