### PR TITLE
darkpoolv2: settlement: Verify obligation constraints for Ring 1

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -22,6 +22,19 @@ import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.s
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 
+/// @title Darkpool State
+/// @notice Storage struct bundling core darkpool state
+/// @dev Used to pass storage references as a single parameter
+struct DarkpoolState {
+    /// @notice The mapping of open public intents
+    /// @dev This maps the intent hash to the amount remaining.
+    mapping(bytes32 => uint256) openPublicIntents;
+    /// @notice The Merkle tree for wallet commitments
+    MerkleTreeLib.MerkleTree merkleTree;
+    /// @notice The nullifier set for the darkpool
+    NullifierLib.NullifierSet nullifierSet;
+}
+
 /// @title DarkpoolV2
 /// @author Renegade Eng
 /// @notice V2 of the Renegade darkpool contract for private trading
@@ -89,22 +102,14 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
 
     // --- Protocol Level State Storage --- //
 
-    /// @notice The mapping of open public intents
-    /// @dev This maps the intent hash to the amount remaining.
+    /// @notice Bundled core darkpool state
+    /// @dev Contains: openPublicIntents mapping, merkleTree, and nullifierSet
     /// @dev An intent hash is a hash of the tuple (executor, intent),
     /// where executor is the address of the party allowed to fill the intent.
-    mapping(bytes32 => uint256) public openPublicIntents;
-    /// @notice The Merkle tree for wallet commitments
-    MerkleTreeLib.MerkleTree private merkleTree;
-    /// @notice The nullifier set for the darkpool
     /// @dev Each time a wallet is updated (placing an order, settling a match, depositing, etc) a nullifier is spent.
     /// @dev This ensures that a pre-update wallet cannot create two separate post-update wallets in the Merkle state
     /// @dev The nullifier is computed deterministically from the shares of the pre-update wallet
-    NullifierLib.NullifierSet private nullifierSet;
-    /// @notice The set of public blinder shares that have been inserted into the darkpool
-    /// @dev We track this to prevent duplicate blinders that may affect the ability of indexers to uniquely
-    /// @dev recover a wallet
-    NullifierLib.NullifierSet private publicBlinderSet;
+    DarkpoolState private _state;
 
     // ---------------------------------
     // | Constructors and Initializers |
@@ -153,18 +158,25 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
 
         // TODO: Replace with a Merkle mountain range
         MerkleTreeLib.MerkleTreeConfig memory config = MerkleTreeLib.MerkleTreeConfig({ storeRoots: true, depth: 10 });
-        merkleTree.initialize(config);
+        _state.merkleTree.initialize(config);
     }
 
     // -----------------
     // | State Getters |
     // -----------------
 
+    /// @notice Get the remaining amount for an open public intent
+    /// @param intentHash The hash of the intent
+    /// @return The remaining amount for the intent
+    function openPublicIntents(bytes32 intentHash) public view returns (uint256) {
+        return _state.openPublicIntents[intentHash];
+    }
+
     /// @notice Check if a nullifier has been spent
     /// @param nullifier The nullifier to check
     /// @return Whether the nullifier has been spent
     function nullifierSpent(BN254.ScalarField nullifier) public view returns (bool) {
-        return nullifierSet.isSpent(nullifier);
+        return _state.nullifierSet.isSpent(nullifier);
     }
 
     // --------------
@@ -188,8 +200,8 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
         SettlementLib.checkObligationCompatibility(party0SettlementBundle.obligation, party1SettlementBundle.obligation);
 
         // 3. Validate and authorize the settlement bundles
-        SettlementLib.executeSettlementBundle(party0SettlementBundle, settlementContext, openPublicIntents);
-        SettlementLib.executeSettlementBundle(party1SettlementBundle, settlementContext, openPublicIntents);
+        SettlementLib.executeSettlementBundle(party0SettlementBundle, settlementContext, _state);
+        SettlementLib.executeSettlementBundle(party1SettlementBundle, settlementContext, _state);
 
         // 4. Execute the transfers necessary for settlement
         // The helpers above will push transfers to the settlement context if necessary

--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -12,7 +12,9 @@ struct PrivateIntentPublicBalanceStatement {
     /// it anyway.
     address intentOwner;
     /// @dev A commitment to the intent
-    BN254.ScalarField intentCommitment;
+    BN254.ScalarField newIntentCommitment;
+    /// @dev A nullifier for the previous version of the intent
+    BN254.ScalarField nullifier;
 }
 
 /// @title Public Inputs Library
@@ -27,8 +29,9 @@ library PublicInputsLib {
         pure
         returns (BN254.ScalarField[] memory publicInputs)
     {
-        publicInputs = new BN254.ScalarField[](2);
+        publicInputs = new BN254.ScalarField[](3);
         publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.intentOwner)));
-        publicInputs[1] = statement.intentCommitment;
+        publicInputs[1] = statement.newIntentCommitment;
+        publicInputs[2] = statement.nullifier;
     }
 }

--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -2,20 +2,38 @@
 pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 
-/// @notice A dummy set of public inputs for a proof
+// -------------------
+// | Statement Types |
+// -------------------
+
+/// @notice A statement for a proof of intent only state validity
 /// TODO: Rename this once circuit spec is defined
-struct PrivateIntentPublicBalanceStatement {
+struct IntentOnlyValidityStatement {
     /// @dev The address of the intent owner
     /// @dev For private intents backed by public balances, we can
     /// leak this field on a match, as the obligation's settlement leaks
     /// it anyway.
     address intentOwner;
     /// @dev A commitment to the intent
-    BN254.ScalarField newIntentCommitment;
+    BN254.ScalarField newIntentPartialCommitment;
     /// @dev A nullifier for the previous version of the intent
     BN254.ScalarField nullifier;
+    /// @dev The settlement obligation
+    SettlementObligation obligation;
 }
+
+/// @notice A statement for a proof of single-intent only match settlement
+/// @dev We only emit the updated public shares for updated fields for efficiency
+struct SingleIntentMatchSettlementStatement {
+    /// @dev The updated public share of the intent's amount
+    BN254.ScalarField newIntentAmountPublicShare;
+}
+
+// -------------------------
+// | Public Inputs Library |
+// -------------------------
 
 /// @title Public Inputs Library
 /// @author Renegade Eng
@@ -24,14 +42,34 @@ library PublicInputsLib {
     /// @notice Serialize the public inputs for a proof
     /// @param statement The statement to serialize
     /// @return publicInputs The serialized public inputs
-    function statementSerialize(PrivateIntentPublicBalanceStatement memory statement)
+    function statementSerialize(IntentOnlyValidityStatement memory statement)
         internal
         pure
         returns (BN254.ScalarField[] memory publicInputs)
     {
-        publicInputs = new BN254.ScalarField[](3);
+        uint256 nPublicInputs = 7;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
         publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.intentOwner)));
-        publicInputs[1] = statement.newIntentCommitment;
+        publicInputs[1] = statement.newIntentPartialCommitment;
         publicInputs[2] = statement.nullifier;
+
+        // Add the settlement obligation
+        publicInputs[4] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.inputToken)));
+        publicInputs[5] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.outputToken)));
+        publicInputs[6] = BN254.ScalarField.wrap(statement.obligation.amountIn);
+        publicInputs[7] = BN254.ScalarField.wrap(statement.obligation.amountOut);
+    }
+
+    /// @notice Serialize the public inputs for a proof of single-intent match settlement
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(SingleIntentMatchSettlementStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 1;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = statement.newIntentAmountPublicShare;
     }
 }

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { BN254Helpers } from "renegade-lib/verifier/BN254Helpers.sol";
-
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import {
     SettlementBundle,
     SettlementBundleLib,
@@ -13,10 +13,15 @@ import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settle
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
 import { PrivateIntentAuthBundle, PrivateIntentAuthBundleLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
-import { PublicInputsLib, PrivateIntentPublicBalanceStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import {
+    PublicInputsLib,
+    IntentOnlyValidityStatement,
+    SingleIntentMatchSettlementStatement
+} from "darkpoolv2-lib/PublicInputs.sol";
 import { VerificationKey } from "renegade-lib/verifier/Types.sol";
 import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
+import { CommitmentNullifierLib } from "darkpoolv2-types/CommitNullify.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { ECDSALib } from "renegade-lib/ECDSA.sol";
 
@@ -29,8 +34,9 @@ library NativeSettledPrivateIntentLib {
     using ObligationLib for ObligationBundle;
     using SettlementObligationLib for SettlementObligation;
     using PrivateIntentAuthBundleLib for PrivateIntentAuthBundle;
-    using PublicInputsLib for PrivateIntentPublicBalanceStatement;
     using SettlementContextLib for SettlementContext;
+    using PublicInputsLib for IntentOnlyValidityStatement;
+    using PublicInputsLib for SingleIntentMatchSettlementStatement;
 
     // --- Errors --- //
 
@@ -43,18 +49,48 @@ library NativeSettledPrivateIntentLib {
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing
+    /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
+    /// The balance constraint is implicitly checked by transferring into the darkpool.
     function execute(
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
-        DarkpoolState storage state
+        DarkpoolState storage state,
+        IHasher hasher
     )
         internal
     {
         // Decode the bundle data
         PrivateIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePrivateIntentBundleData();
+        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
+
+        // Compute the full commitment to the updated intent
+        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(bundleData, hasher);
 
         // 1. Validate the intent authorization
-        validatePrivateIntentAuthorization(bundleData.auth, settlementContext, state);
+        validatePrivateIntentAuthorization(newIntentCommitment, bundleData.auth, settlementContext, state);
+
+        // 2. Validate the intent constraints on the obligation
+        validateObligationIntentConstraints(bundleData, settlementContext);
+    }
+
+    /// @notice Compute the full commitment to the updated intent
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the intent
+    function computeFullIntentCommitment(
+        PrivateIntentPublicBalanceBundle memory bundleData,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        // Compute the full commitment to the updated intent
+        BN254.ScalarField partialCommitment = bundleData.auth.statement.newIntentPartialCommitment;
+        BN254.ScalarField[] memory remainingShares = new BN254.ScalarField[](1);
+        remainingShares[0] = bundleData.settlementStatement.newIntentAmountPublicShare;
+        newIntentCommitment = CommitmentNullifierLib.computeFullCommitment(partialCommitment, remainingShares, hasher);
     }
 
     // ------------------------
@@ -62,6 +98,7 @@ library NativeSettledPrivateIntentLib {
     // ------------------------
 
     /// @notice Authorize a private intent
+    /// @param newIntentCommitment The full commitment to the updated intent
     /// @param auth The authorization bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
@@ -71,6 +108,7 @@ library NativeSettledPrivateIntentLib {
     /// intent owner's signature has already been verified (in a previous fill). So in this case, we need only
     /// verify the proof attached to the bundle.
     function validatePrivateIntentAuthorization(
+        BN254.ScalarField newIntentCommitment,
         PrivateIntentAuthBundle memory auth,
         SettlementContext memory settlementContext,
         DarkpoolState storage state
@@ -80,24 +118,55 @@ library NativeSettledPrivateIntentLib {
         // If this is the first fill, we check that the intent owner has signed the intent's commitment
         if (auth.isFirstFill) {
             // Verify that the intent owner has signed the intent's commitment
-            verifyIntentCommitmentSignature(auth);
+            verifyIntentCommitmentSignature(newIntentCommitment, auth);
         }
 
         // Append a proof to the settlement context
         // TODO: Fetch a real verification key
         BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(auth.statement);
         VerificationKey memory vk = dummyVkey();
-        settlementContext.pushProof(publicInputs, auth.proof, vk);
+        settlementContext.pushProof(publicInputs, auth.validityProof, vk);
     }
 
     /// @notice Verify the signature of the intent commitment by its owner
+    /// @param newIntentCommitment The full commitment to the updated intent
     /// @param authBundle The authorization bundle to verify the signature for
-    function verifyIntentCommitmentSignature(PrivateIntentAuthBundle memory authBundle) internal {
-        bytes32 intentCommitmentBytes = bytes32(BN254.ScalarField.unwrap(authBundle.statement.newIntentCommitment));
+    function verifyIntentCommitmentSignature(
+        BN254.ScalarField newIntentCommitment,
+        PrivateIntentAuthBundle memory authBundle
+    )
+        internal
+        pure
+    {
+        bytes32 intentCommitmentBytes = bytes32(BN254.ScalarField.unwrap(newIntentCommitment));
         bytes32 commitmentHash = EfficientHashLib.hash(abi.encode(intentCommitmentBytes));
         address intentOwner = authBundle.extractIntentOwner();
         bool valid = ECDSALib.verify(commitmentHash, authBundle.intentSignature, intentOwner);
         if (!valid) revert InvalidIntentCommitmentSignature();
+    }
+
+    // --------------------------
+    // | Obligation Constraints |
+    // --------------------------
+
+    /// @notice Validate the constraints on the settlement obligation
+    /// @param bundleData The bundle data to validate
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @dev The verification logic is the same as for a public intent, but is done in a ZKP.
+    /// So all that needs to be done here is to register the proof with the settlement context
+    /// for deferred verification
+    function validateObligationIntentConstraints(
+        PrivateIntentPublicBalanceBundle memory bundleData,
+        SettlementContext memory settlementContext
+    )
+        internal
+        pure
+    {
+        // Append a proof to the settlement context
+        // TODO: Fetch a real verification key
+        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(bundleData.settlementStatement);
+        VerificationKey memory vk = dummyVkey();
+        settlementContext.pushProof(publicInputs, bundleData.settlementProof, vk);
     }
 
     /// @notice Build a dummy verification key

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -16,6 +16,7 @@ import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
 import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol";
 import { SettlementTransfers, SettlementTransfersLib } from "darkpoolv2-types/Transfers.sol";
 import { ExternalTransferLib } from "darkpoolv2-lib/TransferLib.sol";
+import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
 import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
 import { emptyOpeningElements } from "renegade-lib/verifier/Types.sol";
@@ -127,21 +128,21 @@ library SettlementLib {
     /// @notice Execute a settlement bundle
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param openPublicIntents Mapping of open public intents, this maps the intent hash to the amount remaining.
+    /// @param state The darkpool state containing all storage references
     /// @dev This function validates and executes the settlement bundle based on the bundle type
     /// @dev See the library files in this directory for type-specific execution & validation logic.
     function executeSettlementBundle(
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
-        mapping(bytes32 => uint256) storage openPublicIntents
+        DarkpoolState storage state
     )
         internal
     {
         SettlementBundleType bundleType = settlementBundle.bundleType;
         if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
-            NativeSettledPublicIntentLib.execute(settlementBundle, settlementContext, openPublicIntents);
+            NativeSettledPublicIntentLib.execute(settlementBundle, settlementContext, state);
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
-            NativeSettledPrivateIntentLib.execute(settlementBundle, settlementContext);
+            NativeSettledPrivateIntentLib.execute(settlementBundle, settlementContext, state);
         } else {
             revert("Not implemented");
         }

--- a/src/darkpool/v2/types/CommitNullify.sol
+++ b/src/darkpool/v2/types/CommitNullify.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+
+/// @title CommitmentNullifierLib
+/// @author Renegade Eng
+/// @notice Library for computing and operating on commitments and nullifiers
+library CommitmentNullifierLib {
+    /// @notice Compute the full commitment to a state element from a partial commitment
+    /// @param partialCommitment The partial commitment to the state element
+    /// @param remainingShares The remaining shares to hash into the commitment
+    /// @param hasher The hasher to use for hashing
+    /// @return The full commitment to the state element
+    /// @dev We assume the commitment is computed as :
+    ///     H(partialCommitment || share0 || share1 || ... || shareN)
+    function computeFullCommitment(
+        BN254.ScalarField partialCommitment,
+        BN254.ScalarField[] memory remainingShares,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField)
+    {
+        // Build inputs and hash
+        uint256[] memory hashInputs = new uint256[](remainingShares.length + 1);
+        hashInputs[0] = BN254.ScalarField.unwrap(partialCommitment);
+        for (uint256 i = 1; i < remainingShares.length + 1; ++i) {
+            hashInputs[i] = BN254.ScalarField.unwrap(remainingShares[i - 1]);
+        }
+
+        return BN254.ScalarField.wrap(hasher.spongeHash(hashInputs));
+    }
+}

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.24;
 
 import { Intent } from "darkpoolv2-types/Intent.sol";
-import { PrivateIntentPublicBalanceStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import { IntentOnlyValidityStatement } from "darkpoolv2-lib/PublicInputs.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
@@ -55,9 +55,9 @@ struct PrivateIntentAuthBundle {
     /// @dev The signature of the intent by its owner
     bytes intentSignature;
     /// @dev The statement for the proof of `PrivateIntentPublicBalance`
-    PrivateIntentPublicBalanceStatement statement;
+    IntentOnlyValidityStatement statement;
     /// @dev The proof of `PrivateIntentPublicBalance`
-    PlonkProof proof;
+    PlonkProof validityProof;
 }
 
 /// @title Private Intent Auth Bundle Library

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { PublicIntentAuthBundle, PrivateIntentAuthBundle } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SingleIntentMatchSettlementStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
 // ---------------------------
 // | Settlement Bundle Types |
@@ -54,6 +56,10 @@ struct PublicIntentPublicBalanceBundle {
 struct PrivateIntentPublicBalanceBundle {
     /// @dev The private intent authorization payload with signature attached
     PrivateIntentAuthBundle auth;
+    /// @dev The statement of single-intent match settlement
+    SingleIntentMatchSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent match settlement
+    PlonkProof settlementProof;
 }
 
 /// @title Settlement Bundle Library

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -31,7 +31,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
     /// @notice Wrapper to convert memory to calldata for library call
     function _executeSettlementBundle(SettlementBundle calldata bundle) external returns (SettlementContext memory) {
         SettlementContext memory settlementContext = _createSettlementContext();
-        SettlementLib.executeSettlementBundle(bundle, settlementContext, openPublicIntents);
+        SettlementLib.executeSettlementBundle(bundle, settlementContext, darkpoolState);
         return settlementContext;
     }
 
@@ -108,7 +108,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
 
         bytes32 intentHash = authBundle.permit.computeHash();
-        uint256 amountRemaining = openPublicIntents[intentHash];
+        uint256 amountRemaining = darkpoolState.openPublicIntents[intentHash];
         uint256 expectedAmountRemaining = authBundle.permit.intent.amountIn - obligation.amountIn;
         assertEq(amountRemaining, expectedAmountRemaining, "Intent not cached");
 

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -31,7 +31,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
     /// @notice Wrapper to convert memory to calldata for library call
     function _executeSettlementBundle(SettlementBundle calldata bundle) external returns (SettlementContext memory) {
         SettlementContext memory settlementContext = _createSettlementContext();
-        SettlementLib.executeSettlementBundle(bundle, settlementContext, darkpoolState);
+        SettlementLib.executeSettlementBundle(bundle, settlementContext, darkpoolState, hasher);
         return settlementContext;
     }
 

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
@@ -23,7 +23,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
     /// @notice Wrapper to convert memory to calldata for library call
     function _validateSettlementBundleCalldata(SettlementBundle calldata bundle) external {
         SettlementContext memory settlementContext = _createSettlementContext();
-        NativeSettledPublicIntentLib.execute(bundle, settlementContext, openPublicIntents);
+        NativeSettledPublicIntentLib.execute(bundle, settlementContext, darkpoolState);
     }
 
     // ---------

--- a/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
@@ -18,6 +18,7 @@ import {
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
 contract SettlementTestUtils is DarkpoolV2TestBase {
     using ObligationLib for ObligationBundle;
@@ -37,8 +38,8 @@ contract SettlementTestUtils is DarkpoolV2TestBase {
     Vm.Wallet internal executor;
     Vm.Wallet internal wrongSigner;
 
-    // Storage for open public intents
-    mapping(bytes32 => uint256) internal openPublicIntents;
+    // Bundled darkpool state for testing
+    DarkpoolState internal darkpoolState;
 
     function setUp() public virtual override {
         super.setUp();


### PR DESCRIPTION
### Purpose
This PR adds the verification logic for the obligation constraints introduced by the intent in Ring 1 (native-settled private intent) trades. Note that like Ring 0 trades, balance constraints are automatically enforced by attempting to transfer ERC20 allowances.

Verification here is entirely done inside a ZKP, much like the match settlement circuits from v1.

### Testing
- [x] Existing unit tests pass