### PR TITLE
darkpoolv2: settlement: Use per-type libs for type hashing

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,20 @@
+[lint]
+exclude_lints = ["incorrect-shift"]
+
+[fmt]
+line_length = 120
+tab_width = 4
+bracket_spacing = true
+int_types = "long"
+multiline_func_header = "all"
+quote_style = "double"
+number_underscore = "thousands"
+wrap_comments = true
+ignore = [
+    "src/darkpool/v1/libraries/VerificationKeys.sol",
+    "src/libraries/merkle/MerkleZeros.sol",
+]
+
 [profile.default]
 evm_version = "cancun"
 src = "src"
@@ -30,17 +47,3 @@ remappings = ["forge-std/=lib/forge-std/src/"]
 via_ir = true
 optimizer = true
 optimizer_runs = 100_000
-
-[fmt]
-line_length = 120
-tab_width = 4
-bracket_spacing = true
-int_types = "long"
-multiline_func_header = "all"
-quote_style = "double"
-number_underscore = "thousands"
-wrap_comments = true
-ignore = [
-    "src/darkpool/v1/libraries/VerificationKeys.sol",
-    "src/libraries/merkle/MerkleZeros.sol",
-]

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -11,11 +11,10 @@ import {
     ObligationLib,
     PublicIntentPermitLib
 } from "darkpoolv2-types/Settlement.sol";
-import { SettlementLib } from "./SettlementLib.sol";
 import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/SettlementObligation.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 
-import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { ECDSALib } from "renegade-lib/ECDSA.sol";
 
 /// @title Native Settled Public Intent Library
@@ -23,6 +22,7 @@ import { ECDSALib } from "renegade-lib/ECDSA.sol";
 /// @notice Library for validating a natively settled public intent
 /// @dev A natively settled public intent is a public intent with a public (EOA) balance.
 library NativeSettledPublicIntentLib {
+    using FixedPointLib for FixedPoint;
     using SettlementBundleLib for SettlementBundle;
     using ObligationLib for ObligationBundle;
     using SettlementObligationLib for SettlementObligation;
@@ -32,11 +32,19 @@ library NativeSettledPublicIntentLib {
     error InvalidIntentSignature();
     /// @notice Error thrown when an executor signature is invalid
     error InvalidExecutorSignature();
+    /// @notice Error thrown when an intent and obligation pair is invalid
+    error InvalidObligationPair();
+    /// @notice Error thrown when the input amount on the obligation is invalid
+    error InvalidObligationAmountIn(uint256 amountRemaining, uint256 amountIn);
+    /// @notice Error thrown when the implied price of the obligation does not meet the
+    /// minimum authorized price
+    error InvalidObligationPrice(uint256 amountOut, uint256 minAmountOut);
 
     /// @notice Validate a public intent and public balance settlement bundle
     /// @param settlementBundle The settlement bundle to validate
     /// @param openPublicIntents Mapping of open public intents, this maps the intent hash to the amount remaining.
     /// If an intent's hash is already in the mapping, we need not check its owner's signature.
+    /// TODO: Add bounds checks on the amounts in the intent and obligation
     function validate(
         SettlementBundle calldata settlementBundle,
         mapping(bytes32 => uint256) storage openPublicIntents
@@ -45,12 +53,14 @@ library NativeSettledPublicIntentLib {
     {
         // Decode the settlement bundle data
         PublicIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePublicBundleData();
-        ObligationBundle calldata obligationBundle = settlementBundle.obligation;
-        SettlementObligation memory obligation = obligationBundle.decodePublicObligation();
+        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
 
         // 1. Validate the intent authorization
-        uint256 amountRemaining =
-            validatePublicIntentAuthorization(bundleData.auth, obligationBundle, openPublicIntents);
+        uint256 amountRemaining = validatePublicIntentAuthorization(bundleData.auth, obligation, openPublicIntents);
+
+        // 2. Validate the intent and balance constraints on the obligation
+        Intent memory intent = bundleData.auth.permit.intent;
+        validateObligationIntentConstraints(amountRemaining, intent, obligation);
     }
 
     // ------------------------
@@ -59,7 +69,7 @@ library NativeSettledPublicIntentLib {
 
     /// @notice Validate the authorization of a public intent
     /// @param auth The public intent authorization bundle to validate
-    /// @param obligationBundle The obligation bundle to validate
+    /// @param obligation The settlement obligation to validate
     /// @param openPublicIntents Mapping of open public intents, this maps the intent hash to the amount remaining.
     /// If an intent's hash is already in the mapping, we need not check its owner's signature.
     /// @dev We require two checks to pass for a public intent to be authorized:
@@ -69,14 +79,13 @@ library NativeSettledPublicIntentLib {
     /// @return amountRemaining The amount remaining of the intent
     function validatePublicIntentAuthorization(
         PublicIntentAuthBundle memory auth,
-        ObligationBundle calldata obligationBundle,
+        SettlementObligation memory obligation,
         mapping(bytes32 => uint256) storage openPublicIntents
     )
         internal
         returns (uint256 amountRemaining)
     {
         // Verify that the executor has signed the settlement obligation
-        SettlementObligation memory obligation = obligationBundle.decodePublicObligation();
         bytes32 obligationHash = obligation.computeObligationHash();
         bool executorValid = ECDSALib.verify(obligationHash, auth.executorSignature, auth.permit.executor);
         if (!executorValid) revert InvalidExecutorSignature();
@@ -103,16 +112,29 @@ library NativeSettledPublicIntentLib {
     // --------------------------
 
     /// @notice Validate the constraints on the settlement obligation
+    /// @param amountRemaining The amount remaining on the intent
     /// @param intent The intent to validate
-    /// @param obligationBundle The obligation bundle to validate
-    function validateObligationConstraints(
+    /// @param obligation The settlement obligation to validate
+    function validateObligationIntentConstraints(
+        uint256 amountRemaining,
         Intent memory intent,
-        ObligationBundle calldata obligationBundle
+        SettlementObligation memory obligation
     )
         internal
         pure
     {
-        // Decode the obligation
-        SettlementObligation memory obligation = obligationBundle.decodePublicObligation();
+        // Verify that the pair
+        bool pairValid = intent.inToken == obligation.inputToken && intent.outToken == obligation.outputToken;
+        if (!pairValid) revert InvalidObligationPair();
+
+        // Verify that the input amount does not exceed the authorized amount remaining
+        if (amountRemaining < obligation.amountIn) {
+            revert InvalidObligationAmountIn(amountRemaining, obligation.amountIn);
+        }
+
+        // Lastly, the obligation must be matched at a price that is *at least* the minimum authorized price
+        // The price here is in units of `outToken/inToken`
+        uint256 minAmountOut = intent.minPrice.unsafeFixedPointMul(obligation.amountIn);
+        if (obligation.amountOut < minAmountOut) revert InvalidObligationPrice(obligation.amountOut, minAmountOut);
     }
 }

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -1,14 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-
 import {
-    SettlementBundle,
-    SettlementBundleType,
-    ObligationBundle,
-    ObligationType,
-    PublicIntentPermit
+    SettlementBundle, SettlementBundleType, ObligationBundle, ObligationType
 } from "darkpoolv2-types/Settlement.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
 import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -100,14 +100,4 @@ library SettlementLib {
             revert("Not implemented");
         }
     }
-
-    // --- Helpers --- //
-
-    /// @notice Compute the intent hash for a given intent permit
-    /// @param permit The intent permit to compute the hash for
-    /// @return The hash of the intent permit
-    function computeIntentHash(PublicIntentPermit memory permit) internal pure returns (bytes32) {
-        bytes memory intentBytes = abi.encode(permit);
-        return EfficientHashLib.hash(intentBytes);
-    }
 }

--- a/src/darkpool/v2/types/Settlement.sol
+++ b/src/darkpool/v2/types/Settlement.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.24;
 
 import { Intent } from "darkpoolv2-types/Intent.sol";
+import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 
 // ---------------------------
 // | Settlement Bundle Types |
@@ -49,6 +51,26 @@ struct PublicIntentPublicBalanceBundle {
     PublicIntentAuthBundle auth;
 }
 
+/// @title Settlement Bundle Library
+/// @author Renegade Eng
+/// @notice Library for decoding settlement bundle data
+library SettlementBundleLib {
+    /// @notice The error type emitted when a settlement bundle type check fails
+    error InvalidSettlementBundleType();
+
+    /// @notice Decode a public settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePublicBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PublicIntentPublicBalanceBundle memory bundleData)
+    {
+        require(bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT, InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
+    }
+}
+
 // --------------------
 // | Obligation Types |
 // --------------------
@@ -68,6 +90,26 @@ struct ObligationBundle {
 enum ObligationType {
     PUBLIC,
     PRIVATE
+}
+
+/// @title Obligation Library
+/// @author Renegade Eng
+/// @notice Library for decoding and hashing obligation data
+library ObligationLib {
+    /// @notice The error type emitted when an obligation type check fails
+    error InvalidObligationType();
+
+    /// @notice Decode a public obligation
+    /// @param bundle The obligation bundle to decode
+    /// @return obligation The decoded obligation
+    function decodePublicObligation(ObligationBundle calldata bundle)
+        internal
+        pure
+        returns (SettlementObligation memory obligation)
+    {
+        require(bundle.obligationType == ObligationType.PUBLIC, InvalidObligationType());
+        obligation = abi.decode(bundle.data, (SettlementObligation));
+    }
 }
 
 // ------------------------------
@@ -91,4 +133,16 @@ struct PublicIntentPermit {
     Intent intent;
     /// @dev The authorized executor of the intent
     address executor;
+}
+
+/// @title Public Intent Permit Library
+/// @author Renegade Eng
+/// @notice Library for computing the hash of a public intent permit
+library PublicIntentPermitLib {
+    /// @notice Compute the hash of a public intent permit
+    /// @param permit The public intent permit to compute the hash for
+    /// @return The hash of the public intent permit
+    function computeHash(PublicIntentPermit memory permit) internal pure returns (bytes32) {
+        return EfficientHashLib.hash(abi.encode(permit));
+    }
 }

--- a/src/darkpool/v2/types/Settlement.sol
+++ b/src/darkpool/v2/types/Settlement.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache
+/* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.24;
 
 import { Intent } from "darkpoolv2-types/Intent.sol";

--- a/src/darkpool/v2/types/SettlementObligation.sol
+++ b/src/darkpool/v2/types/SettlementObligation.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache
 pragma solidity ^0.8.24;
 
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
 /// @notice A settlement obligation for a user
 struct SettlementObligation {
     /// @dev The input token address
@@ -11,4 +13,17 @@ struct SettlementObligation {
     uint256 amountIn;
     /// @dev The amount of the output token to receive, before fees
     uint256 amountOut;
+}
+
+/// @title Settlement Obligation Library
+/// @author Renegade Eng
+/// @notice Library for settlement obligation operations
+library SettlementObligationLib {
+    /// @notice Compute the obligation hash for a given settlement obligation
+    /// @param obligation The settlement obligation to compute the hash for
+    /// @return The hash of the obligation
+    function computeObligationHash(SettlementObligation memory obligation) internal pure returns (bytes32) {
+        bytes memory obligationBytes = abi.encode(obligation);
+        return EfficientHashLib.hash(obligationBytes);
+    }
 }

--- a/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
@@ -10,18 +10,20 @@ import {
     ObligationType,
     PublicIntentPublicBalanceBundle,
     PublicIntentAuthBundle,
-    PublicIntentPermit
+    PublicIntentPermit,
+    PublicIntentPermitLib
 } from "darkpoolv2-types/Settlement.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
-import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
+import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/SettlementObligation.sol";
 import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
+import { NativeSettledPublicIntentLib } from "darkpoolv2-libraries/settlement/NativeSettledPublicIntent.sol";
 import { FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract IntentAuthorizationTest is SettlementTestUtils {
-    using SettlementLib for PublicIntentPermit;
+    using PublicIntentPermitLib for PublicIntentPermit;
 
     // Test wallets
     Vm.Wallet internal intentOwner;
@@ -121,7 +123,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         bundle.data = abi.encode(bundleData);
 
         // Should revert with InvalidIntentSignature
-        vm.expectRevert(SettlementLib.InvalidIntentSignature.selector);
+        vm.expectRevert(NativeSettledPublicIntentLib.InvalidIntentSignature.selector);
         authorizeIntentHelper(bundle);
     }
 
@@ -135,7 +137,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         bundle.data = abi.encode(bundleData);
 
         // Should revert with InvalidIntentSignature
-        vm.expectRevert(SettlementLib.InvalidIntentSignature.selector);
+        vm.expectRevert(NativeSettledPublicIntentLib.InvalidIntentSignature.selector);
         authorizeIntentHelper(bundle);
     }
 
@@ -150,7 +152,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         bundle.data = abi.encode(bundleData);
 
         // Should revert with InvalidExecutorSignature
-        vm.expectRevert(SettlementLib.InvalidExecutorSignature.selector);
+        vm.expectRevert(NativeSettledPublicIntentLib.InvalidExecutorSignature.selector);
         authorizeIntentHelper(bundle);
     }
 
@@ -162,7 +164,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         // Verify the intent was cached in the mapping
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
-        bytes32 intentHash = authBundle.permit.computeIntentHash();
+        bytes32 intentHash = authBundle.permit.computeHash();
         uint256 amountRemaining = openPublicIntents[intentHash];
         assertEq(amountRemaining, authBundle.permit.intent.amountIn, "Intent not cached");
 

--- a/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
@@ -6,41 +6,17 @@ pragma solidity ^0.8.24;
 import {
     SettlementBundle,
     SettlementBundleType,
-    ObligationBundle,
-    ObligationType,
     PublicIntentPublicBalanceBundle,
     PublicIntentAuthBundle,
     PublicIntentPermit,
     PublicIntentPermitLib
 } from "darkpoolv2-types/Settlement.sol";
-import { Intent } from "darkpoolv2-types/Intent.sol";
-import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/SettlementObligation.sol";
 import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-libraries/settlement/NativeSettledPublicIntent.sol";
-import { FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-import { Vm } from "forge-std/Vm.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract IntentAuthorizationTest is SettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
-
-    // Test wallets
-    Vm.Wallet internal intentOwner;
-    Vm.Wallet internal executor;
-    Vm.Wallet internal wrongSigner;
-
-    // Storage for open public intents
-    mapping(bytes32 => uint256) internal openPublicIntents;
-
-    function setUp() public override {
-        super.setUp();
-
-        // Create test wallets
-        intentOwner = vm.createWallet("intent_owner");
-        executor = vm.createWallet("executor");
-        wrongSigner = vm.createWallet("wrong_signer");
-    }
 
     // -----------
     // | Helpers |
@@ -54,52 +30,6 @@ contract IntentAuthorizationTest is SettlementTestUtils {
     /// @notice Helper that accepts memory and calls library with calldata
     function authorizeIntentHelper(SettlementBundle memory bundle) internal {
         this._validateSettlementBundleCalldata(bundle);
-    }
-
-    /// @notice Helper to create a sample intent
-    function createSampleIntent() internal view returns (Intent memory) {
-        return Intent({
-            inToken: address(baseToken),
-            outToken: address(quoteToken),
-            owner: intentOwner.addr,
-            minPrice: FixedPointLib.wrap(2e18), // 2:1 ratio
-            amountIn: 100
-        });
-    }
-
-    /// @notice Helper to create a sample settlement bundle
-    function createSampleBundle() internal view returns (SettlementBundle memory) {
-        // Create obligation
-        SettlementObligation memory obligation = SettlementObligation({
-            inputToken: address(baseToken),
-            outputToken: address(quoteToken),
-            amountIn: 100,
-            amountOut: 200
-        });
-        ObligationBundle memory obligationBundle =
-            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation) });
-
-        // Create intent and signatures
-        Intent memory intent = createSampleIntent();
-        PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
-        bytes memory intentSignature = signIntentPermit(permit, intentOwner.privateKey);
-        bytes memory executorSignature = signObligation(obligationBundle, executor.privateKey);
-
-        // Create the auth bundle
-        PublicIntentAuthBundle memory authBundle = PublicIntentAuthBundle({
-            permit: PublicIntentPermit({ intent: intent, executor: executor.addr }),
-            intentSignature: intentSignature,
-            executorSignature: executorSignature
-        });
-
-        // Create the public intent public balance bundle
-        PublicIntentPublicBalanceBundle memory bundleData = PublicIntentPublicBalanceBundle({ auth: authBundle });
-
-        return SettlementBundle({
-            obligation: obligationBundle,
-            bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,
-            data: abi.encode(bundleData)
-        });
     }
 
     // ---------
@@ -136,8 +66,8 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         bundleData.auth = authBundle;
         bundle.data = abi.encode(bundleData);
 
-        // Should revert with InvalidIntentSignature
-        vm.expectRevert(NativeSettledPublicIntentLib.InvalidIntentSignature.selector);
+        // Should revert with ECDSAInvalidSignature (from OpenZeppelin ECDSA library)
+        vm.expectRevert(abi.encodeWithSignature("ECDSAInvalidSignature()"));
         authorizeIntentHelper(bundle);
     }
 

--- a/test/darkpool/v2/settlement/settlement-lib/IntentConstraints.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/IntentConstraints.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/* solhint-disable func-name-mixedcase */
+
+import { SettlementBundle, PublicIntentPermit, PublicIntentPermitLib } from "darkpoolv2-types/Settlement.sol";
+import { Intent } from "darkpoolv2-types/Intent.sol";
+import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { NativeSettledPublicIntentLib } from "darkpoolv2-libraries/settlement/NativeSettledPublicIntent.sol";
+import { SettlementTestUtils } from "./Utils.sol";
+
+contract IntentConstraintsTest is SettlementTestUtils {
+    using PublicIntentPermitLib for PublicIntentPermit;
+    using FixedPointLib for FixedPoint;
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @notice Wrapper to convert memory to calldata for library call
+    function _validateSettlementBundleCalldata(SettlementBundle calldata bundle) external {
+        NativeSettledPublicIntentLib.validate(bundle, openPublicIntents);
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// @notice Test that validation fails when intent and obligation have mismatched token pairs
+    function test_validateObligationIntentConstraints_InvalidPair() public {
+        // Create an intent for base -> quote
+        Intent memory intent = createSampleIntent();
+
+        // Corrupt the token pair
+        address inputToken = address(quoteToken);
+        address outputToken = address(baseToken);
+        if (vm.randomBool()) {
+            inputToken = address(weth);
+        } else {
+            outputToken = address(weth);
+        }
+
+        // Create an obligation for the mismatched pair
+        SettlementObligation memory obligation =
+            SettlementObligation({ inputToken: inputToken, outputToken: outputToken, amountIn: 100, amountOut: 200 });
+        SettlementBundle memory bundle = createSettlementBundle(intent, obligation);
+
+        // Expect the validation to revert with InvalidObligationPair
+        vm.expectRevert(NativeSettledPublicIntentLib.InvalidObligationPair.selector);
+        this._validateSettlementBundleCalldata(bundle);
+    }
+
+    /// @notice Test that validation fails when the input amount is larger than the intent amount
+    function test_validateObligationIntentConstraints_InvalidAmountIn() public {
+        // Create an intent and an obligation which is too large
+        Intent memory intent = createSampleIntent();
+        SettlementObligation memory obligation = SettlementObligation({
+            inputToken: address(baseToken),
+            outputToken: address(quoteToken),
+            amountIn: intent.amountIn + 1,
+            amountOut: 200
+        });
+        SettlementBundle memory bundle = createSettlementBundle(intent, obligation);
+
+        // Expect the validation to revert with InvalidObligationAmountIn
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NativeSettledPublicIntentLib.InvalidObligationAmountIn.selector,
+                intent.amountIn, // amountRemaining
+                intent.amountIn + 1 // amountIn (from obligation)
+            )
+        );
+        this._validateSettlementBundleCalldata(bundle);
+    }
+
+    /// TODO: Add a test which fills a public intent multiple times, overfilling the intent
+    /// on the second fill.
+
+    /// @notice Test that validation fails when the implied price of the obligation is less than the minimum authorized
+    /// price
+    function test_validateObligationIntentConstraints_InvalidPrice() public {
+        // Create an intent and an obligation which has a bad price
+        Intent memory intent = createSampleIntent();
+
+        uint256 amountIn = vm.randomUint(1, intent.amountIn);
+        uint256 minAmountOut = intent.minPrice.unsafeFixedPointMul(amountIn);
+        uint256 amountOut = minAmountOut - 1;
+        SettlementObligation memory obligation = SettlementObligation({
+            inputToken: address(baseToken),
+            outputToken: address(quoteToken),
+            amountIn: amountIn,
+            amountOut: amountOut
+        });
+        SettlementBundle memory bundle = createSettlementBundle(intent, obligation);
+
+        // Expect the validation to revert with InvalidObligationPrice
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NativeSettledPublicIntentLib.InvalidObligationPrice.selector, amountOut, minAmountOut
+            )
+        );
+        this._validateSettlementBundleCalldata(bundle);
+    }
+}

--- a/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
@@ -3,18 +3,12 @@ pragma solidity ^0.8.24;
 
 /* solhint-disable func-name-mixedcase */
 
-import {
-    SettlementBundle, SettlementBundleType, ObligationBundle, ObligationType
-} from "darkpoolv2-types/Settlement.sol";
+import { ObligationBundle, ObligationType } from "darkpoolv2-types/Settlement.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
 import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract ObligationCompatibilityTest is SettlementTestUtils {
-    function setUp() public override {
-        super.setUp();
-    }
-
     function test_compatibleObligations() public view {
         // Create compatible obligations
         (SettlementObligation memory party0Obligation, SettlementObligation memory party1Obligation) =


### PR DESCRIPTION
### Purpose

This PR adds the next step in the obligation verification for public intents; verifying that the obligation respects the intent parameters.

I also modularized the obligation and intent hashing into their own type-specific libraries for ergonomics.

### Testing

- [x] All unit tests pass