### PR TITLE
darkpoolv2: settlement: Ring 2 intent authorization first fill

### DIFF
--- a/src/darkpool/v1/interfaces/IDarkpool.sol
+++ b/src/darkpool/v1/interfaces/IDarkpool.sol
@@ -55,6 +55,8 @@ interface IDarkpool {
     error InvalidETHValue();
     /// @notice Thrown when protocol encryption key doesn't match
     error InvalidProtocolEncryptionKey();
+    /// @notice Thrown when the Merkle depth is invalid
+    error InvalidMerkleDepthRequested();
 
     // --- Events --- //
 

--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -70,6 +70,18 @@ struct IntentAndBalanceValidityStatementFirstFill {
     BN254.ScalarField balanceNullifier;
 }
 
+/// @notice A statement for a proof of intent and balance validity
+struct IntentAndBalanceValidityStatement {
+    /// @dev A commitment to the intent
+    BN254.ScalarField newIntentPartialCommitment;
+    /// @dev A partial commitment to the new balance
+    BN254.ScalarField balancePartialCommitment;
+    /// @dev The nullifier for the previous version of the intent
+    BN254.ScalarField intentNullifier;
+    /// @dev The nullifier for the previous version of the balance
+    BN254.ScalarField balanceNullifier;
+}
+
 // --- Settlement Statements --- //
 // Settlement proofs verify that:
 // 1. A settlement obligation is well capitalized by the balance
@@ -199,6 +211,22 @@ library PublicInputsLib {
         publicInputs[5] = BN254.ScalarField.wrap(uint256(uint160(statement.obligation.outputToken)));
         publicInputs[6] = BN254.ScalarField.wrap(statement.obligation.amountIn);
         publicInputs[7] = BN254.ScalarField.wrap(statement.obligation.amountOut);
+    }
+
+    /// @notice Serialize the public inputs for a proof of intent and balance validity
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(IntentAndBalanceValidityStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 4;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = statement.newIntentPartialCommitment;
+        publicInputs[1] = statement.balancePartialCommitment;
+        publicInputs[2] = statement.intentNullifier;
+        publicInputs[3] = statement.balanceNullifier;
     }
 
     /// @notice Get a dummy verification key for testing

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -1,18 +1,44 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+import {
+    SettlementBundle,
+    SettlementBundleLib,
+    RenegadeSettledIntentBundleFirstFill
+} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
+import { PublicInputsLib, IntentAndBalanceValidityStatementFirstFill } from "darkpoolv2-lib/PublicInputs.sol";
+import { VerificationKey } from "renegade-lib/verifier/Types.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+
+import {
+    SignatureWithNonce,
+    SignatureWithNonceLib,
+    RenegadeSettledIntentAuthBundleFirstFill,
+    PrivateIntentPrivateBalanceAuthBundleLib
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
 
 /// @title Renegade Settled Private Intent Library
 /// @author Renegade Eng
 /// @notice Library for validating a renegade settled private intents
 /// @dev A renegade settled private intent is a private intent with a private (darkpool) balance.
 library RenegadeSettledPrivateIntentLib {
+    using SignatureWithNonceLib for SignatureWithNonce;
     using SettlementBundleLib for SettlementBundle;
+    using SettlementContextLib for SettlementContext;
     using DarkpoolStateLib for DarkpoolState;
+    using PublicInputsLib for IntentAndBalanceValidityStatementFirstFill;
+
+    // --- Errors --- //
+
+    /// @notice Error thrown when the owner signature is invalid
+    error InvalidOwnerSignature();
+
+    // --- Implementation --- //
 
     /// @notice Execute a renegade settled private intent bundle
     /// @param isFirstFill Whether the settlement bundle is a first fill
@@ -31,6 +57,83 @@ library RenegadeSettledPrivateIntentLib {
     )
         internal
     {
+        if (isFirstFill) {
+            executeFirstFill(settlementBundle, settlementContext, state);
+        } else {
+            executeSubsequentFill(settlementBundle, settlementContext, state, hasher);
+        }
+    }
+
+    /// @notice Execute the state updates necessary to settle the bundle for a first fill
+    /// @param settlementBundle The settlement bundle to execute
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
+    function executeFirstFill(
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Decode the bundle data
+        RenegadeSettledIntentBundleFirstFill memory bundleData =
+            settlementBundle.decodeRenegadeSettledIntentBundleDataFirstFill();
+
+        // 1. Validate the intent authorization
+        validateIntentAuthorizationFirstFill(bundleData.auth, settlementContext, state);
+    }
+
+    /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill
+    /// @param settlementBundle The settlement bundle to execute
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing
+    function executeSubsequentFill(
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
         // TODO: Implement
+    }
+
+    // ------------------------
+    // | Intent Authorization |
+    // ------------------------
+
+    /// @notice Execute the state updates necessary to authorize the intent for a first fill
+    /// @param bundleData The bundle data to execute the state updates for
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
+    /// @dev On the first fill, we verify that the balance-leaked one-time key has signed the initial
+    /// intent commitment as well as the rotated one-time key.
+    function validateIntentAuthorizationFirstFill(
+        RenegadeSettledIntentAuthBundleFirstFill memory bundleData,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Validate the Merkle depth
+        // TODO: Allow for dynamic Merkle depth
+        if (bundleData.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
+            revert IDarkpool.InvalidMerkleDepthRequested();
+        }
+
+        // Verify the owner signature and spend the nonce
+        bytes32 digest = PrivateIntentPrivateBalanceAuthBundleLib.getOwnerSignatureDigest(bundleData);
+        address signer = bundleData.statement.oneTimeAuthorizingAddress;
+
+        bool valid = bundleData.ownerSignature.verifyPrehashed(signer, digest);
+        if (!valid) revert InvalidOwnerSignature();
+        state.spendNonce(bundleData.ownerSignature.nonce);
+
+        // Register a proof of validity for the intent and balance
+        // TODO: Fetch a real verification key
+        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(bundleData.statement);
+        VerificationKey memory vk = PublicInputsLib.dummyVkey();
+        settlementContext.pushProof(publicInputs, bundleData.validityProof, vk);
     }
 }

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -116,58 +116,39 @@ struct PrivateIntentAuthBundle {
 
 // --- Private Intent, Private Balance Authorization --- //
 
-/// @notice The Renegade settled private intent auth bundle
-/// @dev The bundle is verified differently depending on whether this is the first fill or not.
-/// For this reason, we don't attach a statement type directly to the bundle. Rather, we build
-/// a statement type on the fly depending on the value of `isFirstFill`, using the fields of the bundle.
-struct PrivateIntentPrivateBalanceAuthBundle {
-    // --- First Fill Authorization --- //
-    /// @dev Whether this is the first fill or not
-    bool isFirstFill;
-    /// @dev The one time authorizing address for the balance
-    /// @dev This is unconstrained if this is not the first fill, allowing
-    /// clients to set the value arbitrarily to hide the address
-    address oneTimeAuthorizingAddress;
-    /// @dev The hash of the new one time key for the balance
-    BN254.ScalarField newBalanceOneTimeKeyHash;
+/// @notice The private intent authorization payload for a first fill
+struct RenegadeSettledIntentAuthBundleFirstFill {
+    /// @dev The depth of the Merkle tree to insert the intent into
+    uint256 merkleDepth;
     /// @dev The signature of the intent and an updated balance one time key hash
     /// @dev In specific, we sign:
     ///     H(intentCommitment || updatedBalanceOneTimeKeyHash)
     /// under the previous, now leaked, one time key. This authorizes the intent to be capitalized by
     /// the balance which the owner (hidden) has deposited in the darkpool. This signature also
     /// authorizes the one time key to be rotated to the new one time key.
-    /// @dev When `isFirstFill` is false, this field may be omitted
-    bytes ownerSignature;
-    // --- Commit Nullify Fields --- //
-    /// @dev The nullifier for the previous version of the intent
-    BN254.ScalarField intentNullifier;
-    /// @dev The nullifier for the previous version of the balance
-    BN254.ScalarField balanceNullifier;
-    /// @dev The partial commitment to the new balance
-    BN254.ScalarField balancePartialCommitment;
-    /// @dev The partial commitment to the new intent
-    BN254.ScalarField intentPartialCommitment;
+    SignatureWithNonce ownerSignature;
+    /// @dev The statement for the proof intent and balance validity
+    IntentAndBalanceValidityStatementFirstFill statement;
+    /// @dev The proof of intent and balance validity
+    PlonkProof validityProof;
 }
 
 /// @title Private Intent, Private Balance Auth Bundle Library
 /// @author Renegade Eng
 /// @notice Library for decoding private intent, private balance auth bundle data
 library PrivateIntentPrivateBalanceAuthBundleLib {
-    /// @notice Build a statement for a first fill validity proof
-    /// @param bundle The private intent, private balance auth bundle to build the statement for
-    /// @return statement The statement for the first fill validity proof
-    function buildFirstFillValidityStatement(PrivateIntentPrivateBalanceAuthBundle memory bundle)
+    /// @notice Get the digest for the owner signature
+    /// @param bundleData The bundle data to get the digest for
+    /// @return digest The digest for the owner signature
+    /// @dev The digest is computed as:
+    ///     H(intentCommitment || updatedBalanceOneTimeKeyHash)
+    function getOwnerSignatureDigest(RenegadeSettledIntentAuthBundleFirstFill memory bundleData)
         internal
         pure
-        returns (IntentAndBalanceValidityStatementFirstFill memory statement)
+        returns (bytes32 digest)
     {
-        statement = IntentAndBalanceValidityStatementFirstFill({
-            oneTimeAuthorizingAddress: bundle.oneTimeAuthorizingAddress,
-            newOneTimeKeyHash: bundle.newBalanceOneTimeKeyHash,
-            balancePartialCommitment: bundle.balancePartialCommitment,
-            intentPartialCommitment: bundle.intentPartialCommitment,
-            balanceNullifier: bundle.balanceNullifier,
-            intentNullifier: bundle.intentNullifier
-        });
+        uint256 commitment = BN254.ScalarField.unwrap(bundleData.statement.initialIntentCommitment);
+        uint256 newOneTimeKeyHash = BN254.ScalarField.unwrap(bundleData.statement.newOneTimeKeyHash);
+        digest = EfficientHashLib.hash(bytes32(commitment), bytes32(newOneTimeKeyHash));
     }
 }

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -9,7 +9,8 @@ import { Intent } from "darkpoolv2-types/Intent.sol";
 import {
     IntentOnlyValidityStatement,
     IntentOnlyValidityStatementFirstFill,
-    IntentAndBalanceValidityStatementFirstFill
+    IntentAndBalanceValidityStatementFirstFill,
+    IntentAndBalanceValidityStatement
 } from "darkpoolv2-lib/PublicInputs.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
@@ -133,6 +134,16 @@ struct RenegadeSettledIntentAuthBundleFirstFill {
     PlonkProof validityProof;
 }
 
+/// @notice The private intent authorization payload for a subsequent fill
+struct RenegadeSettledIntentAuthBundle {
+    /// @dev The depth of the Merkle tree to insert the intent into
+    uint256 merkleDepth;
+    /// @dev The statement for the proof intent and balance validity
+    IntentAndBalanceValidityStatement statement;
+    /// @dev The proof of intent and balance validity
+    PlonkProof validityProof;
+}
+
 /// @title Private Intent, Private Balance Auth Bundle Library
 /// @author Renegade Eng
 /// @notice Library for decoding private intent, private balance auth bundle data
@@ -149,6 +160,6 @@ library PrivateIntentPrivateBalanceAuthBundleLib {
     {
         uint256 commitment = BN254.ScalarField.unwrap(bundleData.statement.initialIntentCommitment);
         uint256 newOneTimeKeyHash = BN254.ScalarField.unwrap(bundleData.statement.newOneTimeKeyHash);
-        digest = EfficientHashLib.hash(bytes32(commitment), bytes32(newOneTimeKeyHash));
+        digest = EfficientHashLib.hash(commitment, newOneTimeKeyHash);
     }
 }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -7,7 +7,7 @@ import {
     PublicIntentAuthBundle,
     PrivateIntentAuthBundleFirstFill,
     PrivateIntentAuthBundle,
-    PrivateIntentPrivateBalanceAuthBundle
+    RenegadeSettledIntentAuthBundleFirstFill
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import {
     SingleIntentMatchSettlementStatement,
@@ -83,10 +83,10 @@ struct PrivateIntentPublicBalanceBundle {
     PlonkProof settlementProof;
 }
 
-/// @notice The settlement bundle data for a `RENEGADE_SETTLED_INTENT` bundle
-struct RenegadeSettledPrivateIntentBundle {
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL` bundle
+struct RenegadeSettledIntentBundleFirstFill {
     /// @dev The private intent authorization payload with signature attached
-    PrivateIntentPrivateBalanceAuthBundle auth;
+    RenegadeSettledIntentAuthBundleFirstFill auth;
     /// @dev The statement of renegade settled private intent public settlement
     RenegadeSettledPrivateIntentPublicSettlementStatement settlementStatement;
     /// @dev The proof of renegade settled private intent public settlement
@@ -203,12 +203,15 @@ library SettlementBundleLib {
     /// @notice Decode a renegade settled private intent settlement bundle
     /// @param bundle The settlement bundle to decode
     /// @return bundleData The decoded bundle data
-    function decodeRenegadeSettledPrivateIntentBundleData(SettlementBundle calldata bundle)
+    function decodeRenegadeSettledIntentBundleDataFirstFill(SettlementBundle calldata bundle)
         internal
         pure
-        returns (RenegadeSettledPrivateIntentBundle memory bundleData)
+        returns (RenegadeSettledIntentBundleFirstFill memory bundleData)
     {
-        require(bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT, InvalidSettlementBundleType());
-        bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateIntentBundle));
+        require(
+            bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL,
+            InvalidSettlementBundleType()
+        );
+        bundleData = abi.decode(bundle.data, (RenegadeSettledIntentBundleFirstFill));
     }
 }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -7,7 +7,8 @@ import {
     PublicIntentAuthBundle,
     PrivateIntentAuthBundleFirstFill,
     PrivateIntentAuthBundle,
-    RenegadeSettledIntentAuthBundleFirstFill
+    RenegadeSettledIntentAuthBundleFirstFill,
+    RenegadeSettledIntentAuthBundle
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import {
     SingleIntentMatchSettlementStatement,
@@ -87,6 +88,16 @@ struct PrivateIntentPublicBalanceBundle {
 struct RenegadeSettledIntentBundleFirstFill {
     /// @dev The private intent authorization payload with signature attached
     RenegadeSettledIntentAuthBundleFirstFill auth;
+    /// @dev The statement of renegade settled private intent public settlement
+    RenegadeSettledPrivateIntentPublicSettlementStatement settlementStatement;
+    /// @dev The proof of renegade settled private intent public settlement
+    PlonkProof settlementProof;
+}
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_INTENT` bundle
+struct RenegadeSettledIntentBundle {
+    /// @dev The private intent authorization payload with signature attached
+    RenegadeSettledIntentAuthBundle auth;
     /// @dev The statement of renegade settled private intent public settlement
     RenegadeSettledPrivateIntentPublicSettlementStatement settlementStatement;
     /// @dev The proof of renegade settled private intent public settlement
@@ -213,5 +224,17 @@ library SettlementBundleLib {
             InvalidSettlementBundleType()
         );
         bundleData = abi.decode(bundle.data, (RenegadeSettledIntentBundleFirstFill));
+    }
+
+    /// @notice Decode a renegade settled private intent settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledIntentBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledIntentBundle memory bundleData)
+    {
+        require(bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT, InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledIntentBundle));
     }
 }

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -14,6 +14,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { NativeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPrivateIntent.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
 import { PrivateIntentSettlementTestUtils } from "./Utils.sol";
 
 contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
@@ -103,7 +104,7 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         SettlementBundle memory bundle = createSettlementBundleSubsequentFill(invalidDepth, obligation, intentOwner);
 
         // Should revert with InvalidMerkleDepthRequested
-        vm.expectRevert(NativeSettledPrivateIntentLib.InvalidMerkleDepthRequested.selector);
+        vm.expectRevert(IDarkpool.InvalidMerkleDepthRequested.selector);
         authorizeIntentHelper(bundle);
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds intent authorization logic to the darkpool for Ring 2 users. On the first fill, we verify that the user has spent a one-time key to sign the commitment to the intent as well as the updated one-time key.

For subsequent fills, we need only verify a validity proof.

### Testing
- [x] Unit tests pass