### PR TITLE
darkpoolv2: settlement: Execute transfers necessary to settle match

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -24,7 +24,7 @@ darkpoolv1-test/=test/darkpool/v1
 
 darkpoolv2-contracts/=src/darkpool/v2/contracts
 darkpoolv2-interfaces/=src/darkpool/v2/interfaces
-darkpoolv2-libraries/=src/darkpool/v2/libraries
+darkpoolv2-lib/=src/darkpool/v2/libraries
 darkpoolv2-types/=src/darkpool/v2/types
 
 renegade-lib/=src/libraries

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -19,7 +19,7 @@ import { NullifierLib } from "renegade-lib/NullifierSet.sol";
 import { EncryptionKey } from "darkpoolv1-types/Ciphertext.sol";
 
 import { SettlementBundle } from "darkpoolv2-types/Settlement.sol";
-import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
+import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 
 /// @title DarkpoolV2
 /// @author Renegade Eng
@@ -183,7 +183,12 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
         SettlementLib.validateSettlementBundle(party0SettlementBundle, openPublicIntents);
         SettlementLib.validateSettlementBundle(party1SettlementBundle, openPublicIntents);
 
-        // 4. Settle the match by updating the balances for each party
-        // TODO: Settlement logic
+        // 3. After the settlement bundles are validated, update the darkpool's state
+        // TODO: In this step, we re-decode the settlement bundles to operate on data. We mostly do
+        // this to handle both bundles simultaneously for e.g. ERC20 transfers. We could defer transfers
+        // to the end of the method like we do proofs, and operate on the decoded data all at once.
+        SettlementLib.updateDarkpoolState(party0SettlementBundle, party1SettlementBundle, weth);
+
+        // TODO: Verify proofs necessary for each step here
     }
 }

--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title DarkpoolConstants
+/// @author Renegade Eng
+/// @notice This library contains constants for the darkpool
+library DarkpoolConstants {
+    /// @notice The address used for native tokens in trade settlement
+    /// @dev This is currently just ETH, but intentionally written abstractly
+    address internal constant NATIVE_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @notice Check whether an address is the native token address
+    /// @param addr The address to check
+    /// @return True if the address is the native token address, false otherwise
+    function isNativeToken(address addr) public pure returns (bool) {
+        return addr == NATIVE_TOKEN_ADDRESS;
+    }
+}

--- a/src/darkpool/v2/libraries/Transfers.sol
+++ b/src/darkpool/v2/libraries/Transfers.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
+import { IERC20 } from "oz-contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "oz-contracts/token/ERC20/utils/SafeERC20.sol";
+import { SafeTransferLib } from "solmate/src/utils/SafeTransferLib.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+
+/// @title ExternalTransferLib
+/// @author Renegade Eng
+/// @notice This library implements the logic for executing ERC20 transfers
+/// @notice External transfers are either deposits or withdrawals into/from the darkpool
+/// @dev This library handles both ERC20 transfers that from native settlements as well as
+/// individual deposit/withdrawals into/from Merklized balances.
+library ExternalTransferLib {
+    // --- Errors --- //
+    /// @notice Thrown when balance after transfer does not match expected balance
+    error BalanceMismatch();
+    /// @notice Thrown when the deposit amount does not match the msg.value for a native token deposit
+    error InvalidDepositAmount();
+
+    // --- Types --- //
+
+    /// @notice A simple ERC20 transfer
+    struct SimpleTransfer {
+        /// @dev The address to withdraw to or deposit from
+        address account;
+        /// @dev The ERC20 token to transfer
+        address mint;
+        /// @dev The amount of tokens to transfer
+        uint256 amount;
+        /// @dev The type of transfer
+        SimpleTransferType transferType;
+    }
+
+    /// @notice The type of a simple ERC20 transfer
+    enum SimpleTransferType {
+        /// @dev A withdrawal
+        Withdrawal,
+        /// @dev A deposit using an permit2 allowance transfer
+        Permit2AllowanceDeposit,
+        /// @dev A deposit using an ERC20 approval directly
+        ERC20ApprovalDeposit
+    }
+
+    // --- Interface --- //
+
+    /// @notice Execute a single ERC20 transfer
+    /// @param transfer The transfer to execute
+    /// @param wrapper The WETH9 wrapper contract for native token handling
+    function executeTransfer(SimpleTransfer memory transfer, IWETH9 wrapper) internal {
+        // If the amount is zero, do nothing
+        if (transfer.amount == 0) {
+            return;
+        }
+
+        // Otherwise, execute the transfer
+        uint256 balanceBefore = getDarkpoolBalanceMaybeNative(transfer.mint, wrapper);
+        uint256 expectedBalance;
+        SimpleTransferType transferType = transfer.transferType;
+        if (transferType == SimpleTransferType.Withdrawal) {
+            executeSimpleWithdrawal(transfer, wrapper);
+            expectedBalance = balanceBefore - transfer.amount;
+        } else if (transferType == SimpleTransferType.Permit2AllowanceDeposit) {
+            revert("unimplemented");
+        } else {
+            executeErc20ApprovalDeposit(transfer, wrapper);
+            expectedBalance = balanceBefore + transfer.amount;
+        }
+
+        // Check that the balance after the transfer equals the expected balance
+        uint256 balanceAfter = getDarkpoolBalanceMaybeNative(transfer.mint, wrapper);
+        if (balanceAfter != expectedBalance) revert BalanceMismatch();
+    }
+
+    /// @notice Execute a batch of simple ERC20 transfers
+    /// @param transfers The batch of transfers to execute
+    /// @param wrapper The WETH9 wrapper contract for native token handling
+    function executeTransfers(SimpleTransfer[] memory transfers, IWETH9 wrapper) internal {
+        for (uint256 i = 0; i < transfers.length; ++i) {
+            executeTransfer(transfers[i], wrapper);
+        }
+    }
+
+    // --- Deposit --- //
+
+    /// @notice Execute a direct ERC20 deposit
+    /// @dev It is assumed that the address from which we deposit has approved the darkpool to spend the tokens
+    /// @param transfer The transfer to execute
+    /// @param wrapper The WETH9 wrapper contract for native token handling
+    function executeDirectErc20Deposit(SimpleTransfer memory transfer, IWETH9 wrapper) internal {
+        // Handle native token deposits by wrapping the transaction value
+        if (DarkpoolConstants.isNativeToken(transfer.mint)) {
+            if (msg.value != transfer.amount) revert InvalidDepositAmount();
+            wrapper.deposit{ value: transfer.amount }();
+            return;
+        }
+
+        IERC20 token = IERC20(transfer.mint);
+        address self = address(this);
+        SafeERC20.safeTransferFrom(token, transfer.account, self, transfer.amount);
+    }
+
+    // --- Withdrawal --- //
+
+    /// @notice Execute a simple ERC20 withdrawal
+    /// @param transfer The transfer to execute
+    /// @param wrapper The WETH9 wrapper contract for native token handling
+    function executeSimpleWithdrawal(SimpleTransfer memory transfer, IWETH9 wrapper) internal {
+        // Handle native token withdrawals by unwrapping the transfer amount into ETH
+        if (DarkpoolConstants.isNativeToken(transfer.mint)) {
+            wrapper.withdraw(transfer.amount);
+            SafeTransferLib.safeTransferETH(transfer.account, transfer.amount);
+            return;
+        }
+
+        IERC20 token = IERC20(transfer.mint);
+        SafeERC20.safeTransfer(token, transfer.account, transfer.amount);
+    }
+
+    // --- Helpers --- //
+
+    /// @notice Get the balance of the darkpool for a given ERC20 token
+    /// @param token The ERC20 token address
+    /// @return The balance of the darkpool for the given token
+    function getDarkpoolBalance(address token) internal view returns (uint256) {
+        return IERC20(token).balanceOf(address(this));
+    }
+
+    /// @notice Get a darkpool balance for an ERC20 token address that might be the native token
+    /// @dev The darkpool only ever holds the wrapped native asset, so use the wrapped balance if the token is native
+    /// @param token The ERC20 token address (or native token address)
+    /// @param wrapper The WETH9 wrapper contract
+    /// @return The balance of the darkpool for the given token
+    function getDarkpoolBalanceMaybeNative(address token, IWETH9 wrapper) internal view returns (uint256) {
+        if (DarkpoolConstants.isNativeToken(token)) {
+            return wrapper.balanceOf(address(this));
+        }
+
+        return getDarkpoolBalance(token);
+    }
+}

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -41,6 +41,9 @@ library NativeSettledPublicIntentLib {
     error InvalidObligationPrice(uint256 amountOut, uint256 minAmountOut);
 
     /// @notice Validate a public intent and public balance settlement bundle
+    /// @dev Note that in contrast to other settlement bundle types, no balance obligation
+    /// constraints are checked here. The balance constraint is implicitly checked by transferring
+    /// into the darkpool.
     /// @param settlementBundle The settlement bundle to validate
     /// @param openPublicIntents Mapping of open public intents, this maps the intent hash to the amount remaining.
     /// If an intent's hash is already in the mapping, we need not check its owner's signature.
@@ -123,7 +126,7 @@ library NativeSettledPublicIntentLib {
         internal
         pure
     {
-        // Verify that the pair
+        // Verify that the pair matches the intent
         bool pairValid = intent.inToken == obligation.inputToken && intent.outToken == obligation.outputToken;
         if (!pairValid) revert InvalidObligationPair();
 

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import {
     SettlementBundle, SettlementBundleType, ObligationBundle, ObligationType
 } from "darkpoolv2-types/Settlement.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
 import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
+import { SettlementTransfersLib } from "./SettlementTransfers.sol";
 
 /// @title SettlementLib
 /// @author Renegade Eng
@@ -93,5 +95,22 @@ library SettlementLib {
         } else {
             revert("Not implemented");
         }
+    }
+
+    // --- State Updates --- //
+
+    /// @notice Update darkpool state for a pair of settlement bundles
+    /// @param party0SettlementBundle The settlement bundle for the first party
+    /// @param party1SettlementBundle The settlement bundle for the second party
+    /// @param weth The WETH9 contract instance used for depositing/withdrawing native tokens
+    function updateDarkpoolState(
+        SettlementBundle calldata party0SettlementBundle,
+        SettlementBundle calldata party1SettlementBundle,
+        IWETH9 weth
+    )
+        public
+    {
+        // First, execute any ERC20 transfers necessary for the settlement bundles
+        SettlementTransfersLib.executeTransfers(party0SettlementBundle, party1SettlementBundle, weth);
     }
 }

--- a/src/darkpool/v2/libraries/settlement/SettlementTransfers.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementTransfers.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
+import { SettlementBundle } from "darkpoolv2-types/Settlement.sol";
+import { SettlementBundleLib } from "darkpoolv2-types/Settlement.sol";
+import { ObligationBundle, ObligationLib } from "darkpoolv2-types/Settlement.sol";
+import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/SettlementObligation.sol";
+import { ExternalTransferLib } from "darkpoolv2-lib/Transfers.sol";
+
+/// @title Settlement Transfers Library
+/// @author Renegade Eng
+/// @notice Library for executing ERC20 transfers necessary for a pair of settlement bundles
+library SettlementTransfersLib {
+    using SettlementBundleLib for SettlementBundle;
+    using SettlementObligationLib for SettlementObligation;
+    using ObligationLib for ObligationBundle;
+    using ExternalTransferLib for ExternalTransferLib.SimpleTransfer;
+
+    /// @notice Execute the transfers necessary for a pair of settlement bundles
+    /// @param party0SettlementBundle The settlement bundle for the first party
+    /// @param party1SettlementBundle The settlement bundle for the second party
+    /// @param weth The WETH9 contract instance used for depositing/withdrawing native tokens
+    function executeTransfers(
+        SettlementBundle calldata party0SettlementBundle,
+        SettlementBundle calldata party1SettlementBundle,
+        IWETH9 weth
+    )
+        internal
+    {
+        // First execute the deposits for both parties
+        // We do this first to ensure that the darkpool is capitalized to execute the withdrawals
+        executeDeposits(party0SettlementBundle, weth);
+        executeDeposits(party1SettlementBundle, weth);
+        executeWithdrawals(party0SettlementBundle, weth);
+        executeWithdrawals(party1SettlementBundle, weth);
+    }
+
+    /// @notice Execute the deposits for a settlement bundle
+    /// @param settlementBundle The settlement bundle to execute the deposits for
+    /// @param weth The WETH9 contract instance used for depositing/withdrawing native tokens
+    function executeDeposits(SettlementBundle calldata settlementBundle, IWETH9 weth) internal {
+        // If the bundle is not natively settled, no deposits are necessary
+        bool nativelySettled = settlementBundle.isNativelySettled();
+        if (!nativelySettled) {
+            return;
+        }
+
+        // Otherwise, execute the deposit
+        address eoaAddress = settlementBundle.getEOAAddress();
+        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
+        ExternalTransferLib.SimpleTransfer memory depositTransfer = obligation.buildPermit2AllowanceDeposit(eoaAddress);
+        ExternalTransferLib.executeTransfer(depositTransfer, weth);
+    }
+
+    /// @notice Execute the withdrawals for a settlement bundle
+    /// @param settlementBundle The settlement bundle to execute the withdrawals for
+    /// @param weth The WETH9 contract instance used for depositing/withdrawing native tokens
+    function executeWithdrawals(SettlementBundle calldata settlementBundle, IWETH9 weth) internal {
+        // If the bundle is not natively settled, no withdrawals are necessary
+        if (!settlementBundle.isNativelySettled()) {
+            return;
+        }
+
+        // Otherwise, execute the withdrawal
+        address eoaAddress = settlementBundle.getEOAAddress();
+        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
+        ExternalTransferLib.SimpleTransfer memory withdrawalTransfer = obligation.buildWithdrawalTransfer(eoaAddress);
+        ExternalTransferLib.executeTransfer(withdrawalTransfer, weth);
+    }
+}

--- a/src/darkpool/v2/types/Settlement.sol
+++ b/src/darkpool/v2/types/Settlement.sol
@@ -59,6 +59,30 @@ library SettlementBundleLib {
     /// @notice The error type emitted when a settlement bundle type check fails
     error InvalidSettlementBundleType();
 
+    /// @notice Return whether a settlement bundle is natively settled; i.e. is
+    /// capitalized by an EOA balance
+    /// @param bundle The settlement bundle to check
+    /// @return Whether the settlement bundle is natively settled
+    function isNativelySettled(SettlementBundle calldata bundle) internal pure returns (bool) {
+        return bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT
+            || bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
+    }
+
+    // forge-lint: disable-next-item(mixed-case-function)
+    /// @notice Return the EOA address of a natively settled bundle
+    /// @param bundle The settlement bundle to return the EOA address for
+    /// @return The EOA address of the natively settled bundle
+    function getEOAAddress(SettlementBundle calldata bundle) internal pure returns (address) {
+        require(isNativelySettled(bundle), InvalidSettlementBundleType());
+
+        if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
+            PublicIntentPublicBalanceBundle memory bundleData = decodePublicBundleData(bundle);
+            return bundleData.auth.permit.intent.owner;
+        } else if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
+            revert("Not implemented");
+        }
+    }
+
     /// @notice Decode a public settlement bundle
     /// @param bundle The settlement bundle to decode
     /// @return bundleData The decoded bundle data

--- a/src/darkpool/v2/types/SettlementObligation.sol
+++ b/src/darkpool/v2/types/SettlementObligation.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { ExternalTransferLib } from "darkpoolv2-lib/Transfers.sol";
 
 /// @notice A settlement obligation for a user
 struct SettlementObligation {
@@ -25,5 +26,45 @@ library SettlementObligationLib {
     function computeObligationHash(SettlementObligation memory obligation) internal pure returns (bytes32) {
         bytes memory obligationBytes = abi.encode(obligation);
         return EfficientHashLib.hash(obligationBytes);
+    }
+
+    /// @notice Get the deposit transfer for a settlement obligation
+    /// @param obligation The settlement obligation to get the deposit transfer for
+    /// @param owner The owner of the settlement obligation
+    /// @return The deposit transfer
+    function buildPermit2AllowanceDeposit(
+        SettlementObligation memory obligation,
+        address owner
+    )
+        internal
+        pure
+        returns (ExternalTransferLib.SimpleTransfer memory)
+    {
+        return ExternalTransferLib.SimpleTransfer({
+            account: owner,
+            mint: obligation.inputToken,
+            amount: obligation.amountIn,
+            transferType: ExternalTransferLib.SimpleTransferType.Permit2AllowanceDeposit
+        });
+    }
+
+    /// @notice Get the withdrawal transfer for a settlement obligation
+    /// @param obligation The settlement obligation to get the withdrawal transfer for
+    /// @param owner The owner of the settlement obligation
+    /// @return The withdrawal transfer
+    function buildWithdrawalTransfer(
+        SettlementObligation memory obligation,
+        address owner
+    )
+        internal
+        pure
+        returns (ExternalTransferLib.SimpleTransfer memory)
+    {
+        return ExternalTransferLib.SimpleTransfer({
+            account: owner,
+            mint: obligation.outputToken,
+            amount: obligation.amountOut,
+            transferType: ExternalTransferLib.SimpleTransferType.Withdrawal
+        });
     }
 }

--- a/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/IntentAuthorization.sol
@@ -11,8 +11,8 @@ import {
     PublicIntentPermit,
     PublicIntentPermitLib
 } from "darkpoolv2-types/Settlement.sol";
-import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
-import { NativeSettledPublicIntentLib } from "darkpoolv2-libraries/settlement/NativeSettledPublicIntent.sol";
+import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract IntentAuthorizationTest is SettlementTestUtils {

--- a/test/darkpool/v2/settlement/settlement-lib/IntentConstraints.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/IntentConstraints.sol
@@ -7,7 +7,7 @@ import { SettlementBundle, PublicIntentPermit, PublicIntentPermitLib } from "dar
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { NativeSettledPublicIntentLib } from "darkpoolv2-libraries/settlement/NativeSettledPublicIntent.sol";
+import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract IntentConstraintsTest is SettlementTestUtils {

--- a/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
+++ b/test/darkpool/v2/settlement/settlement-lib/ObligationCompatibility.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.24;
 
 import { ObligationBundle, ObligationType } from "darkpoolv2-types/Settlement.sol";
 import { SettlementObligation } from "darkpoolv2-types/SettlementObligation.sol";
-import { SettlementLib } from "darkpoolv2-libraries/settlement/SettlementLib.sol";
+import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract ObligationCompatibilityTest is SettlementTestUtils {


### PR DESCRIPTION
### Purpose
This PR begins implementing the method to update state for the settled match. I began by executing transfers to/from EOA accounts involved in the match.

The `Transfers.sol` file is directly copied over from the v1 implementation, it will be modified in a follow-up.

### Todo
- Implement the logic for transferring from a permit2 allowance.
- Implement the rest of the state updates; e.g. updating the amount remaining in the `openPublicIntents` map.

### Testing
- [x] Unit tests pass