### PR TITLE
darkpoolv2: settlement: Use separate libraries for privacy rings

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -19,7 +19,7 @@ import { NullifierLib } from "renegade-lib/NullifierSet.sol";
 import { EncryptionKey } from "darkpoolv1-types/Ciphertext.sol";
 
 import { SettlementBundle } from "darkpoolv2-types/Settlement.sol";
-import { SettlementLib } from "darkpoolv2-libraries/SettlementLib.sol";
+import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
 
 /// @title DarkpoolV2
 /// @author Renegade Eng
@@ -180,12 +180,8 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
         SettlementLib.checkObligationCompatibility(party0SettlementBundle.obligation, party1SettlementBundle.obligation);
 
         // 2. Authorize the intents in the settlement bundles
-        SettlementLib.authorizeIntent(party0SettlementBundle, openPublicIntents);
-        SettlementLib.authorizeIntent(party1SettlementBundle, openPublicIntents);
-
-        // 3. Validate the intent and balance constraints on the obligations
-        SettlementLib.validateObligationConstraints(party0SettlementBundle);
-        SettlementLib.validateObligationConstraints(party1SettlementBundle);
+        SettlementLib.validateSettlementBundle(party0SettlementBundle, openPublicIntents);
+        SettlementLib.validateSettlementBundle(party1SettlementBundle, openPublicIntents);
 
         // 4. Settle the match by updating the balances for each party
         // TODO: Settlement logic

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {
+    SettlementBundle,
+    PublicIntentPublicBalanceBundle,
+    PublicIntentAuthBundle,
+    ObligationBundle,
+    PublicIntentPermit
+} from "darkpoolv2-types/Settlement.sol";
+import { SettlementLib } from "./SettlementLib.sol";
+
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { ECDSALib } from "renegade-lib/ECDSA.sol";
+
+/// @title Native Settled Public Intent Library
+/// @author Renegade Eng
+/// @notice Library for validating a natively settled public intent
+/// @dev A natively settled public intent is a public intent with a public (EOA) balance.
+library NativeSettledPublicIntentLib {
+    using SettlementLib for PublicIntentPermit;
+
+    /// @notice Error thrown when an intent signature is invalid
+    error InvalidIntentSignature();
+    /// @notice Error thrown when an executor signature is invalid
+    error InvalidExecutorSignature();
+
+    /// @notice Validate a public intent and public balance settlement bundle
+    /// @param settlementBundle The settlement bundle to validate
+    /// @param openPublicIntents Mapping of open public intents, this maps the intent hash to the amount remaining.
+    /// If an intent's hash is already in the mapping, we need not check its owner's signature.
+    function validate(
+        SettlementBundle calldata settlementBundle,
+        mapping(bytes32 => uint256) storage openPublicIntents
+    )
+        public
+    {
+        // Decode the settlement bundle data
+        PublicIntentPublicBalanceBundle memory bundleData =
+            abi.decode(settlementBundle.data, (PublicIntentPublicBalanceBundle));
+
+        // 1. Validate the intent authorization
+        validatePublicIntentAuthorization(bundleData.auth, settlementBundle.obligation, openPublicIntents);
+    }
+
+    // ------------------------
+    // | Intent Authorization |
+    // ------------------------
+
+    /// @notice Validate the authorization of a public intent
+    /// @param auth The public intent authorization bundle to validate
+    /// @param obligationBundle The obligation bundle to validate
+    /// @param openPublicIntents Mapping of open public intents, this maps the intent hash to the amount remaining.
+    /// If an intent's hash is already in the mapping, we need not check its owner's signature.
+    /// @dev We require two checks to pass for a public intent to be authorized:
+    /// 1. The executor has signed the settlement obligation. This authorizes the individual fill parameters.
+    /// 2. The intent owner has signed a tuple of (executor, intent). This authorizes the intent to be filled by the
+    /// executor.
+    function validatePublicIntentAuthorization(
+        PublicIntentAuthBundle memory auth,
+        ObligationBundle calldata obligationBundle,
+        mapping(bytes32 => uint256) storage openPublicIntents
+    )
+        internal
+    {
+        // Verify that the executor has signed the settlement obligation
+        bytes memory obligationBytes = abi.encode(obligationBundle);
+        bytes32 obligationHash = EfficientHashLib.hash(obligationBytes);
+        bool executorValid = ECDSALib.verify(obligationHash, auth.executorSignature, auth.permit.executor);
+        if (!executorValid) revert InvalidExecutorSignature();
+
+        // If the intent is already in the mapping, we need not check its owner's signature
+        bytes32 intentHash = auth.permit.computeIntentHash();
+        uint256 amountRemaining = openPublicIntents[intentHash];
+        if (amountRemaining > 0) {
+            return;
+        }
+
+        // If the intent is not in the mapping, this is its first fill, and we must verify the signature
+        bool sigValid = ECDSALib.verify(intentHash, auth.intentSignature, auth.permit.intent.owner);
+        if (!sigValid) revert InvalidIntentSignature();
+
+        // Now that we've authorized the intent, update the amount remaining mapping
+        openPublicIntents[intentHash] = auth.permit.intent.amountIn;
+    }
+}

--- a/src/darkpool/v2/types/Settlement.sol
+++ b/src/darkpool/v2/types/Settlement.sol
@@ -3,41 +3,76 @@ pragma solidity ^0.8.24;
 
 import { Intent } from "darkpoolv2-types/Intent.sol";
 
+// ---------------------------
+// | Settlement Bundle Types |
+// ---------------------------
+
 /// @notice A settlement bundle for a user
 /// @dev This type encapsulates all the data required to validate a user's obligation to a trade
 /// @dev and settle the trade. The fields themselves are tagged unions of different data types representing
 /// @dev the different privacy configurations for each side of the trade.
 struct SettlementBundle {
     /// @dev The settlement obligation
+    /// @dev Note that the settlement obligation may vary independently of the settlement bundle type.
+    /// For example, a renegade settled intent may have a public obligation. So we encode the obligation
+    /// separately from the settlement bundle data.
     ObligationBundle obligation;
-    /// @dev The intent to settle
-    IntentBundle intent;
+    /// @dev The type of settlement bundle
+    SettlementBundleType bundleType;
+    /// @dev The data validating the settlement bundle
+    bytes data;
 }
 
-/// @notice The obligation to settle
-/// @dev This type represents a tagged union of different obligation types: public and private
+/// @notice The type of settlement bundle
+/// @dev Each settlement bundle may be of a different type depending on the privacy configuration of the trade.
+/// @dev A settlement bundle contains an intent and a balance capitalizing the intent; each of which may be
+/// public or private. This gives us four possible combinations:
+/// 1. Public intent and public balance
+/// 2. Public intent and private balance
+/// 3. Private intent and public balance
+/// 4. Private intent and private balance
+/// However, we currently have no use for a private balance with a public intent, so we remove that use case.
+/// We term these the following:
+/// 1. *Natively Settled Public Intent*: A public intent with a public (EOA) balance
+/// 2. *Natively Settled Private Intent*: A private intent with a public (EOA) balance
+/// 3. *Renegade Settled Intent*: A private intent with a private (darkpool) balance
+enum SettlementBundleType {
+    NATIVELY_SETTLED_PUBLIC_INTENT,
+    NATIVELY_SETTLED_PRIVATE_INTENT,
+    RENEGADE_SETTLED_INTENT
+}
+
+/// @notice The settlement bundle data for a `PUBLIC_INTENT_PUBLIC_BALANCE` bundle
+/// TODO: Add balance information here
+struct PublicIntentPublicBalanceBundle {
+    /// @dev The public intent authorization payload with signature attached
+    PublicIntentAuthBundle auth;
+}
+
+// --------------------
+// | Obligation Types |
+// --------------------
+
+/// @notice The settlement obligation bundle for a user
+/// @dev This data represents the following based on the obligation type:
+/// 1. *Public Obligation*: A plaintext settlement obligation
+/// 2. TODO: Add private obligation data here
 struct ObligationBundle {
-    /// @dev The type of obligation to settle
+    /// @dev The type of obligation
     ObligationType obligationType;
     /// @dev The data validating the obligation
     bytes data;
 }
 
-/// @notice The type of the obligation to settle
+/// @notice The types of obligations possible in the darkpool
 enum ObligationType {
     PUBLIC,
     PRIVATE
 }
 
-/// @notice The intent to settle
-/// @dev This type represents a tagged union of different intent types: public and private
-/// @dev The `data` field contains the fields required to authorize the intent type.
-struct IntentBundle {
-    /// @dev The type of intent to settle
-    IntentType intentType;
-    /// @dev The data validating the intent
-    bytes data;
-}
+// ------------------------------
+// | Intent Authorization Types |
+// ------------------------------
 
 /// @notice The public intent authorization payload with signature attached
 struct PublicIntentAuthBundle {
@@ -56,25 +91,4 @@ struct PublicIntentPermit {
     Intent intent;
     /// @dev The authorized executor of the intent
     address executor;
-}
-
-/// @notice The type of intent to settle
-enum IntentType {
-    PUBLIC,
-    PRIVATE
-}
-
-/// @notice The balance capitalizing the intent
-/// @dev This type represents a tagged union of different balance types: EOA and private
-struct BalanceBundle {
-    /// @dev The type of balance to settle
-    BalanceType balanceType;
-    /// @dev The data validating the balance type
-    bytes data;
-}
-
-/// @notice The type of the balance to settle
-enum BalanceType {
-    EOA,
-    PRIVATE
 }

--- a/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
@@ -3,9 +3,11 @@ pragma solidity ^0.8.24;
 
 /* solhint-disable func-name-mixedcase */
 
-import { ObligationBundle, ObligationType } from "darkpoolv2-types/Settlement.sol";
+import {
+    SettlementBundle, SettlementBundleType, ObligationBundle, ObligationType
+} from "darkpoolv2-types/Settlement.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
-import { SettlementLib } from "darkpoolv2-libraries/SettlementLib.sol";
+import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract ObligationCompatibilityTest is SettlementTestUtils {

--- a/test/darkpool/v2/settlement/settlement-lib/Utils.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/Utils.sol
@@ -4,25 +4,24 @@ pragma solidity ^0.8.24;
 import { DarkpoolV2TestBase } from "../../DarkpoolV2TestBase.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
-import { ObligationBundle } from "darkpoolv2-types/Settlement.sol";
+import { SettlementBundle, ObligationBundle, PublicIntentPermit } from "darkpoolv2-types/Settlement.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
 
 contract SettlementTestUtils is DarkpoolV2TestBase {
+    using SettlementLib for PublicIntentPermit;
+
     /// @dev Sign an intent permit
     function signIntentPermit(
-        Intent memory intent,
-        address executorAddr,
+        PublicIntentPermit memory permit,
         uint256 signerPrivateKey
     )
         internal
         pure
         returns (bytes memory)
     {
-        // Create the message hash
-        bytes memory permitBytes = abi.encode(executorAddr, intent);
-        bytes32 permitHash = EfficientHashLib.hash(permitBytes);
-
         // Sign with the private key
+        bytes32 permitHash = permit.computeIntentHash();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, permitHash);
         return abi.encodePacked(r, s, v);
     }


### PR DESCRIPTION
### Purpose
This PR refactors the settlement lib to branch earlier in the settlement verification process on a per-ring basis. That is, we will define privacy-ring-specific settlement verification libraries and branch at the top level into those.

This PR implements the beginning of the ring 0 library, bringing over logic that was present in `SettlementLib.sol` before.

### Testing
- [x] All test pass