### PR TITLE
darkpoolv2: settlement: ring1: Separate first & subsequent fill handlers

### DIFF
--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -8,8 +8,36 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 // | Statement Types |
 // -------------------
 
+// --- Validity Statements --- //
+// Validity proofs verify that:
+// 1. The owner of all new state elements has authorized their creation
+// 2. Existing state elements are present in the Merkle tree
+// 3. Nullifiers have been computed correctly for pre-update state elements
+// 4. New shares have been allocated for updated elements
+// The statements below represent different configurations of private vs public intents and balances,
+// as well as first fill vs subsequent fills for private intents.
+// TODO: Cleanup naming in this file once circuit spec is defined
+
+/// @notice A statement proving validity only for an intent, on its first fill
+/// @dev This type doesn't need a nullifier, for example, but needs to emit the commitment
+/// to the pre-updated intent so that we may check a signature.
+struct IntentOnlyValidityStatementFirstFill {
+    /// @dev The address of the intent owner
+    /// @dev For private intents backed by public balances, we can
+    /// leak this field on a match, as the obligation's settlement leaks
+    /// it anyway.
+    address intentOwner;
+    /// @dev The commitment to the initial version of the intent
+    BN254.ScalarField initialIntentCommitment;
+    /// @dev A partial commitment to the updated version of the intent after settlement
+    /// @dev This is a commitment over all shares of the intent not updated in the match.
+    /// The settlement handlers will hash the updated shares into this commitment to build an updated commitment.
+    BN254.ScalarField newIntentPartialCommitment;
+}
+
 /// @notice A statement for a proof of intent only state validity
-/// TODO: Rename this once circuit spec is defined
+/// @dev This is the same statement as above, but for a subsequent fill of a private intent.
+/// As a result, it needs to nullify the previous intent commitment allocated into the darkpool.
 struct IntentOnlyValidityStatement {
     /// @dev The address of the intent owner
     /// @dev For private intents backed by public balances, we can
@@ -39,6 +67,14 @@ struct IntentAndBalanceValidityStatementFirstFill {
     /// @dev The nullifier for the previous version of the intent
     BN254.ScalarField intentNullifier;
 }
+
+// --- Settlement Statements --- //
+// Settlement proofs verify that:
+// 1. A settlement obligation is well capitalized by the balance
+// 2. A settlement obligation doesn't violate the intent's constraints
+// 3. The shares of the balance and intent are updated correctly
+// These proofs are proof-linked into the validity proofs so that they may be
+// constrained to share witness elements.
 
 /// @notice A statement for a proof of single-intent only match settlement
 /// @dev We only emit the updated public shares for updated fields for efficiency
@@ -72,6 +108,21 @@ struct RenegadeSettledPrivateIntentPublicSettlementStatement {
 /// @author Renegade Eng
 /// @notice Library for operating on proof public inputs
 library PublicInputsLib {
+    /// @notice Serialize the public inputs for a proof of intent only validity (first fill)
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(IntentOnlyValidityStatementFirstFill memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 3;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.intentOwner)));
+        publicInputs[1] = statement.initialIntentCommitment;
+        publicInputs[2] = statement.newIntentPartialCommitment;
+    }
+
     /// @notice Serialize the public inputs for a proof
     /// @param statement The statement to serialize
     /// @return publicInputs The serialized public inputs

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -7,15 +7,17 @@ import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import {
     SettlementBundle,
     SettlementBundleLib,
-    PrivateIntentPublicBalanceBundle
+    PrivateIntentPublicBalanceBundle,
+    PrivateIntentPublicBalanceBundleFirstFill
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
-import { PrivateIntentAuthBundle, PrivateIntentAuthBundleLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { PrivateIntentAuthBundle, PrivateIntentAuthBundleFirstFill } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import {
     PublicInputsLib,
     IntentOnlyValidityStatement,
+    IntentOnlyValidityStatementFirstFill,
     SingleIntentMatchSettlementStatement
 } from "darkpoolv2-lib/PublicInputs.sol";
 import { VerificationKey } from "renegade-lib/verifier/Types.sol";
@@ -37,11 +39,11 @@ library NativeSettledPrivateIntentLib {
     using SettlementBundleLib for SettlementBundle;
     using ObligationLib for ObligationBundle;
     using SettlementObligationLib for SettlementObligation;
-    using PrivateIntentAuthBundleLib for PrivateIntentAuthBundle;
     using SettlementContextLib for SettlementContext;
     using NullifierLib for NullifierLib.NullifierSet;
     using MerkleMountainLib for MerkleMountainLib.MerkleMountainRange;
     using PublicInputsLib for IntentOnlyValidityStatement;
+    using PublicInputsLib for IntentOnlyValidityStatementFirstFill;
     using PublicInputsLib for SingleIntentMatchSettlementStatement;
 
     // --- Errors --- //
@@ -61,6 +63,63 @@ library NativeSettledPrivateIntentLib {
     /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function execute(
+        bool isFirstFill,
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        if (isFirstFill) {
+            executeFirstFill(settlementBundle, settlementContext, state, hasher);
+        } else {
+            executeSubsequentFill(settlementBundle, settlementContext, state, hasher);
+        }
+    }
+
+    /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a first fill
+    /// @param settlementBundle The settlement bundle to validate
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing
+    /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
+    /// The balance constraint is implicitly checked by transferring into the darkpool.
+    function executeFirstFill(
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        // Decode the bundle data
+        PrivateIntentPublicBalanceBundleFirstFill memory bundleData =
+            settlementBundle.decodePrivateIntentBundleDataFirstFill();
+        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
+
+        // 1. Validate the intent authorization
+        validatePrivateIntentAuthorizationFirstFill(bundleData.auth, settlementContext);
+
+        // 2. Validate the intent constraints on the obligation
+        // This is done in the settlement proof
+        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(bundleData.settlementStatement);
+        VerificationKey memory vk = dummyVkey();
+        settlementContext.pushProof(publicInputs, bundleData.settlementProof, vk);
+
+        // 3. Execute state updates for the bundle
+        executeStateUpdatesFirstFill(bundleData, obligation, settlementContext, state, hasher);
+    }
+
+    /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a subsequent
+    /// fill; i.e. not the first fill
+    /// @param settlementBundle The settlement bundle to validate
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing
+    /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
+    /// The balance constraint is implicitly checked by transferring into the darkpool.
+    function executeSubsequentFill(
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -72,53 +131,55 @@ library NativeSettledPrivateIntentLib {
         PrivateIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePrivateIntentBundleData();
         SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
 
-        // Compute the full commitment to the updated intent
-        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(bundleData, hasher);
-
         // 1. Validate the intent authorization
-        validatePrivateIntentAuthorization(newIntentCommitment, bundleData.auth, settlementContext);
+        validatePrivateIntentAuthorization(bundleData.auth, settlementContext);
 
         // 2. Validate the intent constraints on the obligation
-        validateObligationIntentConstraints(bundleData, settlementContext);
+        // This is done in the settlement proof
+        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(bundleData.settlementStatement);
+        VerificationKey memory vk = dummyVkey();
+        settlementContext.pushProof(publicInputs, bundleData.settlementProof, vk);
 
         // 3. Execute state updates for the bundle
-        executeStateUpdates(newIntentCommitment, bundleData, obligation, settlementContext, state, hasher);
-    }
-
-    /// @notice Compute the full commitment to the updated intent
-    /// @param bundleData The bundle data to compute the commitment for
-    /// @param hasher The hasher to use for hashing
-    /// @return newIntentCommitment The full commitment to the intent
-    function computeFullIntentCommitment(
-        PrivateIntentPublicBalanceBundle memory bundleData,
-        IHasher hasher
-    )
-        internal
-        view
-        returns (BN254.ScalarField newIntentCommitment)
-    {
-        // Compute the full commitment to the updated intent
-        BN254.ScalarField partialCommitment = bundleData.auth.statement.newIntentPartialCommitment;
-        BN254.ScalarField[] memory remainingShares = new BN254.ScalarField[](1);
-        remainingShares[0] = bundleData.settlementStatement.newIntentAmountPublicShare;
-        newIntentCommitment = CommitmentNullifierLib.computeFullCommitment(partialCommitment, remainingShares, hasher);
+        executeStateUpdates(bundleData, obligation, settlementContext, state, hasher);
     }
 
     // ------------------------
     // | Intent Authorization |
     // ------------------------
 
-    /// @notice Authorize a private intent
-    /// @param newIntentCommitment The full commitment to the updated intent
+    /// @notice Validate the authorization of a private intent for a first fill
     /// @param auth The authorization bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @dev The checks here depend on whether this is the first fill of the intent or not
-    /// 1. If this is the first fill, we check that the intent owner has signed the intent's commitment.
-    /// 2. If this is not the first fill, the presence of the intent in the Merkle tree implies that the
+    /// @dev On the first fill, we verify that the intent owner has signed the intent's commitment.
+    function validatePrivateIntentAuthorizationFirstFill(
+        PrivateIntentAuthBundleFirstFill memory auth,
+        SettlementContext memory settlementContext
+    )
+        internal
+        pure
+    {
+        // Validate the Merkle depth
+        // TODO: Allow for dynamic Merkle depth
+        if (auth.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) revert InvalidMerkleDepthRequested();
+
+        // On the first fill, we verify that the intent owner has signed the intent's commitment
+        verifyIntentCommitmentSignature(auth);
+
+        // Append a proof to the settlement context
+        // TODO: Fetch a real verification key
+        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(auth.statement);
+        VerificationKey memory vk = dummyVkey();
+        settlementContext.pushProof(publicInputs, auth.validityProof, vk);
+    }
+
+    /// @notice Authorize a private intent
+    /// @param auth The authorization bundle to validate
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @dev Because this is not the first fill, the presence of the intent in the Merkle tree implies that the
     /// intent owner's signature has already been verified (in a previous fill). So in this case, we need only
     /// verify the proof attached to the bundle.
     function validatePrivateIntentAuthorization(
-        BN254.ScalarField newIntentCommitment,
         PrivateIntentAuthBundle memory auth,
         SettlementContext memory settlementContext
     )
@@ -129,12 +190,6 @@ library NativeSettledPrivateIntentLib {
         // TODO: Allow for dynamic Merkle depth
         if (auth.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) revert InvalidMerkleDepthRequested();
 
-        // If this is the first fill, we check that the intent owner has signed the intent's commitment
-        if (auth.isFirstFill) {
-            // Verify that the intent owner has signed the intent's commitment
-            verifyIntentCommitmentSignature(newIntentCommitment, auth);
-        }
-
         // Append a proof to the settlement context
         // TODO: Fetch a real verification key
         BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(auth.statement);
@@ -143,59 +198,58 @@ library NativeSettledPrivateIntentLib {
     }
 
     /// @notice Verify the signature of the intent commitment by its owner
-    /// @param newIntentCommitment The full commitment to the updated intent
     /// @param authBundle The authorization bundle to verify the signature for
-    function verifyIntentCommitmentSignature(
-        BN254.ScalarField newIntentCommitment,
-        PrivateIntentAuthBundle memory authBundle
-    )
-        internal
-        pure
-    {
-        bytes32 intentCommitmentBytes = bytes32(BN254.ScalarField.unwrap(newIntentCommitment));
-        bytes32 commitmentHash = EfficientHashLib.hash(abi.encode(intentCommitmentBytes));
-        address intentOwner = authBundle.extractIntentOwner();
+    function verifyIntentCommitmentSignature(PrivateIntentAuthBundleFirstFill memory authBundle) internal pure {
+        address intentOwner = authBundle.statement.intentOwner;
+        uint256 commitment = BN254.ScalarField.unwrap(authBundle.statement.initialIntentCommitment);
+
+        bytes32 commitmentHash = EfficientHashLib.hash(abi.encode(bytes32(commitment)));
         bool valid = ECDSALib.verify(commitmentHash, authBundle.intentSignature, intentOwner);
         if (!valid) revert InvalidIntentCommitmentSignature();
-    }
-
-    // --------------------------
-    // | Obligation Constraints |
-    // --------------------------
-
-    /// @notice Validate the constraints on the settlement obligation
-    /// @param bundleData The bundle data to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @dev The verification logic is the same as for a public intent, but is done in a ZKP.
-    /// So all that needs to be done here is to register the proof with the settlement context
-    /// for deferred verification
-    function validateObligationIntentConstraints(
-        PrivateIntentPublicBalanceBundle memory bundleData,
-        SettlementContext memory settlementContext
-    )
-        internal
-        pure
-    {
-        // Append a proof to the settlement context
-        // TODO: Fetch a real verification key
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(bundleData.settlementStatement);
-        VerificationKey memory vk = dummyVkey();
-        settlementContext.pushProof(publicInputs, bundleData.settlementProof, vk);
     }
 
     // -----------------
     // | State Updates |
     // -----------------
 
+    /// @notice Execute the state updates necessary to settle the bundle for a first fill
+    /// @param bundleData The bundle data to execute the state updates for
+    /// @param obligation The settlement obligation to settle
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing
+    /// @dev On the first fill, no state needs to be nullified. We must only insert the new intent commitment and
+    /// allocate the transfers.
+    function executeStateUpdatesFirstFill(
+        PrivateIntentPublicBalanceBundleFirstFill memory bundleData,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        // 1. Insert a commitment to the updated intent into the Merkle tree
+        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(
+            bundleData.auth.statement.newIntentPartialCommitment,
+            bundleData.settlementStatement.newIntentAmountPublicShare,
+            hasher
+        );
+        uint256 merkleDepth = bundleData.auth.merkleDepth;
+        state.merkleMountainRange.insertLeaf(merkleDepth, newIntentCommitment, hasher);
+
+        // 2. Allocate transfers to settle the obligation in the settlement context
+        address owner = bundleData.auth.statement.intentOwner;
+        allocateTransfers(owner, obligation, settlementContext);
+    }
+
     /// @notice Execute the state updates necessary to settle the bundle
-    /// @param newIntentCommitment The full commitment to the updated intent
     /// @param bundleData The bundle data to execute the state updates for
     /// @param obligation The settlement obligation to settle
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
     /// @param hasher The hasher to use for hashing
     function executeStateUpdates(
-        BN254.ScalarField newIntentCommitment,
         PrivateIntentPublicBalanceBundle memory bundleData,
         SettlementObligation memory obligation,
         SettlementContext memory settlementContext,
@@ -209,17 +263,56 @@ library NativeSettledPrivateIntentLib {
         state.nullifierSet.spend(nullifier);
 
         // 2. Insert a commitment to the updated intent into the Merkle tree
+        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(
+            bundleData.auth.statement.newIntentPartialCommitment,
+            bundleData.settlementStatement.newIntentAmountPublicShare,
+            hasher
+        );
         uint256 merkleDepth = bundleData.auth.merkleDepth;
         state.merkleMountainRange.insertLeaf(merkleDepth, newIntentCommitment, hasher);
 
         // 3. Allocate transfers to settle the obligation in the settlement context
+        address owner = bundleData.auth.statement.intentOwner;
+        allocateTransfers(owner, obligation, settlementContext);
+    }
+
+    /// @notice Compute the full commitment to the updated intent
+    /// @param partialCommitment The partial commitment to the intent
+    /// @param amountPublicShare The public share of the intent's amount
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the intent
+    function computeFullIntentCommitment(
+        BN254.ScalarField partialCommitment,
+        BN254.ScalarField amountPublicShare,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        // Compute the full commitment to the updated intent
+        BN254.ScalarField[] memory remainingShares = new BN254.ScalarField[](1);
+        remainingShares[0] = amountPublicShare;
+        newIntentCommitment = CommitmentNullifierLib.computeFullCommitment(partialCommitment, remainingShares, hasher);
+    }
+
+    /// @notice Allocate transfers to settle the obligation into the settlement context
+    /// @param obligation The settlement obligation to settle
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    function allocateTransfers(
+        address owner,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext
+    )
+        internal
+        pure
+    {
         // Deposit the input token into the darkpool
-        address intentOwner = bundleData.auth.extractIntentOwner();
-        SimpleTransfer memory deposit = obligation.buildPermit2AllowanceDeposit(intentOwner);
+        SimpleTransfer memory deposit = obligation.buildPermit2AllowanceDeposit(owner);
         settlementContext.pushDeposit(deposit);
 
         // Withdraw the output token from the darkpool
-        SimpleTransfer memory withdrawal = obligation.buildWithdrawalTransfer(intentOwner);
+        SimpleTransfer memory withdrawal = obligation.buildWithdrawalTransfer(owner);
         settlementContext.pushWithdrawal(withdrawal);
     }
 

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -56,6 +56,7 @@ library NativeSettledPrivateIntentLib {
     // --- Implementation --- //
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance
+    /// @param isFirstFill Whether the settlement bundle is a first fill
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
@@ -297,6 +298,7 @@ library NativeSettledPrivateIntentLib {
     }
 
     /// @notice Allocate transfers to settle the obligation into the settlement context
+    /// @param owner The owner of the intent
     /// @param obligation The settlement obligation to settle
     /// @param settlementContext The settlement context to which we append post-validation updates.
     function allocateTransfers(

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -23,6 +23,7 @@ library RenegadeSettledPrivateIntentLib {
     /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function execute(
+        bool isFirstFill,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -30,9 +31,6 @@ library RenegadeSettledPrivateIntentLib {
     )
         internal
     {
-        // Decode the bundle data
-        RenegadeSettledPrivateIntentBundle memory bundle =
-            settlementBundle.decodeRenegadeSettledPrivateIntentBundleData();
         // TODO: Implement
     }
 }

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { RenegadeSettledPrivateIntentBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
-
 import { SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
@@ -16,6 +14,7 @@ library RenegadeSettledPrivateIntentLib {
     using SettlementBundleLib for SettlementBundle;
 
     /// @notice Execute a renegade settled private intent bundle
+    /// @param isFirstFill Whether the settlement bundle is a first fill
     /// @param settlementBundle The settlement bundle to execute
     /// @param settlementContext The settlement context to which we append post-execution updates.
     /// @param state The darkpool state containing all storage references

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -146,10 +146,14 @@ library SettlementLib {
         SettlementBundleType bundleType = settlementBundle.bundleType;
         if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
             NativeSettledPublicIntentLib.execute(settlementBundle, settlementContext, state);
+        } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL) {
+            NativeSettledPrivateIntentLib.execute(true, settlementBundle, settlementContext, state, hasher);
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
-            NativeSettledPrivateIntentLib.execute(settlementBundle, settlementContext, state, hasher);
+            NativeSettledPrivateIntentLib.execute(false, settlementBundle, settlementContext, state, hasher);
+        } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL) {
+            RenegadeSettledPrivateIntentLib.execute(true, settlementBundle, settlementContext, state, hasher);
         } else {
-            RenegadeSettledPrivateIntentLib.execute(settlementBundle, settlementContext, state, hasher);
+            RenegadeSettledPrivateIntentLib.execute(false, settlementBundle, settlementContext, state, hasher);
         }
     }
 

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -5,7 +5,9 @@ pragma solidity ^0.8.24;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import {
-    IntentOnlyValidityStatement, IntentAndBalanceValidityStatementFirstFill
+    IntentOnlyValidityStatement,
+    IntentOnlyValidityStatementFirstFill,
+    IntentAndBalanceValidityStatementFirstFill
 } from "darkpoolv2-lib/PublicInputs.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
@@ -52,29 +54,26 @@ library PublicIntentPermitLib {
 
 /// @notice The private intent authorization payload
 /// TODO: Update names in comments once circuit spec is defined
-struct PrivateIntentAuthBundle {
-    /// @dev Whether this is the first fill or not
-    bool isFirstFill;
+struct PrivateIntentAuthBundleFirstFill {
     /// @dev The signature of the intent by its owner
     bytes intentSignature;
+    /// @dev The depth of the Merkle tree to insert the intent into
+    uint256 merkleDepth;
+    /// @dev The statement for the proof of `PrivateIntentPublicBalance`
+    IntentOnlyValidityStatementFirstFill statement;
+    /// @dev The proof of `PrivateIntentPublicBalance`
+    PlonkProof validityProof;
+}
+
+/// @notice The private intent authorization payload
+/// TODO: Update names in comments once circuit spec is defined
+struct PrivateIntentAuthBundle {
     /// @dev The depth of the Merkle tree to insert the intent into
     uint256 merkleDepth;
     /// @dev The statement for the proof of `PrivateIntentPublicBalance`
     IntentOnlyValidityStatement statement;
     /// @dev The proof of `PrivateIntentPublicBalance`
     PlonkProof validityProof;
-}
-
-/// @title Private Intent Auth Bundle Library
-/// @author Renegade Eng
-/// @notice Library for decoding private intent auth bundle data
-library PrivateIntentAuthBundleLib {
-    /// @notice Extract the intent owner from a private intent auth bundle
-    /// @param bundle The private intent auth bundle to extract the intent owner from
-    /// @return intentOwner The intent owner
-    function extractIntentOwner(PrivateIntentAuthBundle memory bundle) internal pure returns (address intentOwner) {
-        intentOwner = bundle.statement.intentOwner;
-    }
 }
 
 // --- Private Intent, Private Balance Authorization --- //

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -121,9 +121,15 @@ library SettlementBundleLib {
     function getNumProofs(SettlementBundle calldata bundle) internal pure returns (uint256 numProofs) {
         if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
             numProofs = 0;
-        } else if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
+        } else if (
+            bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT
+                || bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL
+        ) {
             numProofs = 2;
-        } else if (bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT) {
+        } else if (
+            bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT
+                || bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL
+        ) {
             revert("Not implemented");
         }
     }
@@ -134,6 +140,7 @@ library SettlementBundleLib {
     /// @return Whether the settlement bundle is natively settled
     function isNativelySettled(SettlementBundle calldata bundle) internal pure returns (bool) {
         return bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT
+            || bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL
             || bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
     }
 

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.24;
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     PublicIntentAuthBundle,
+    PrivateIntentAuthBundleFirstFill,
     PrivateIntentAuthBundle,
     PrivateIntentPrivateBalanceAuthBundle
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
@@ -47,9 +48,12 @@ struct SettlementBundle {
 /// 1. *Natively Settled Public Intent*: A public intent with a public (EOA) balance
 /// 2. *Natively Settled Private Intent*: A private intent with a public (EOA) balance
 /// 3. *Renegade Settled Intent*: A private intent with a private (darkpool) balance
+/// Separately, bundle shapes for the latter two cases change for the first fill and subsequent fills.
 enum SettlementBundleType {
     NATIVELY_SETTLED_PUBLIC_INTENT,
+    NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL,
     NATIVELY_SETTLED_PRIVATE_INTENT,
+    RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL,
     RENEGADE_SETTLED_INTENT
 }
 
@@ -57,6 +61,16 @@ enum SettlementBundleType {
 struct PublicIntentPublicBalanceBundle {
     /// @dev The public intent authorization payload with signature attached
     PublicIntentAuthBundle auth;
+}
+
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL` bundle
+struct PrivateIntentPublicBalanceBundleFirstFill {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentAuthBundleFirstFill auth;
+    /// @dev The statement of single-intent match settlement
+    SingleIntentMatchSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent match settlement
+    PlonkProof settlementProof;
 }
 
 /// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bundle
@@ -148,6 +162,21 @@ library SettlementBundleLib {
     {
         require(bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT, InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
+    }
+
+    /// @notice Decode a private settlement bundle for a first fill
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePrivateIntentBundleDataFirstFill(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateIntentPublicBalanceBundleFirstFill memory bundleData)
+    {
+        require(
+            bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL,
+            InvalidSettlementBundleType()
+        );
+        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundleFirstFill));
     }
 
     /// @notice Decode a private settlement bundle


### PR DESCRIPTION
### Purpose
This PR separates out the logic (handlers, bundle & statement types, etc) for first fill and subsequent fills in the natively-settled private intent code path. This pattern will be carried forward to the Renegade-settled private intent implementation.

### Testing
- [x] All unit tests pass