### PR TITLE
darkpoolv2: settlement: Declare Ring 2 statement and bundle types

### DIFF
--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -20,8 +20,24 @@ struct IntentOnlyValidityStatement {
     BN254.ScalarField newIntentPartialCommitment;
     /// @dev A nullifier for the previous version of the intent
     BN254.ScalarField nullifier;
-    /// @dev The settlement obligation
-    SettlementObligation obligation;
+}
+
+/// @notice A statement for a proof of intent and balance validity
+struct IntentAndBalanceValidityStatementFirstFill {
+    /// @dev The one time authorizing address for the balance
+    /// @dev This is unconstrained if this is not the first fill, allowing
+    /// clients to set the value arbitrarily to hide the address
+    address oneTimeAuthorizingAddress;
+    /// @dev The hash of the new one-time key
+    BN254.ScalarField newOneTimeKeyHash;
+    /// @dev A partial commitment to the new balance
+    BN254.ScalarField balancePartialCommitment;
+    /// @dev A partial commitment to the new intent
+    BN254.ScalarField intentPartialCommitment;
+    /// @dev The nullifier for the previous version of the balance
+    BN254.ScalarField balanceNullifier;
+    /// @dev The nullifier for the previous version of the intent
+    BN254.ScalarField intentNullifier;
 }
 
 /// @notice A statement for a proof of single-intent only match settlement
@@ -29,6 +45,23 @@ struct IntentOnlyValidityStatement {
 struct SingleIntentMatchSettlementStatement {
     /// @dev The updated public share of the intent's amount
     BN254.ScalarField newIntentAmountPublicShare;
+    /// @dev The settlement obligation
+    SettlementObligation obligation;
+}
+
+/// @notice A statement for a proof of Renegade settled private intent settlement
+/// @dev We only emit the updated public shares for updated fields for efficiency
+struct RenegadeSettledPrivateIntentPublicSettlementStatement {
+    /// @dev The updated public share of the intent's amount
+    BN254.ScalarField newIntentAmountPublicShare;
+    /// @dev The new public shares of the balance
+    /// These correspond to the updated:
+    /// - Relayer fee
+    /// - Protocol fee
+    /// - Amount
+    BN254.ScalarField[3] newBalancePublicShares;
+    /// @dev The settlement obligation
+    SettlementObligation obligation;
 }
 
 // -------------------------
@@ -47,17 +80,29 @@ library PublicInputsLib {
         pure
         returns (BN254.ScalarField[] memory publicInputs)
     {
-        uint256 nPublicInputs = 7;
+        uint256 nPublicInputs = 3;
         publicInputs = new BN254.ScalarField[](nPublicInputs);
         publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.intentOwner)));
         publicInputs[1] = statement.newIntentPartialCommitment;
         publicInputs[2] = statement.nullifier;
+    }
 
-        // Add the settlement obligation
-        publicInputs[3] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.inputToken)));
-        publicInputs[4] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.outputToken)));
-        publicInputs[5] = BN254.ScalarField.wrap(statement.obligation.amountIn);
-        publicInputs[6] = BN254.ScalarField.wrap(statement.obligation.amountOut);
+    /// @notice Serialize the public inputs for a proof of intent and balance validity
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(IntentAndBalanceValidityStatementFirstFill memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 6;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.oneTimeAuthorizingAddress)));
+        publicInputs[1] = statement.newOneTimeKeyHash;
+        publicInputs[2] = statement.balancePartialCommitment;
+        publicInputs[3] = statement.intentPartialCommitment;
+        publicInputs[4] = statement.balanceNullifier;
+        publicInputs[5] = statement.intentNullifier;
     }
 
     /// @notice Serialize the public inputs for a proof of single-intent match settlement
@@ -68,8 +113,38 @@ library PublicInputsLib {
         pure
         returns (BN254.ScalarField[] memory publicInputs)
     {
-        uint256 nPublicInputs = 1;
+        uint256 nPublicInputs = 5;
         publicInputs = new BN254.ScalarField[](nPublicInputs);
         publicInputs[0] = statement.newIntentAmountPublicShare;
+
+        // Add the settlement obligation
+        publicInputs[1] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.inputToken)));
+        publicInputs[2] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.outputToken)));
+        publicInputs[3] = BN254.ScalarField.wrap(statement.obligation.amountIn);
+        publicInputs[4] = BN254.ScalarField.wrap(statement.obligation.amountOut);
+    }
+
+    /// @notice Serialize the public inputs for a proof of Renegade settled private intent settlement
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(RenegadeSettledPrivateIntentPublicSettlementStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 8;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = statement.newIntentAmountPublicShare;
+
+        // Add the new balance public shares
+        publicInputs[1] = statement.newBalancePublicShares[0];
+        publicInputs[2] = statement.newBalancePublicShares[1];
+        publicInputs[3] = statement.newBalancePublicShares[2];
+
+        // Add the settlement obligation
+        publicInputs[4] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.inputToken)));
+        publicInputs[5] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.outputToken)));
+        publicInputs[6] = BN254.ScalarField.wrap(statement.obligation.amountIn);
+        publicInputs[7] = BN254.ScalarField.wrap(statement.obligation.amountOut);
     }
 }

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { RenegadeSettledPrivateIntentBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+
+import { SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+
+/// @title Renegade Settled Private Intent Library
+/// @author Renegade Eng
+/// @notice Library for validating a renegade settled private intents
+/// @dev A renegade settled private intent is a private intent with a private (darkpool) balance.
+library RenegadeSettledPrivateIntentLib {
+    using SettlementBundleLib for SettlementBundle;
+
+    /// @notice Execute a renegade settled private intent bundle
+    /// @param settlementBundle The settlement bundle to execute
+    /// @param settlementContext The settlement context to which we append post-execution updates.
+    /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing
+    /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
+    /// The balance constraint is implicitly checked by transferring into the darkpool.
+    function execute(
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        // Decode the bundle data
+        RenegadeSettledPrivateIntentBundle memory bundle =
+            settlementBundle.decodeRenegadeSettledPrivateIntentBundleData();
+        // TODO: Implement
+    }
+}

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -17,6 +17,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
 import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol";
+import { RenegadeSettledPrivateIntentLib } from "./RenegadeSettledPrivateIntent.sol";
 import { SettlementTransfers, SettlementTransfersLib } from "darkpoolv2-types/Transfers.sol";
 import { ExternalTransferLib } from "darkpoolv2-lib/TransferLib.sol";
 import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
@@ -148,7 +149,7 @@ library SettlementLib {
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
             NativeSettledPrivateIntentLib.execute(settlementBundle, settlementContext, state, hasher);
         } else {
-            revert("Not implemented");
+            RenegadeSettledPrivateIntentLib.execute(settlementBundle, settlementContext, state, hasher);
         }
     }
 

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -3,8 +3,15 @@
 pragma solidity ^0.8.24;
 
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
-import { PublicIntentAuthBundle, PrivateIntentAuthBundle } from "darkpoolv2-types/settlement/IntentBundle.sol";
-import { SingleIntentMatchSettlementStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import {
+    PublicIntentAuthBundle,
+    PrivateIntentAuthBundle,
+    PrivateIntentPrivateBalanceAuthBundle
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import {
+    SingleIntentMatchSettlementStatement,
+    RenegadeSettledPrivateIntentPublicSettlementStatement
+} from "darkpoolv2-lib/PublicInputs.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
 // ---------------------------
@@ -46,19 +53,29 @@ enum SettlementBundleType {
     RENEGADE_SETTLED_INTENT
 }
 
-/// @notice The settlement bundle data for a `PUBLIC_INTENT_PUBLIC_BALANCE` bundle
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PUBLIC_INTENT` bundle
 struct PublicIntentPublicBalanceBundle {
     /// @dev The public intent authorization payload with signature attached
     PublicIntentAuthBundle auth;
 }
 
-/// @notice The settlement bundle data for a `PRIVATE_INTENT_PUBLIC_BALANCE` bundle
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bundle
 struct PrivateIntentPublicBalanceBundle {
     /// @dev The private intent authorization payload with signature attached
     PrivateIntentAuthBundle auth;
     /// @dev The statement of single-intent match settlement
     SingleIntentMatchSettlementStatement settlementStatement;
     /// @dev The proof of single-intent match settlement
+    PlonkProof settlementProof;
+}
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_INTENT` bundle
+struct RenegadeSettledPrivateIntentBundle {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentPrivateBalanceAuthBundle auth;
+    /// @dev The statement of renegade settled private intent public settlement
+    RenegadeSettledPrivateIntentPublicSettlementStatement settlementStatement;
+    /// @dev The proof of renegade settled private intent public settlement
     PlonkProof settlementProof;
 }
 
@@ -145,5 +162,17 @@ library SettlementBundleLib {
             bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT, InvalidSettlementBundleType()
         );
         bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundle));
+    }
+
+    /// @notice Decode a renegade settled private intent settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledPrivateIntentBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledPrivateIntentBundle memory bundleData)
+    {
+        require(bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT, InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateIntentBundle));
     }
 }

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -55,21 +55,21 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Create a dummy intent validity statement
-    function createSampleIntentValidityStatement(SettlementObligation memory obligation)
-        internal
-        returns (IntentOnlyValidityStatement memory)
-    {
+    function createSampleIntentValidityStatement() internal returns (IntentOnlyValidityStatement memory) {
         return IntentOnlyValidityStatement({
             intentOwner: intentOwner.addr,
             newIntentPartialCommitment: randomScalar(),
-            nullifier: randomScalar(),
-            obligation: obligation
+            nullifier: randomScalar()
         });
     }
 
     /// @dev Create a dummy settlement statement
-    function createSampleSettlementStatement() internal returns (SingleIntentMatchSettlementStatement memory) {
-        return SingleIntentMatchSettlementStatement({ newIntentAmountPublicShare: randomScalar() });
+    function createSampleSettlementStatement(SettlementObligation memory obligation)
+        internal
+        returns (SingleIntentMatchSettlementStatement memory)
+    {
+        return
+            SingleIntentMatchSettlementStatement({ newIntentAmountPublicShare: randomScalar(), obligation: obligation });
     }
 
     /// @dev Helper to create a sample settlement bundle
@@ -115,12 +115,11 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
         IntentOnlyValidityStatement memory validityStatement = IntentOnlyValidityStatement({
             intentOwner: owner.addr,
             newIntentPartialCommitment: randomScalar(),
-            nullifier: randomScalar(),
-            obligation: obligation
+            nullifier: randomScalar()
         });
 
         // Create settlement statement
-        SingleIntentMatchSettlementStatement memory settlementStatement = createSampleSettlementStatement();
+        SingleIntentMatchSettlementStatement memory settlementStatement = createSampleSettlementStatement(obligation);
 
         // Compute the full intent commitment and sign it
         BN254.ScalarField fullCommitment = computeFullIntentCommitment(


### PR DESCRIPTION
### Purpose
This PR declares the statement and bundle types we'll use for Ring 2 (private intent, private balance, public obligations allowed) settlement. 

Though Ring 2 and 3 largely follow the same logic--their only difference is that Ring 2 allows public obligations--the Ring 3 (private obligation) logic will come after the Ring 2 implementation is complete.

### Todo
- Implement settlement logic

### Testing
- [x] Unit tests pass
