### PR TITLE
darkpoolv2: settlement: Verify executor signature over obligation

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -152,8 +152,8 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
         SettlementLib.checkObligationCompatibility(party0SettlementBundle.obligation, party1SettlementBundle.obligation);
 
         // 2. Authorize the intents in the settlement bundles
-        SettlementLib.authorizeIntent(party0SettlementBundle.intent);
-        SettlementLib.authorizeIntent(party1SettlementBundle.intent);
+        SettlementLib.authorizeIntent(party0SettlementBundle);
+        SettlementLib.authorizeIntent(party1SettlementBundle);
 
         // 3. Validate the intent and balance constraints on the obligations
         SettlementLib.validateObligationConstraints(party0SettlementBundle);

--- a/src/darkpool/v2/types/Settlement.sol
+++ b/src/darkpool/v2/types/Settlement.sol
@@ -44,7 +44,10 @@ struct PublicIntentAuthBundle {
     /// @dev The intent authorization permit
     PublicIntentPermit permit;
     /// @dev The signature of the intent
-    bytes signature;
+    bytes intentSignature;
+    /// @dev The signature of the settlement obligation by the authorized executor
+    /// @dev This authorizes the fields of the obligation, and importantly implicitly authorizes the price
+    bytes executorSignature;
 }
 
 /// @notice Intent authorization data for a public intent

--- a/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
@@ -3,15 +3,23 @@ pragma solidity ^0.8.24;
 
 /* solhint-disable func-name-mixedcase */
 
-import { DarkpoolV2TestBase } from "../../DarkpoolV2TestBase.sol";
-import { IntentBundle, IntentType, PublicIntentAuthBundle, PublicIntentPermit } from "darkpoolv2-types/Settlement.sol";
+import {
+    SettlementBundle,
+    ObligationBundle,
+    ObligationType,
+    IntentBundle,
+    IntentType,
+    PublicIntentAuthBundle,
+    PublicIntentPermit
+} from "darkpoolv2-types/Settlement.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
+import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
 import { SettlementLib } from "darkpoolv2-libraries/SettlementLib.sol";
 import { FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
-contract IntentAuthorizationTest is DarkpoolV2TestBase {
+contract IntentAuthorizationTest is SettlementTestUtils {
     // Test wallets
     Vm.Wallet internal intentOwner;
     Vm.Wallet internal executor;
@@ -41,55 +49,81 @@ contract IntentAuthorizationTest is DarkpoolV2TestBase {
         });
     }
 
+    /// @notice Helper to create a sample settlement bundle
+    function createSampleBundle() internal view returns (SettlementBundle memory) {
+        // Create obligation
+        SettlementObligation memory obligation = SettlementObligation({
+            inputToken: address(baseToken),
+            outputToken: address(quoteToken),
+            amountIn: 100,
+            amountOut: 200
+        });
+
+        ObligationBundle memory obligationBundle =
+            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation) });
+
+        // Create intent and signatures
+        Intent memory intent = createSampleIntent();
+        bytes memory intentSignature = signIntentPermit(intent, executor.addr, intentOwner.privateKey);
+        bytes memory executorSignature = signObligation(obligationBundle, executor.privateKey);
+
+        // Create the auth bundle
+        PublicIntentAuthBundle memory authBundle = PublicIntentAuthBundle({
+            permit: PublicIntentPermit({ intent: intent, executor: executor.addr }),
+            intentSignature: intentSignature,
+            executorSignature: executorSignature
+        });
+
+        IntentBundle memory intentBundle = IntentBundle({ intentType: IntentType.PUBLIC, data: abi.encode(authBundle) });
+        return SettlementBundle({ obligation: obligationBundle, intent: intentBundle });
+    }
+
     // ---------
     // | Tests |
     // ---------
 
-    function test_validSignature() public view {
-        // Create intent & signature
-        Intent memory intent = createSampleIntent();
-        bytes memory signature = SettlementTestUtils.signIntentPermit(intent, executor.addr, intentOwner.privateKey);
-
-        // Create the auth bundle
-        PublicIntentAuthBundle memory authBundle = PublicIntentAuthBundle({
-            permit: PublicIntentPermit({ intent: intent, executor: executor.addr }),
-            signature: signature
-        });
-        IntentBundle memory intentBundle = IntentBundle({ intentType: IntentType.PUBLIC, data: abi.encode(authBundle) });
-
+    function test_validSignatures() public view {
         // Should not revert
-        SettlementLib.authorizeIntent(intentBundle);
+        SettlementBundle memory bundle = createSampleBundle();
+        SettlementLib.authorizeIntent(bundle);
     }
 
-    function test_invalidSignature_wrongSigner() public {
-        // Create intent and sign with wrong signer
-        Intent memory intent = createSampleIntent();
-        bytes memory signature = SettlementTestUtils.signIntentPermit(intent, executor.addr, wrongSigner.privateKey);
-
-        // Create intent bundle and try to authorize
-        IntentBundle memory intentBundle = IntentBundle({ intentType: IntentType.PUBLIC, data: abi.encode(signature) });
-        // Should revert with InvalidIntentSignature
-        vm.expectRevert(SettlementLib.InvalidIntentSignature.selector);
-        SettlementLib.authorizeIntent(intentBundle);
-    }
-
-    function test_invalidSignature_modifiedBytes() public {
-        // Create intent & signature, then modify the signature
-        Intent memory intent = createSampleIntent();
-        bytes memory signature = SettlementTestUtils.signIntentPermit(intent, executor.addr, intentOwner.privateKey);
-        signature[0] = bytes1(uint8(signature[0]) ^ 0xFF);
-
-        // Create the auth bundle
-        PublicIntentAuthBundle memory authBundle = PublicIntentAuthBundle({
-            permit: PublicIntentPermit({ intent: intent, executor: executor.addr }),
-            signature: signature
-        });
-
-        // Create intent bundle
-        IntentBundle memory intentBundle = IntentBundle({ intentType: IntentType.PUBLIC, data: abi.encode(authBundle) });
+    function test_invalidIntentSignature_wrongSigner() public {
+        // Create bundle and replace the intent signature with a wrong signatures
+        SettlementBundle memory bundle = createSampleBundle();
+        PublicIntentAuthBundle memory authBundle = abi.decode(bundle.intent.data, (PublicIntentAuthBundle));
+        bytes memory sig =
+            signIntentPermit(authBundle.permit.intent, authBundle.permit.executor, wrongSigner.privateKey);
+        authBundle.intentSignature = sig;
+        bundle.intent.data = abi.encode(authBundle);
 
         // Should revert with InvalidIntentSignature
         vm.expectRevert(SettlementLib.InvalidIntentSignature.selector);
-        SettlementLib.authorizeIntent(intentBundle);
+        SettlementLib.authorizeIntent(bundle);
+    }
+
+    function test_invalidIntentSignature_modifiedBytes() public {
+        // Create bundle with modified intent signature
+        SettlementBundle memory bundle = createSampleBundle();
+        PublicIntentAuthBundle memory authBundle = abi.decode(bundle.intent.data, (PublicIntentAuthBundle));
+        authBundle.intentSignature[0] = bytes1(uint8(authBundle.intentSignature[0]) ^ 0xFF); // Modify signature
+        bundle.intent.data = abi.encode(authBundle);
+
+        // Should revert with InvalidIntentSignature
+        vm.expectRevert(SettlementLib.InvalidIntentSignature.selector);
+        SettlementLib.authorizeIntent(bundle);
+    }
+
+    function test_invalidExecutorSignature_wrongSigner() public {
+        // Create bundle with executor signature from wrong signer
+        SettlementBundle memory bundle = createSampleBundle();
+        PublicIntentAuthBundle memory authBundle = abi.decode(bundle.intent.data, (PublicIntentAuthBundle));
+        bytes memory sig = signObligation(bundle.obligation, wrongSigner.privateKey);
+        authBundle.executorSignature = sig;
+        bundle.intent.data = abi.encode(authBundle);
+
+        // Should revert with InvalidExecutorSignature
+        vm.expectRevert(SettlementLib.InvalidExecutorSignature.selector);
+        SettlementLib.authorizeIntent(bundle);
     }
 }

--- a/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
@@ -3,13 +3,12 @@ pragma solidity ^0.8.24;
 
 /* solhint-disable func-name-mixedcase */
 
-import { DarkpoolV2TestBase } from "../../DarkpoolV2TestBase.sol";
 import { ObligationBundle, ObligationType } from "darkpoolv2-types/Settlement.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
 import { SettlementLib } from "darkpoolv2-libraries/SettlementLib.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
-contract ObligationCompatibilityTest is DarkpoolV2TestBase {
+contract ObligationCompatibilityTest is SettlementTestUtils {
     function setUp() public override {
         super.setUp();
     }
@@ -17,7 +16,7 @@ contract ObligationCompatibilityTest is DarkpoolV2TestBase {
     function test_compatibleObligations() public view {
         // Create compatible obligations
         (SettlementObligation memory party0Obligation, SettlementObligation memory party1Obligation) =
-            SettlementTestUtils.createCompatibleObligations(address(baseToken), address(quoteToken));
+            createCompatibleObligations(address(baseToken), address(quoteToken));
 
         ObligationBundle memory party0Bundle =
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(party0Obligation) });
@@ -31,7 +30,7 @@ contract ObligationCompatibilityTest is DarkpoolV2TestBase {
     function test_incompatiblePairs() public {
         // Party 0: Selling 100 base for 200 quote
         (SettlementObligation memory party0Obligation, SettlementObligation memory party1Obligation) =
-            SettlementTestUtils.createCompatibleObligations(address(baseToken), address(quoteToken));
+            createCompatibleObligations(address(baseToken), address(quoteToken));
 
         // Corrupt one of the obligations
         if (vm.randomBool()) {
@@ -52,7 +51,7 @@ contract ObligationCompatibilityTest is DarkpoolV2TestBase {
 
     function test_incompatibleAmounts() public {
         (SettlementObligation memory party0Obligation, SettlementObligation memory party1Obligation) =
-            SettlementTestUtils.createCompatibleObligations(address(baseToken), address(quoteToken));
+            createCompatibleObligations(address(baseToken), address(quoteToken));
 
         // Corrupt one of the obligations
         if (vm.randomBool()) {

--- a/test/darkpool/v2/settlement/settlement-lib/Utils.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/Utils.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
+import { DarkpoolV2TestBase } from "../../DarkpoolV2TestBase.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
+import { ObligationBundle } from "darkpoolv2-types/Settlement.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-import { Vm } from "forge-std/Vm.sol";
 
-library SettlementTestUtils {
+contract SettlementTestUtils is DarkpoolV2TestBase {
     /// @dev Sign an intent permit
     function signIntentPermit(
         Intent memory intent,
@@ -22,8 +23,25 @@ library SettlementTestUtils {
         bytes32 permitHash = EfficientHashLib.hash(permitBytes);
 
         // Sign with the private key
-        (uint8 v, bytes32 r, bytes32 s) =
-            Vm(address(uint160(uint256(keccak256("hevm cheat code"))))).sign(signerPrivateKey, permitHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, permitHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Sign an obligation bundle
+    function signObligation(
+        ObligationBundle memory obligation,
+        uint256 signerPrivateKey
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        // Create the message hash
+        bytes memory obligationBytes = abi.encode(obligation);
+        bytes32 obligationHash = EfficientHashLib.hash(obligationBytes);
+
+        // Sign with the private key
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, obligationHash);
         return abi.encodePacked(r, s, v);
     }
 


### PR DESCRIPTION
### Purpose
This PR adds an additional check to the public intent authorization wherein the authorized executor must have signed the settlement obligation. 

This effectively completes the delegated trust from user to relayer. The user delegates their intent to be executed by `executor` and the executor must sign off on any matches to validate the match params.

### Todo
- Insert verified intents into an `open_public_intents` map which we can use in place of signature verification.

### Testing
- [x] Unit tests pass