### PR TITLE
darkpoolv2: settlement: Require nonces with all signatures

### DIFF
--- a/src/darkpool/v2/libraries/DarkpoolState.sol
+++ b/src/darkpool/v2/libraries/DarkpoolState.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { MerkleMountainLib } from "renegade-lib/merkle/MerkleMountain.sol";
+import { NullifierLib } from "renegade-lib/NullifierSet.sol";
+
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+
+/// @title Darkpool State
+/// @notice Storage struct bundling core darkpool state
+/// @dev Used to pass storage references as a single parameter
+struct DarkpoolState {
+    /// @notice The mapping of open public intents
+    /// @dev This maps the intent hash to the amount remaining.
+    /// @dev An intent hash is a hash of the tuple (executor, intent),
+    /// where executor is the address of the party allowed to fill the intent.
+    mapping(bytes32 => uint256) openPublicIntents;
+    /// @notice A store of spent signature nonces for user updates
+    /// @dev This is used to prevent a relayer from submitting the same update twice
+    mapping(uint256 => bool) spentNonces;
+    /// @notice The Merkle mountain range for state element commitments
+    MerkleMountainLib.MerkleMountainRange merkleMountainRange;
+    /// @notice The nullifier set for the darkpool
+    /// @dev Each time a state element is updated a nullifier is spent.
+    /// @dev The nullifier set ensures that a pre-update state element cannot create two separate post-update state
+    /// elements in the Merkle state
+    /// @dev The nullifier is computed deterministically from the shares of the pre-update state element
+    NullifierLib.NullifierSet nullifierSet;
+}
+
+/// @title DarkpoolState
+/// @author Renegade Eng
+/// @notice Library for the darkpool state
+library DarkpoolStateLib {
+    using MerkleMountainLib for MerkleMountainLib.MerkleMountainRange;
+    using NullifierLib for NullifierLib.NullifierSet;
+
+    // --- Errors --- //
+
+    /// @notice Error thrown when a signature nonce has already been spent
+    error NonceAlreadySpent();
+
+    // --- Getters --- //
+
+    /// @notice Get the amount remaining for an open public intent
+    /// @param state The darkpool state
+    /// @param intentHash The hash of the intent
+    /// @return The amount remaining for the intent
+    function getOpenIntentAmountRemaining(
+        DarkpoolState storage state,
+        bytes32 intentHash
+    )
+        internal
+        view
+        returns (uint256)
+    {
+        return state.openPublicIntents[intentHash];
+    }
+
+    /// @notice Check if a nullifier has been spent
+    /// @param state The darkpool state
+    /// @param nullifier The nullifier to check
+    /// @return Whether the nullifier has been spent
+    function nullifierSpent(DarkpoolState storage state, BN254.ScalarField nullifier) internal view returns (bool) {
+        return state.nullifierSet.isSpent(nullifier);
+    }
+
+    /// @notice Check if a root is in the Merkle mountain range history
+    /// @param state The darkpool state
+    /// @param root The root to check
+    /// @return Whether the root is in the history
+    function rootInHistory(DarkpoolState storage state, BN254.ScalarField root) internal view returns (bool) {
+        return state.merkleMountainRange.rootInHistory(root);
+    }
+
+    // --- Setters --- //
+
+    /// @notice Set the amount remaining for an open public intent
+    /// @param state The darkpool state
+    /// @param intentHash The hash of the intent
+    /// @param amount The amount remaining for the intent
+    function setOpenIntentAmountRemaining(DarkpoolState storage state, bytes32 intentHash, uint256 amount) internal {
+        state.openPublicIntents[intentHash] = amount;
+    }
+
+    /// @notice Decrement the amount remaining for an open public intent
+    /// @param state The darkpool state
+    /// @param intentHash The hash of the intent
+    /// @param amount The amount to decrement the amount remaining by
+    function decrementOpenIntentAmountRemaining(
+        DarkpoolState storage state,
+        bytes32 intentHash,
+        uint256 amount
+    )
+        internal
+    {
+        state.openPublicIntents[intentHash] -= amount;
+    }
+
+    /// @notice Spend a signature nonce
+    /// @param state The darkpool state
+    /// @param nonce The nonce to spend
+    function spendNonce(DarkpoolState storage state, uint256 nonce) internal {
+        if (state.spentNonces[nonce]) revert NonceAlreadySpent();
+        state.spentNonces[nonce] = true;
+    }
+
+    /// @notice Spend a nullifier
+    /// @param state The darkpool state
+    /// @param nullifier The nullifier to spend
+    function spendNullifier(DarkpoolState storage state, BN254.ScalarField nullifier) internal {
+        state.nullifierSet.spend(nullifier);
+    }
+
+    /// @notice Insert a leaf into the Merkle mountain range at the given depth
+    /// @param state The darkpool state
+    /// @param depth The depth at which to insert the leaf
+    /// @param leaf The leaf to insert
+    /// @param hasher The hasher to use for hashing
+    function insertMerkleLeaf(
+        DarkpoolState storage state,
+        uint256 depth,
+        BN254.ScalarField leaf,
+        IHasher hasher
+    )
+        internal
+    {
+        state.merkleMountainRange.insertLeaf(depth, leaf, hasher);
+    }
+}

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import { SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
-import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 
 /// @title Renegade Settled Private Intent Library
@@ -12,6 +12,7 @@ import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 /// @dev A renegade settled private intent is a private intent with a private (darkpool) balance.
 library RenegadeSettledPrivateIntentLib {
     using SettlementBundleLib for SettlementBundle;
+    using DarkpoolStateLib for DarkpoolState;
 
     /// @notice Execute a renegade settled private intent bundle
     /// @param isFirstFill Whether the settlement bundle is a first fill

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -20,7 +20,7 @@ import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol"
 import { RenegadeSettledPrivateIntentLib } from "./RenegadeSettledPrivateIntent.sol";
 import { SettlementTransfers, SettlementTransfersLib } from "darkpoolv2-types/Transfers.sol";
 import { ExternalTransferLib } from "darkpoolv2-lib/TransferLib.sol";
-import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
+import { DarkpoolState } from "darkpoolv2-lib/DarkpoolState.sol";
 
 import { emptyOpeningElements } from "renegade-lib/verifier/Types.sol";
 

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -3,6 +3,8 @@
 pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { ECDSALib } from "renegade-lib/ECDSA.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import {
     IntentOnlyValidityStatement,
@@ -11,11 +13,47 @@ import {
 } from "darkpoolv2-lib/PublicInputs.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
-import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-
 // ------------------------------
 // | Intent Authorization Types |
 // ------------------------------
+
+/// @notice A signature with a nonce
+/// @dev We assume the signature is encoded in the format:
+/// - r in the first 32 bytes
+/// - s in the next 32 bytes
+/// - v in the last byte
+/// @dev We further assume that the signature is over the following:
+/// H(H(message) || nonce)
+struct SignatureWithNonce {
+    /// @dev The nonce of the signature
+    uint256 nonce;
+    /// @dev The signature
+    bytes signature;
+}
+
+/// @title Signature With Nonce Library
+/// @author Renegade Eng
+/// @notice Library for computing the hash of a signature with a nonce
+library SignatureWithNonceLib {
+    /// @notice Verify a signature with a nonce
+    /// @param signature The signature to verify
+    /// @param expectedSigner The expected signer of the signature
+    /// @param digest The bytes32 digest of the message to verify
+    /// @return Whether the signature is valid
+    /// @dev Verifies the signature over H(digest || nonce)
+    function verifyPrehashed(
+        SignatureWithNonce memory signature,
+        address expectedSigner,
+        bytes32 digest
+    )
+        internal
+        pure
+        returns (bool)
+    {
+        bytes32 signatureHash = EfficientHashLib.hash(digest, bytes32(signature.nonce));
+        return ECDSALib.verify(signatureHash, signature.signature, expectedSigner);
+    }
+}
 
 // --- Public Intent Authorization --- //
 
@@ -24,10 +62,10 @@ struct PublicIntentAuthBundle {
     /// @dev The intent authorization permit
     PublicIntentPermit permit;
     /// @dev The signature of the intent
-    bytes intentSignature;
+    SignatureWithNonce intentSignature;
     /// @dev The signature of the settlement obligation by the authorized executor
     /// @dev This authorizes the fields of the obligation, and importantly implicitly authorizes the price
-    bytes executorSignature;
+    SignatureWithNonce executorSignature;
 }
 
 /// @notice Intent authorization data for a public intent
@@ -56,7 +94,7 @@ library PublicIntentPermitLib {
 /// TODO: Update names in comments once circuit spec is defined
 struct PrivateIntentAuthBundleFirstFill {
     /// @dev The signature of the intent by its owner
-    bytes intentSignature;
+    SignatureWithNonce intentSignature;
     /// @dev The depth of the Merkle tree to insert the intent into
     uint256 merkleDepth;
     /// @dev The statement for the proof of `PrivateIntentPublicBalance`

--- a/test/darkpool/v2/settlement/native-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/FullMatchTests.t.sol
@@ -12,6 +12,7 @@ import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
 import { MerkleTreeLib } from "renegade-lib/merkle/MerkleTree.sol";
 import { NullifierLib } from "renegade-lib/NullifierSet.sol";
+import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 
 contract FullMatchTests is PrivateIntentSettlementTestUtils {
     using ObligationLib for ObligationBundle;
@@ -159,7 +160,16 @@ contract FullMatchTests is PrivateIntentSettlementTestUtils {
         darkpoolRealVerifier.settleMatch(bundle0, bundle1);
     }
 
-    // TODO: Add a test for re-submitting a first fill twice once the `spentSignatures` map is in place
+    /// @notice Test a replay attack on a user's intent
+    function test_fullMatch_intentReplay() public {
+        // Create match data
+        (SettlementBundle memory bundle0, SettlementBundle memory bundle1) = _createMatchData(true);
+        darkpool.settleMatch(bundle0, bundle1);
+
+        // Try settling the same match again, the intent should be replayed
+        vm.expectRevert(DarkpoolStateLib.NonceAlreadySpent.selector);
+        darkpool.settleMatch(bundle0, bundle1);
+    }
 
     /// @notice Test the case in which a nullifier is already spent on a settlement bundle
     function test_fullMatch_nullifierAlreadySpent() public {

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -8,7 +8,7 @@ import {
     SettlementBundle,
     PrivateIntentPublicBalanceBundleFirstFill
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import { PrivateIntentAuthBundleFirstFill } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignatureWithNonce, PrivateIntentAuthBundleFirstFill } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
@@ -78,7 +78,7 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         );
 
         // Sign with wrong signer
-        bytes memory wrongSig = signIntentCommitment(fullCommitment, wrongSigner.privateKey);
+        SignatureWithNonce memory wrongSig = signIntentCommitment(fullCommitment, wrongSigner.privateKey);
         authBundle.intentSignature = wrongSig;
         bundleData.auth = authBundle;
         bundle.data = abi.encode(bundleData);

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -20,6 +20,7 @@ import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 
 contract IntentAuthorizationTest is SettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
@@ -51,6 +52,16 @@ contract IntentAuthorizationTest is SettlementTestUtils {
     function test_validSignatures() public {
         // Should not revert
         SettlementBundle memory bundle = createSampleBundle();
+        authorizeIntentHelper(bundle);
+    }
+
+    function test_intentReplay() public {
+        // Create bundle and authorize it once
+        SettlementBundle memory bundle = createSampleBundle();
+        authorizeIntentHelper(bundle);
+
+        // Try settling the same bundle again, the intent should be replayed
+        vm.expectRevert(DarkpoolStateLib.NonceAlreadySpent.selector);
         authorizeIntentHelper(bundle);
     }
 

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -11,7 +11,8 @@ import {
 import {
     PublicIntentAuthBundle,
     PublicIntentPermit,
-    PublicIntentPermitLib
+    PublicIntentPermitLib,
+    SignatureWithNonce
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
@@ -58,7 +59,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         SettlementBundle memory bundle = createSampleBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
-        bytes memory sig = signIntentPermit(authBundle.permit, wrongSigner.privateKey);
+        SignatureWithNonce memory sig = signIntentPermit(authBundle.permit, wrongSigner.privateKey);
         authBundle.intentSignature = sig;
         bundleData.auth = authBundle;
         bundle.data = abi.encode(bundleData);
@@ -73,7 +74,8 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         SettlementBundle memory bundle = createSampleBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
-        authBundle.intentSignature[0] = bytes1(uint8(authBundle.intentSignature[0]) ^ 0xFF); // Modify signature
+        authBundle.intentSignature.signature[0] = bytes1(uint8(authBundle.intentSignature.signature[0]) ^ 0xFF); // Modify
+            // signature
         bundleData.auth = authBundle;
         bundle.data = abi.encode(bundleData);
 
@@ -87,7 +89,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         SettlementBundle memory bundle = createSampleBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
-        bytes memory sig = signObligation(bundle.obligation, wrongSigner.privateKey);
+        SignatureWithNonce memory sig = signObligation(bundle.obligation, wrongSigner.privateKey);
         authBundle.executorSignature = sig;
         bundleData.auth = authBundle;
         bundle.data = abi.encode(bundleData);
@@ -115,7 +117,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         // Now create a second bundle with the same intent but invalid owner signature
         // This should still pass because we skip signature verification for cached intents
         PublicIntentAuthBundle memory authBundle2 = authBundle;
-        authBundle2.intentSignature = hex"deadbeef"; // Invalid signature
+        authBundle2.intentSignature.signature = hex"deadbeef"; // Invalid signature
 
         // Setup an obligation for a smaller amount
         obligation.amountIn = randomUint(1, amountRemaining);


### PR DESCRIPTION
### Purpose
This PR requires nonces with all signatures and spends the nonces after the signature is verified. This prevents replays on the intent signatures for all authorization types.

### Testing
- [x] Unit tests pass