### PR TITLE
darkpoolv2: VerificationList: Implement `VerificationList` type

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -19,7 +19,7 @@ import { NullifierLib } from "renegade-lib/NullifierSet.sol";
 import { EncryptionKey } from "darkpoolv1-types/Ciphertext.sol";
 
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import { SettlementTransfers } from "darkpoolv2-types/Transfers.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 
 /// @title DarkpoolV2
@@ -181,19 +181,19 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
         public
     {
         // 1. Allocate a settlement context
-        SettlementTransfers memory settlementTransfers =
+        SettlementContext memory settlementContext =
             SettlementLib.allocateSettlementTransfers(party0SettlementBundle, party1SettlementBundle);
 
         // 2. Validate that the settlement obligations are compatible with one another
         SettlementLib.checkObligationCompatibility(party0SettlementBundle.obligation, party1SettlementBundle.obligation);
 
         // 3. Validate and authorize the settlement bundles
-        SettlementLib.executeSettlementBundle(party0SettlementBundle, settlementTransfers, openPublicIntents);
-        SettlementLib.executeSettlementBundle(party1SettlementBundle, settlementTransfers, openPublicIntents);
+        SettlementLib.executeSettlementBundle(party0SettlementBundle, settlementContext, openPublicIntents);
+        SettlementLib.executeSettlementBundle(party1SettlementBundle, settlementContext, openPublicIntents);
 
         // 4. Execute the transfers necessary for settlement
-        // The helpers above will push transfers to the settlement transfers list if necessary
-        SettlementLib.executeTransfers(settlementTransfers, weth, permit2);
+        // The helpers above will push transfers to the settlement context if necessary
+        SettlementLib.executeTransfers(settlementContext, weth, permit2);
 
         // TODO: Verify proofs necessary for each step here
     }

--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -14,3 +14,21 @@ struct PrivateIntentPublicBalanceStatement {
     /// @dev A commitment to the intent
     BN254.ScalarField intentCommitment;
 }
+
+/// @title Public Inputs Library
+/// @author Renegade Eng
+/// @notice Library for operating on proof public inputs
+library PublicInputsLib {
+    /// @notice Serialize the public inputs for a proof
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(PrivateIntentPublicBalanceStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        publicInputs = new BN254.ScalarField[](2);
+        publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.intentOwner)));
+        publicInputs[1] = statement.intentCommitment;
+    }
+}

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -2,16 +2,19 @@
 pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { BN254Helpers } from "renegade-lib/verifier/BN254Helpers.sol";
 
 import {
     SettlementBundle,
     SettlementBundleLib,
     PrivateIntentPublicBalanceBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
-import { SettlementTransfers, SettlementTransfersLib } from "darkpoolv2-types/Transfers.sol";
 import { PrivateIntentAuthBundle, PrivateIntentAuthBundleLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { PublicInputsLib, PrivateIntentPublicBalanceStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import { VerificationKey } from "renegade-lib/verifier/Types.sol";
 
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { ECDSALib } from "renegade-lib/ECDSA.sol";
@@ -24,8 +27,9 @@ library NativeSettledPrivateIntentLib {
     using SettlementBundleLib for SettlementBundle;
     using ObligationLib for ObligationBundle;
     using SettlementObligationLib for SettlementObligation;
-    using SettlementTransfersLib for SettlementTransfers;
     using PrivateIntentAuthBundleLib for PrivateIntentAuthBundle;
+    using PublicInputsLib for PrivateIntentPublicBalanceStatement;
+    using SettlementContextLib for SettlementContext;
 
     // --- Errors --- //
 
@@ -36,18 +40,13 @@ library NativeSettledPrivateIntentLib {
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance
     /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementTransfers The settlement transfers to execute, this method will append transfers to this list.
-    function execute(
-        SettlementBundle calldata settlementBundle,
-        SettlementTransfers memory settlementTransfers
-    )
-        internal
-    {
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    function execute(SettlementBundle calldata settlementBundle, SettlementContext memory settlementContext) internal {
         // Decode the bundle data
         PrivateIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePrivateIntentBundleData();
 
         // 1. Validate the intent authorization
-        validatePrivateIntentAuthorization(bundleData);
+        validatePrivateIntentAuthorization(bundleData.auth, settlementContext);
     }
 
     // ------------------------
@@ -55,18 +54,30 @@ library NativeSettledPrivateIntentLib {
     // ------------------------
 
     /// @notice Authorize a private intent
-    /// @param bundleData The bundle data to validate
+    /// @param auth The authorization bundle to validate
+    /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @dev The checks here depend on whether this is the first fill of the intent or not
     /// 1. If this is the first fill, we check that the intent owner has signed the intent's commitment.
     /// 2. If this is not the first fill, the presence of the intent in the Merkle tree implies that the
     /// intent owner's signature has already been verified (in a previous fill). So in this case, we need only
     /// verify the proof attached to the bundle.
-    function validatePrivateIntentAuthorization(PrivateIntentPublicBalanceBundle memory bundleData) internal {
+    function validatePrivateIntentAuthorization(
+        PrivateIntentAuthBundle memory auth,
+        SettlementContext memory settlementContext
+    )
+        internal
+    {
         // If this is the first fill, we check that the intent owner has signed the intent's commitment
-        if (bundleData.auth.isFirstFill) {
+        if (auth.isFirstFill) {
             // Verify that the intent owner has signed the intent's commitment
-            verifyIntentCommitmentSignature(bundleData.auth);
+            verifyIntentCommitmentSignature(auth);
         }
+
+        // Append a proof to the settlement context
+        // TODO: Fetch a real verification key
+        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(auth.statement);
+        VerificationKey memory vk = dummyVkey();
+        settlementContext.pushProof(publicInputs, auth.proof, vk);
     }
 
     /// @notice Verify the signature of the intent commitment by its owner
@@ -77,5 +88,35 @@ library NativeSettledPrivateIntentLib {
         address intentOwner = authBundle.extractIntentOwner();
         bool valid = ECDSALib.verify(commitmentHash, authBundle.intentSignature, intentOwner);
         if (!valid) revert InvalidIntentCommitmentSignature();
+    }
+
+    /// @notice Build a dummy verification key
+    /// @return The dummy verification key
+    /// TODO: Remove this once we have a real verification key
+    function dummyVkey() internal pure returns (VerificationKey memory) {
+        return VerificationKey({
+            n: 0,
+            l: 0,
+            k: [BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO],
+            qComms: [
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1()
+            ],
+            sigmaComms: [BN254.P1(), BN254.P1(), BN254.P1(), BN254.P1(), BN254.P1()],
+            g: BN254.P1(),
+            h: BN254.P2(),
+            xH: BN254.P2()
+        });
     }
 }

--- a/src/darkpool/v2/types/VerificationList.sol
+++ b/src/darkpool/v2/types/VerificationList.sol
@@ -51,7 +51,9 @@ library VerificationListLib {
 
     /// @notice Push a proof to the list
     /// @param list The list to push to
+    /// @param publicInputs The public inputs to the proof
     /// @param proof The proof to push
+    /// @param vk The verification key to use
     function push(
         VerificationList memory list,
         BN254.ScalarField[] memory publicInputs,

--- a/src/darkpool/v2/types/VerificationList.sol
+++ b/src/darkpool/v2/types/VerificationList.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { PlonkProof, VerificationKey } from "renegade-lib/verifier/Types.sol";
+
+/// @title Verification List
+/// @author Renegade Eng
+/// @notice A list of verifications to perform on a settlement bundle
+/// TODO: Add proof-linking arguments
+struct VerificationList {
+    /// @dev The cursor indicating the next index to push to
+    uint256 nextIndex;
+    /// @dev The list of verifications
+    PlonkProof[] proofs;
+    /// @dev The list of public inputs to the proof
+    BN254.ScalarField[][] publicInputs;
+    /// @dev The list of verification keys to use
+    VerificationKey[] vks;
+}
+
+/// @title Verification List Library
+/// @author Renegade Eng
+/// @notice A library for managing verification lists
+library VerificationListLib {
+    // --- Errors --- //
+
+    /// @notice Thrown when attempting to push to a list that has reached its capacity
+    error CapacityExceeded();
+
+    // --- Interface --- //
+
+    /// @notice Create a new verification list
+    /// @param capacity The initial capacity of the list
+    /// @return The new verification list
+    function newList(uint256 capacity) internal pure returns (VerificationList memory) {
+        return VerificationList({
+            nextIndex: 0,
+            proofs: new PlonkProof[](capacity),
+            publicInputs: new BN254.ScalarField[][](capacity),
+            vks: new VerificationKey[](capacity)
+        });
+    }
+
+    /// @notice Get the length of the list
+    /// @param list The list to get the length of
+    /// @return The length of the list
+    function length(VerificationList memory list) internal pure returns (uint256) {
+        return list.nextIndex;
+    }
+
+    /// @notice Push a proof to the list
+    /// @param list The list to push to
+    /// @param proof The proof to push
+    function push(
+        VerificationList memory list,
+        BN254.ScalarField[] memory publicInputs,
+        PlonkProof memory proof,
+        VerificationKey memory vk
+    )
+        internal
+        pure
+    {
+        if (list.nextIndex > list.proofs.length - 1) {
+            revert CapacityExceeded();
+        }
+        list.proofs[list.nextIndex] = proof;
+        list.publicInputs[list.nextIndex] = publicInputs;
+        list.vks[list.nextIndex] = vk;
+        ++list.nextIndex;
+    }
+}

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -78,6 +78,19 @@ library SettlementBundleLib {
         return 0;
     }
 
+    /// @notice Get the number of proofs which need to be verified for a settlement bundle
+    /// @param bundle The settlement bundle to get the number of proofs for
+    /// @return numProofs The number of proofs required to settle the bundle
+    function getNumProofs(SettlementBundle calldata bundle) internal pure returns (uint256 numProofs) {
+        if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
+            numProofs = 0;
+        } else if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
+            numProofs = 1;
+        } else if (bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT) {
+            revert("Not implemented");
+        }
+    }
+
     /// @notice Return whether a settlement bundle is natively settled; i.e. is
     /// capitalized by an EOA balance
     /// @param bundle The settlement bundle to check

--- a/src/darkpool/v2/types/settlement/SettlementContext.sol
+++ b/src/darkpool/v2/types/settlement/SettlementContext.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { PlonkProof, VerificationKey } from "renegade-lib/verifier/Types.sol";
+import { SimpleTransfer } from "darkpoolv2-types/Transfers.sol";
+import { SettlementTransfers, SettlementTransfersLib } from "darkpoolv2-types/Transfers.sol";
+import { VerificationList, VerificationListLib } from "darkpoolv2-types/VerificationList.sol";
+
+/// @title Settlement Context
+/// @author Renegade Eng
+/// @notice A context for a settlement
+struct SettlementContext {
+    /// @dev The transfers to settle
+    SettlementTransfers transfers;
+    /// @dev The verifications to perform on the settlement
+    VerificationList verifications;
+}
+
+/// @title Settlement Context Library
+/// @author Renegade Eng
+/// @notice A library for managing settlement contexts
+library SettlementContextLib {
+    using SettlementTransfersLib for SettlementTransfers;
+    using VerificationListLib for VerificationList;
+
+    /// @notice Create a new settlement context
+    /// @param transferCapacity The capacity of the transfers list
+    /// @param verificationCapacity The capacity of the verifications list
+    /// @return The new settlement context
+    function newContext(
+        uint256 transferCapacity,
+        uint256 verificationCapacity
+    )
+        internal
+        pure
+        returns (SettlementContext memory)
+    {
+        return SettlementContext({
+            transfers: SettlementTransfersLib.newList(transferCapacity),
+            verifications: VerificationListLib.newList(verificationCapacity)
+        });
+    }
+
+    // --- Getters --- //
+
+    /// @notice Get the length of the deposits list
+    /// @param context The context to get the length of
+    /// @return The length of the transfers list
+    function numDeposits(SettlementContext memory context) internal pure returns (uint256) {
+        return context.transfers.numDeposits();
+    }
+
+    /// @notice Get the length of the withdrawals list
+    /// @param context The context to get the length of
+    /// @return The length of the withdrawals list
+    function numWithdrawals(SettlementContext memory context) internal pure returns (uint256) {
+        return context.transfers.numWithdrawals();
+    }
+
+    /// @notice Get the length of the verifications list
+    /// @param context The context to get the length of
+    /// @return The length of the verifications list
+    function numProofs(SettlementContext memory context) internal pure returns (uint256) {
+        return context.verifications.length();
+    }
+
+    // --- Setters --- //
+
+    /// @notice Push a deposit to the transfers list
+    /// @param context The context to push to
+    /// @param deposit The deposit to push
+    function pushDeposit(SettlementContext memory context, SimpleTransfer memory deposit) internal pure {
+        context.transfers.pushDeposit(deposit);
+    }
+
+    /// @notice Push a withdrawal to the transfers list
+    /// @param context The context to push to
+    /// @param withdrawal The withdrawal to push
+    function pushWithdrawal(SettlementContext memory context, SimpleTransfer memory withdrawal) internal pure {
+        context.transfers.pushWithdrawal(withdrawal);
+    }
+
+    /// @notice Push a proof to the verifications list
+    /// @param context The context to push to
+    /// @param publicInputs The public inputs to the proof
+    /// @param proof The proof to push
+    /// @param vk The verification key to use
+    function pushProof(
+        SettlementContext memory context,
+        BN254.ScalarField[] memory publicInputs,
+        PlonkProof memory proof,
+        VerificationKey memory vk
+    )
+        internal
+        pure
+    {
+        context.verifications.push(publicInputs, proof, vk);
+    }
+}

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -13,7 +13,7 @@ import {
     PublicIntentPermit,
     PublicIntentPermitLib
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
-import { SettlementTransfers } from "darkpoolv2-types/Transfers.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
@@ -29,18 +29,18 @@ contract IntentAuthorizationTest is SettlementTestUtils {
     // -----------
 
     /// @notice Wrapper to convert memory to calldata for library call
-    function _executeSettlementBundle(SettlementBundle calldata bundle) external returns (SettlementTransfers memory) {
-        SettlementTransfers memory settlementTransfers = _createSettlementTransfers();
-        SettlementLib.executeSettlementBundle(bundle, settlementTransfers, openPublicIntents);
-        return settlementTransfers;
+    function _executeSettlementBundle(SettlementBundle calldata bundle) external returns (SettlementContext memory) {
+        SettlementContext memory settlementContext = _createSettlementContext();
+        SettlementLib.executeSettlementBundle(bundle, settlementContext, openPublicIntents);
+        return settlementContext;
     }
 
     /// @notice Helper that accepts memory and calls library with calldata
     function authorizeIntentHelper(SettlementBundle memory bundle)
         internal
-        returns (SettlementTransfers memory transfers)
+        returns (SettlementContext memory context)
     {
-        transfers = this._executeSettlementBundle(bundle);
+        context = this._executeSettlementBundle(bundle);
     }
 
     // ---------

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
@@ -10,7 +10,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { SettlementTestUtils } from "./Utils.sol";
-import { SettlementTransfers } from "darkpoolv2-types/Transfers.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 
 contract IntentConstraintsTest is SettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
@@ -21,13 +21,9 @@ contract IntentConstraintsTest is SettlementTestUtils {
     // -----------
 
     /// @notice Wrapper to convert memory to calldata for library call
-    function _validateSettlementBundleCalldata(SettlementBundle calldata bundle)
-        external
-        returns (SettlementTransfers memory)
-    {
-        SettlementTransfers memory settlementTransfers = _createSettlementTransfers();
-        NativeSettledPublicIntentLib.execute(bundle, settlementTransfers, openPublicIntents);
-        return settlementTransfers;
+    function _validateSettlementBundleCalldata(SettlementBundle calldata bundle) external {
+        SettlementContext memory settlementContext = _createSettlementContext();
+        NativeSettledPublicIntentLib.execute(bundle, settlementContext, openPublicIntents);
     }
 
     // ---------

--- a/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
@@ -16,7 +16,7 @@ import {
     PublicIntentPermit,
     PublicIntentPermitLib
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
-import { SettlementTransfers, SettlementTransfersLib } from "darkpoolv2-types/Transfers.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 
 contract SettlementTestUtils is DarkpoolV2TestBase {
@@ -106,8 +106,8 @@ contract SettlementTestUtils is DarkpoolV2TestBase {
     // --- Dummy Data --- //
 
     /// @dev Create a dummy `SettlementTransfers` list for the test
-    function _createSettlementTransfers() internal pure returns (SettlementTransfers memory transfers) {
-        transfers = SettlementTransfersLib.newList(1);
+    function _createSettlementContext() internal pure returns (SettlementContext memory context) {
+        context = SettlementContextLib.newContext(1, /* transferCapacity */ 1 /* verificationCapacity */ );
     }
 
     /// @dev Create two dummy obligations which are compatible with one another


### PR DESCRIPTION
### Purpose
This PR creates a new `VerificationList` type which is analogous to the `SettlementTransfers` type created before. That is, this type allows verification handlers to dynamically register proofs during their execution. These proofs will be batch verified at the end of the transaction.

I then generalized the `SettlementTransfers` allocation into a `SettlementContext` allocation, which tracks both transfers and proofs.

### Todo
- Verify proofs in the verification list
- Register proofs in the native settled private intent handlers

### Testing
- [x] Existing unit tests pass