### PR TITLE
libraries: MerkleMountain: Implement basic Merkle mountain range

### DIFF
--- a/codegen/merkle-zeros/src/main.rs
+++ b/codegen/merkle-zeros/src/main.rs
@@ -2,9 +2,9 @@
 //!
 //! This tool generates a Solidity file with predefined Merkle tree zero values.
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use clap::Parser;
-use common::merkle_helpers::{LEAF_KECCAK_PREIMAGE, generate_zero_values};
+use common::merkle_helpers::{generate_zero_values, LEAF_KECCAK_PREIMAGE};
 use renegade_constants::MERKLE_HEIGHT;
 use std::fs::File;
 use std::io::Write;
@@ -60,7 +60,7 @@ fn generate_solidity_contract() -> Result<String> {
         "\tfunction getZeroValue(uint256 height) internal pure returns (uint256 result) {\n",
     );
     contract.push_str("\t\t// Require height to be within valid range\n");
-    contract.push_str("\t\trequire(height <= 31, \"MerkleZeros: height must be <= 31\");\n\n");
+    contract.push_str("\t\trequire(height <= 32, \"MerkleZeros: height must be <= 32\");\n\n");
 
     contract.push_str("\t\tassembly {\n");
     contract.push_str("\t\t\tswitch height\n");

--- a/src/libraries/merkle/MerkleMountain.sol
+++ b/src/libraries/merkle/MerkleMountain.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { MerkleTreeLib } from "renegade-lib/merkle/MerkleTree.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+
 /// @title MerkleMountainLib
 /// @author Renegade Eng
 /// @notice Library for Merkle mountain range operations
@@ -10,4 +14,61 @@ pragma solidity ^0.8.24;
 /// @dev As a result, we store an active sub-tree for each desired Merkle depth. The roots of these sub-trees
 /// are tracked together in a single mapping of `historicalRoots`. When a sub-tree fills up; a new, empty sub-tree
 /// of the same depth is created and becomes the active sub-tree for that depth.
-library MerkleMountainLib { }
+library MerkleMountainLib {
+    using MerkleTreeLib for MerkleTreeLib.MerkleTree;
+
+    /// @notice A Merkle mountain range is a collection of Merkle trees
+    struct MerkleMountainRange {
+        /// @notice A list of all historical roots for all sub-trees
+        mapping(BN254.ScalarField => bool) historicalRoots;
+        /// @notice A mapping from depth to the active sub-tree at that depth
+        mapping(uint256 => MerkleTreeLib.MerkleTree) activeSubTrees;
+    }
+
+    /// @notice Check if a root is in the historical roots
+    /// @param mountain The Merkle mountain range to check the root in
+    /// @param root The root to check
+    /// @return Whether the root is in the historical roots
+    function rootInHistory(MerkleMountainRange storage mountain, BN254.ScalarField root) internal view returns (bool) {
+        return mountain.historicalRoots[root];
+    }
+
+    /// @notice Insert a leaf into the mountain range in a tree of the given depth
+    /// @param mountain The Merkle mountain range to insert the leaf into
+    /// @param depth The depth of the tree to insert the leaf into
+    /// @param leaf The leaf to insert
+    /// @param hasher The hasher to use for computing Merkle hashes
+    function insertLeaf(
+        MerkleMountainRange storage mountain,
+        uint256 depth,
+        BN254.ScalarField leaf,
+        IHasher hasher
+    )
+        internal
+    {
+        MerkleTreeLib.MerkleTree storage tree = mountain.activeSubTrees[depth];
+        if (!tree.isInitialized() || tree.isFull()) {
+            _replaceActiveSubTree(mountain, depth);
+        }
+
+        tree.insertLeaf(leaf, hasher);
+        _storeRoot(mountain, tree.getRoot());
+    }
+
+    /// @notice Replace the active sub-tree at the given depth
+    /// @param mountain The Merkle mountain range to create the sub-tree in
+    /// @param depth The depth of the sub-tree to create
+    function _replaceActiveSubTree(MerkleMountainRange storage mountain, uint256 depth) private {
+        MerkleTreeLib.MerkleTreeConfig memory config =
+            MerkleTreeLib.MerkleTreeConfig({ depth: depth, storeRoots: false });
+        MerkleTreeLib.MerkleTree storage tree = mountain.activeSubTrees[depth];
+        tree.initialize(config);
+    }
+
+    /// @notice Store a root for the mountain range
+    /// @param mountain The Merkle mountain range to store the root in
+    /// @param root The root to store
+    function _storeRoot(MerkleMountainRange storage mountain, BN254.ScalarField root) private {
+        mountain.historicalRoots[root] = true;
+    }
+}

--- a/src/libraries/merkle/MerkleTree.sol
+++ b/src/libraries/merkle/MerkleTree.sol
@@ -65,6 +65,20 @@ library MerkleTreeLib {
         return BN254.ScalarField.wrap(MerkleZeros.getZeroValue(height));
     }
 
+    /// @notice Whether the Merkle tree is full
+    /// @param tree The tree to check if it is full
+    /// @return full Whether the Merkle tree is full
+    function isFull(MerkleTree storage tree) internal view returns (bool full) {
+        full = tree.nextIndex == (1 << tree.config.depth);
+    }
+
+    /// @notice Whether the Merkle tree has been initialized
+    /// @param tree The tree to check if it has been initialized
+    /// @return initialized Whether the Merkle tree has been initialized
+    function isInitialized(MerkleTree storage tree) internal view returns (bool initialized) {
+        initialized = tree.config.depth != 0;
+    }
+
     /// @notice Initialize the Merkle tree
     /// @param tree The tree to initialize
     /// @param config_ The config to use for the Merkle tree

--- a/src/libraries/merkle/MerkleZeros.sol
+++ b/src/libraries/merkle/MerkleZeros.sol
@@ -44,7 +44,7 @@ library MerkleZeros {
 	/// @return result the zero value for the given height
 	function getZeroValue(uint256 height) internal pure returns (uint256 result) {
 		// Require height to be within valid range
-		require(height <= 31, "MerkleZeros: height must be <= 31");
+		require(height <= 32, "MerkleZeros: height must be <= 32");
 
 		assembly {
 			switch height


### PR DESCRIPTION
### Purpose
This PR adds a basic implementation of our modified Merkle Mountain Range. This type stores active sub-trees at any requested depth and stores all historical roots for all sub-trees.

### Todo
- Test suite, will come in a follow-up

### Testing
- [x] Existing tests pass