### PR TITLE
darkpoolv2: obligation: Move obligation bundle to top level argument

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -186,7 +186,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
     {
         // 1. Allocate a settlement context
         SettlementContext memory settlementContext =
-            SettlementLib.allocateSettlementTransfers(party0SettlementBundle, party1SettlementBundle);
+            SettlementLib.allocateSettlementContext(party0SettlementBundle, party1SettlementBundle);
 
         // 2. Validate that the settlement obligations are compatible with one another
         SettlementLib.validateObligationBundle(obligationBundle);

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
+import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { EncryptionKey } from "darkpoolv1-types/Ciphertext.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
@@ -52,9 +53,13 @@ interface IDarkpoolV2 {
     function openPublicIntents(bytes32 intentHash) external view returns (uint256);
 
     /// @notice Settle a trade
+    /// @param obligationBundle The obligation bundle for the trade. In the case of a public trade, this
+    /// encodes the settlement obligations for each party in the trade. If the trade is private, this bundle holds
+    /// a proof attesting to the validity of the settlement.
     /// @param party0SettlementBundle The settlement bundle for the first party
     /// @param party1SettlementBundle The settlement bundle for the second party
     function settleMatch(
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata party0SettlementBundle,
         SettlementBundle calldata party1SettlementBundle
     )

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import {
+    PartyId,
     SettlementBundle,
     SettlementBundleLib,
     PrivateIntentPublicBalanceBundle,
@@ -54,6 +55,8 @@ library NativeSettledPrivateIntentLib {
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance
     /// @param isFirstFill Whether the settlement bundle is a first fill
+    /// @param partyId The party ID to execute the settlement bundle for
+    /// @param obligationBundle The obligation bundle to validate
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
@@ -62,6 +65,8 @@ library NativeSettledPrivateIntentLib {
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function execute(
         bool isFirstFill,
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -70,13 +75,15 @@ library NativeSettledPrivateIntentLib {
         internal
     {
         if (isFirstFill) {
-            executeFirstFill(settlementBundle, settlementContext, state, hasher);
+            executeFirstFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);
         } else {
-            executeSubsequentFill(settlementBundle, settlementContext, state, hasher);
+            executeSubsequentFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);
         }
     }
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a first fill
+    /// @param partyId The party ID to validate the obligation for
+    /// @param obligationBundle The obligation bundle to validate
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
@@ -84,6 +91,8 @@ library NativeSettledPrivateIntentLib {
     /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function executeFirstFill(
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -94,7 +103,7 @@ library NativeSettledPrivateIntentLib {
         // Decode the bundle data
         PrivateIntentPublicBalanceBundleFirstFill memory bundleData =
             settlementBundle.decodePrivateIntentBundleDataFirstFill();
-        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
+        SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
         // 1. Validate the intent authorization
         validatePrivateIntentAuthorizationFirstFill(bundleData.auth, settlementContext, state);
@@ -111,13 +120,17 @@ library NativeSettledPrivateIntentLib {
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a subsequent
     /// fill; i.e. not the first fill
+    /// @param partyId The party ID to validate the obligation for
+    /// @param obligationBundle The obligation bundle to validate
     /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param settlementContext The settlement context to which we append post-execution updates.
     /// @param state The darkpool state containing all storage references
     /// @param hasher The hasher to use for hashing
     /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function executeSubsequentFill(
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -127,7 +140,7 @@ library NativeSettledPrivateIntentLib {
     {
         // Decode the bundle data
         PrivateIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePrivateIntentBundleData();
-        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
+        SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
         // 1. Validate the intent authorization
         validatePrivateIntentAuthorization(bundleData.auth, settlementContext);

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -54,7 +54,6 @@ library NativeSettledPrivateIntentLib {
     // --- Implementation --- //
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance
-    /// @param isFirstFill Whether the settlement bundle is a first fill
     /// @param partyId The party ID to execute the settlement bundle for
     /// @param obligationBundle The obligation bundle to validate
     /// @param settlementBundle The settlement bundle to validate
@@ -64,7 +63,6 @@ library NativeSettledPrivateIntentLib {
     /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function execute(
-        bool isFirstFill,
         PartyId partyId,
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
@@ -74,7 +72,7 @@ library NativeSettledPrivateIntentLib {
     )
         internal
     {
-        if (isFirstFill) {
+        if (settlementBundle.isFirstFill) {
             executeFirstFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);
         } else {
             executeSubsequentFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {
+    PartyId,
     SettlementBundle,
     PublicIntentPublicBalanceBundle,
     SettlementBundleLib
@@ -51,11 +52,15 @@ library NativeSettledPublicIntentLib {
     /// @dev Note that in contrast to other settlement bundle types, no balance obligation
     /// constraints are checked here. The balance constraint is implicitly checked by transferring
     /// into the darkpool.
+    /// @param partyId The party ID to execute the settlement bundle for
+    /// @param obligationBundle The obligation bundle to validate
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
     /// TODO: Add bounds checks on the amounts in the intent and obligation
     function execute(
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state
@@ -64,7 +69,7 @@ library NativeSettledPublicIntentLib {
     {
         // Decode the settlement bundle data
         PublicIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePublicBundleData();
-        SettlementObligation memory obligation = settlementBundle.obligation.decodePublicObligation();
+        SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
         // 1. Validate the intent authorization
         (uint256 amountRemaining, bytes32 intentHash) =

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -3,11 +3,13 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import {
+    PartyId,
     SettlementBundle,
     SettlementBundleLib,
     RenegadeSettledIntentBundleFirstFill,
     RenegadeSettledIntentBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
@@ -51,6 +53,8 @@ library RenegadeSettledPrivateIntentLib {
 
     /// @notice Execute a renegade settled private intent bundle
     /// @param isFirstFill Whether the settlement bundle is a first fill
+    /// @param partyId The party ID to execute the settlement bundle for
+    /// @param obligationBundle The obligation bundle to execute
     /// @param settlementBundle The settlement bundle to execute
     /// @param settlementContext The settlement context to which we append post-execution updates.
     /// @param state The darkpool state containing all storage references
@@ -59,6 +63,8 @@ library RenegadeSettledPrivateIntentLib {
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function execute(
         bool isFirstFill,
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -67,18 +73,24 @@ library RenegadeSettledPrivateIntentLib {
         internal
     {
         if (isFirstFill) {
-            executeFirstFill(settlementBundle, settlementContext, state, hasher);
+            executeFirstFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);
         } else {
-            executeSubsequentFill(settlementBundle, settlementContext, state, hasher);
+            executeSubsequentFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);
         }
     }
 
     /// @notice Execute the state updates necessary to settle the bundle for a first fill
+    /// @param partyId The party ID to execute the settlement bundle for
+    /// @param obligationBundle The obligation bundle to execute
     /// @param settlementBundle The settlement bundle to execute
-    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param settlementContext The settlement context to which we append post-execution updates.
     /// @param state The darkpool state containing all storage references
     /// @param hasher The hasher to use for hashing
+    /// TODO: Proof link into the obligation bundle's settlement proof
+    /// TODO: Check that the settlement obligation in the statement equals the one in the obligation bundle
     function executeFirstFill(
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -104,11 +116,17 @@ library RenegadeSettledPrivateIntentLib {
     }
 
     /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill
+    /// @param partyId The party ID to execute the settlement bundle for
+    /// @param obligationBundle The obligation bundle to execute
     /// @param settlementBundle The settlement bundle to execute
-    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param settlementContext The settlement context to which we append post-execution updates.
     /// @param state The darkpool state containing all storage references
     /// @param hasher The hasher to use for hashing
+    /// TODO: Proof link into the obligation bundle's settlement proof
+    /// TODO: Check that the settlement obligation in the statement equals the one in the obligation bundle
     function executeSubsequentFill(
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -52,7 +52,6 @@ library RenegadeSettledPrivateIntentLib {
     // --- Implementation --- //
 
     /// @notice Execute a renegade settled private intent bundle
-    /// @param isFirstFill Whether the settlement bundle is a first fill
     /// @param partyId The party ID to execute the settlement bundle for
     /// @param obligationBundle The obligation bundle to execute
     /// @param settlementBundle The settlement bundle to execute
@@ -62,7 +61,6 @@ library RenegadeSettledPrivateIntentLib {
     /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
     /// The balance constraint is implicitly checked by transferring into the darkpool.
     function execute(
-        bool isFirstFill,
         PartyId partyId,
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
@@ -72,7 +70,7 @@ library RenegadeSettledPrivateIntentLib {
     )
         internal
     {
-        if (isFirstFill) {
+        if (settlementBundle.isFirstFill) {
             executeFirstFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);
         } else {
             executeSubsequentFill(partyId, obligationBundle, settlementBundle, settlementContext, state, hasher);

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -7,11 +7,12 @@ import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
 
 import {
+    PartyId,
     SettlementBundle,
     SettlementBundleType,
     SettlementBundleLib
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import { ObligationBundle, ObligationType } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { ObligationBundle, ObligationType, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SimpleTransfer } from "darkpoolv2-types/Transfers.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
@@ -28,6 +29,7 @@ import { emptyOpeningElements } from "renegade-lib/verifier/Types.sol";
 /// @author Renegade Eng
 /// @notice Library for settlement operations
 library SettlementLib {
+    using ObligationLib for ObligationBundle;
     using SettlementBundleLib for SettlementBundle;
     using SettlementContextLib for SettlementContext;
     using SettlementTransfersLib for SettlementTransfers;
@@ -72,55 +74,34 @@ library SettlementLib {
 
     // --- Obligation Compatibility --- //
 
-    /// @notice Check that two settlement obligations are compatible with one another
-    /// @param party0Bundle The obligation bundle for the first party
-    /// @param party1Bundle The obligation bundle for the second party
-    function checkObligationCompatibility(
-        ObligationBundle calldata party0Bundle,
-        ObligationBundle calldata party1Bundle
-    )
-        internal
-        pure
-    {
-        // Parties must have the same obligation type; in that both trades must either settle privately or publicly
-        // Regardless of the intent or balance types
-        if (party0Bundle.obligationType != party1Bundle.obligationType) {
-            revert IncompatibleObligationTypes();
-        }
-
-        ObligationType ty = party0Bundle.obligationType;
-        if (ty == ObligationType.PUBLIC) {
-            // Validate a public obligation
-            validatePublicObligationCompatibility(party0Bundle, party1Bundle);
+    /// @notice Validate an obligation bundle
+    /// @param obligationBundle The obligation bundle to validate
+    function validateObligationBundle(ObligationBundle calldata obligationBundle) internal pure {
+        if (obligationBundle.obligationType == ObligationType.PUBLIC) {
+            // Validate a public obligation bundle
+            validatePublicObligationBundle(obligationBundle);
         } else {
             revert("Not implemented");
         }
     }
 
-    /// @notice Validate compatibility of two public obligations
-    /// @param party0Bundle The settlement bundle for the first party
-    /// @param party1Bundle The settlement bundle for the second party
-    function validatePublicObligationCompatibility(
-        ObligationBundle calldata party0Bundle,
-        ObligationBundle calldata party1Bundle
-    )
-        internal
-        pure
-    {
+    /// @notice Validate a public obligation bundle
+    /// @param obligationBundle The obligation bundle to validate
+    function validatePublicObligationBundle(ObligationBundle calldata obligationBundle) internal pure {
         // Decode the obligations
-        SettlementObligation memory party0Obligation = abi.decode(party0Bundle.data, (SettlementObligation));
-        SettlementObligation memory party1Obligation = abi.decode(party1Bundle.data, (SettlementObligation));
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
+            obligationBundle.decodePublicObligations();
 
         // 1. The input and output tokens must correspond to the same pair
-        bool tokenCompatible = party0Obligation.inputToken == party1Obligation.outputToken
-            && party0Obligation.outputToken == party1Obligation.inputToken;
+        bool tokenCompatible =
+            obligation0.inputToken == obligation1.outputToken && obligation0.outputToken == obligation1.inputToken;
         if (!tokenCompatible) {
             revert IncompatiblePairs();
         }
 
         // 2. The input and output amounts must correspond
-        bool amountCompatible = party0Obligation.amountIn == party1Obligation.amountOut
-            && party0Obligation.amountOut == party1Obligation.amountIn;
+        bool amountCompatible =
+            obligation0.amountIn == obligation1.amountOut && obligation0.amountOut == obligation1.amountIn;
         if (!amountCompatible) {
             revert IncompatibleAmounts();
         }
@@ -129,6 +110,8 @@ library SettlementLib {
     // --- Settlement Bundle Validation --- //
 
     /// @notice Execute a settlement bundle
+    /// @param partyId The party ID to execute the settlement bundle for
+    /// @param obligationBundle The obligation bundle for the trade
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
@@ -136,6 +119,8 @@ library SettlementLib {
     /// @dev This function validates and executes the settlement bundle based on the bundle type
     /// @dev See the library files in this directory for type-specific execution & validation logic.
     function executeSettlementBundle(
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
@@ -145,15 +130,23 @@ library SettlementLib {
     {
         SettlementBundleType bundleType = settlementBundle.bundleType;
         if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
-            NativeSettledPublicIntentLib.execute(settlementBundle, settlementContext, state);
+            NativeSettledPublicIntentLib.execute(partyId, obligationBundle, settlementBundle, settlementContext, state);
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL) {
-            NativeSettledPrivateIntentLib.execute(true, settlementBundle, settlementContext, state, hasher);
+            NativeSettledPrivateIntentLib.execute(
+                true, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
+            );
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
-            NativeSettledPrivateIntentLib.execute(false, settlementBundle, settlementContext, state, hasher);
+            NativeSettledPrivateIntentLib.execute(
+                false, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
+            );
         } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL) {
-            RenegadeSettledPrivateIntentLib.execute(true, settlementBundle, settlementContext, state, hasher);
+            RenegadeSettledPrivateIntentLib.execute(
+                true, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
+            );
         } else {
-            RenegadeSettledPrivateIntentLib.execute(false, settlementBundle, settlementContext, state, hasher);
+            RenegadeSettledPrivateIntentLib.execute(
+                false, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
+            );
         }
     }
 

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -40,6 +40,8 @@ library SettlementLib {
     error IncompatiblePairs();
     /// @notice Error thrown when the obligation amounts are not compatible
     error IncompatibleAmounts();
+    /// @notice Error thrown when the settlement bundle type is invalid
+    error InvalidSettlementBundleType();
     /// @notice Error thrown when verification fails for a settlement
     error SettlementVerificationFailed();
 
@@ -53,10 +55,7 @@ library SettlementLib {
     /// @param party0SettlementBundle The settlement bundle for the first party
     /// @param party1SettlementBundle The settlement bundle for the second party
     /// @return The allocated settlement transfers list
-    /// TODO: Generalize this method to allocate a "settlement context" which will store all data that
-    /// the transaction needs to verify after type-specific logic. This will include the transfers list,
-    /// as well as a proofs list which will store all proofs that the transaction needs to verify for settlement.
-    function allocateSettlementTransfers(
+    function allocateSettlementContext(
         SettlementBundle calldata party0SettlementBundle,
         SettlementBundle calldata party1SettlementBundle
     )
@@ -131,22 +130,16 @@ library SettlementLib {
         SettlementBundleType bundleType = settlementBundle.bundleType;
         if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
             NativeSettledPublicIntentLib.execute(partyId, obligationBundle, settlementBundle, settlementContext, state);
-        } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL) {
-            NativeSettledPrivateIntentLib.execute(
-                true, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
-            );
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
             NativeSettledPrivateIntentLib.execute(
-                false, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
+                partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
             );
-        } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL) {
+        } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT) {
             RenegadeSettledPrivateIntentLib.execute(
-                true, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
+                partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
             );
         } else {
-            RenegadeSettledPrivateIntentLib.execute(
-                false, partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
-            );
+            revert InvalidSettlementBundleType();
         }
     }
 

--- a/src/darkpool/v2/types/settlement/ObligationBundle.sol
+++ b/src/darkpool/v2/types/settlement/ObligationBundle.sol
@@ -1,16 +1,17 @@
 /// SPDX-License-Identifier: Apache
 pragma solidity ^0.8.24;
 
+import { PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 
 // --------------------
 // | Obligation Types |
 // --------------------
 
-/// @notice The settlement obligation bundle for a user
+/// @notice The settlement obligation bundle for both users in a trade
 /// @dev This data represents the following based on the obligation type:
-/// 1. *Public Obligation*: A plaintext settlement obligation
-/// 2. TODO: Add private obligation data here
+/// 1. *Public Obligation*: A plaintext settlement obligation for each party in the trade
+/// 2. *Private Obligation* A proof attesting to the validity of the _private_ settlement obligations in the trade.
 struct ObligationBundle {
     /// @dev The type of obligation
     ObligationType obligationType;
@@ -31,15 +32,77 @@ library ObligationLib {
     /// @notice The error type emitted when an obligation type check fails
     error InvalidObligationType();
 
+    /// @notice Decode both public obligations for a public obligation bundle
+    /// @param bundle The obligation bundle to decode
+    /// @return obligation0 The decoded obligation for the first party
+    /// @return obligation1 The decoded obligation for the second party
+    function decodePublicObligations(ObligationBundle calldata bundle)
+        internal
+        pure
+        returns (SettlementObligation memory obligation0, SettlementObligation memory obligation1)
+    {
+        require(bundle.obligationType == ObligationType.PUBLIC, InvalidObligationType());
+        (obligation0, obligation1) = abi.decode(bundle.data, (SettlementObligation, SettlementObligation));
+    }
+
+    /// @notice Decode both public obligations from a memory-allocated bundle
+    /// @param bundle The obligation bundle to decode
+    /// @return obligation0 The decoded obligation for the first party
+    /// @return obligation1 The decoded obligation for the second party
+    function decodePublicObligationsMemory(ObligationBundle memory bundle)
+        internal
+        pure
+        returns (SettlementObligation memory obligation0, SettlementObligation memory obligation1)
+    {
+        require(bundle.obligationType == ObligationType.PRIVATE, InvalidObligationType());
+        (obligation0, obligation1) = abi.decode(bundle.data, (SettlementObligation, SettlementObligation));
+    }
+
     /// @notice Decode a public obligation
     /// @param bundle The obligation bundle to decode
-    /// @return obligation The decoded obligation
-    function decodePublicObligation(ObligationBundle calldata bundle)
+    /// @param partyId The party ID to decode the obligation for
+    /// @return obligation The decoded obligation for the given party ID
+    function decodePublicObligation(
+        ObligationBundle calldata bundle,
+        PartyId partyId
+    )
         internal
         pure
         returns (SettlementObligation memory obligation)
     {
         require(bundle.obligationType == ObligationType.PUBLIC, InvalidObligationType());
-        obligation = abi.decode(bundle.data, (SettlementObligation));
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
+            abi.decode(bundle.data, (SettlementObligation, SettlementObligation));
+        if (partyId == PartyId.PARTY_0) {
+            obligation = obligation0;
+        } else if (partyId == PartyId.PARTY_1) {
+            obligation = obligation1;
+        } else {
+            revert InvalidObligationType();
+        }
+    }
+
+    /// @notice Decode a public obligation from a memory-allocated bundle
+    /// @param bundle The obligation bundle to decode
+    /// @param partyId The party ID to decode the obligation for
+    /// @return obligation The decoded obligation for the given party ID
+    function decodePublicObligationMemory(
+        ObligationBundle memory bundle,
+        PartyId partyId
+    )
+        internal
+        pure
+        returns (SettlementObligation memory obligation)
+    {
+        require(bundle.obligationType == ObligationType.PRIVATE, InvalidObligationType());
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
+            abi.decode(bundle.data, (SettlementObligation, SettlementObligation));
+        if (partyId == PartyId.PARTY_0) {
+            obligation = obligation0;
+        } else if (partyId == PartyId.PARTY_1) {
+            obligation = obligation1;
+        } else {
+            revert InvalidObligationType();
+        }
     }
 }

--- a/src/darkpool/v2/types/settlement/ObligationBundle.sol
+++ b/src/darkpool/v2/types/settlement/ObligationBundle.sol
@@ -54,7 +54,7 @@ library ObligationLib {
         pure
         returns (SettlementObligation memory obligation0, SettlementObligation memory obligation1)
     {
-        require(bundle.obligationType == ObligationType.PRIVATE, InvalidObligationType());
+        require(bundle.obligationType == ObligationType.PUBLIC, InvalidObligationType());
         (obligation0, obligation1) = abi.decode(bundle.data, (SettlementObligation, SettlementObligation));
     }
 
@@ -94,7 +94,7 @@ library ObligationLib {
         pure
         returns (SettlementObligation memory obligation)
     {
-        require(bundle.obligationType == ObligationType.PRIVATE, InvalidObligationType());
+        require(bundle.obligationType == ObligationType.PUBLIC, InvalidObligationType());
         (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
             abi.decode(bundle.data, (SettlementObligation, SettlementObligation));
         if (partyId == PartyId.PARTY_0) {

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
-import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     PublicIntentAuthBundle,
     PrivateIntentAuthBundleFirstFill,
@@ -23,16 +22,17 @@ import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 // | Settlement Bundle Types |
 // ---------------------------
 
+/// @notice The party IDs in a trade
+enum PartyId {
+    PARTY_0,
+    PARTY_1
+}
+
 /// @notice A settlement bundle for a user
 /// @dev This type encapsulates all the data required to validate a user's obligation to a trade
 /// @dev and settle the trade. The fields themselves are tagged unions of different data types representing
 /// @dev the different privacy configurations for each side of the trade.
 struct SettlementBundle {
-    /// @dev The settlement obligation
-    /// @dev Note that the settlement obligation may vary independently of the settlement bundle type.
-    /// For example, a renegade settled intent may have a public obligation. So we encode the obligation
-    /// separately from the settlement bundle data.
-    ObligationBundle obligation;
     /// @dev The type of settlement bundle
     SettlementBundleType bundleType;
     /// @dev The data validating the settlement bundle

--- a/src/libraries/FixedPoint.sol
+++ b/src/libraries/FixedPoint.sol
@@ -54,6 +54,16 @@ library FixedPointLib {
         return FixedPoint({ repr: repr });
     }
 
+    /// @notice Divide two integers and return a fixed point result
+    /// @dev This avoids the overflow that occurs when converting both integers to fixed point first
+    /// @param x The numerator (as an integer)
+    /// @param y The denominator (as an integer)
+    /// @return The fixed point result of x / y
+    function divIntegers(uint256 x, uint256 y) public pure returns (FixedPoint memory) {
+        uint256 repr = (x * (1 << FIXED_POINT_PRECISION_BITS)) / y;
+        return FixedPoint({ repr: repr });
+    }
+
     /// @notice Divide a fixed point by a scalar and return the truncated result
     /// @param x The fixed point to divide
     /// @param scalar The scalar to divide by

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -104,9 +104,8 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
     /// @dev Create an intent for an obligation
     function createIntentForObligation(SettlementObligation memory obligation) internal returns (Intent memory) {
         // Compute the min price
-        FixedPoint memory outAmtFixed = FixedPointLib.integerToFixedPoint(obligation.amountOut);
-        FixedPoint memory inAmtFixed = FixedPointLib.integerToFixedPoint(obligation.amountIn);
-        FixedPoint memory minPrice = outAmtFixed.div(inAmtFixed).divByInteger(2);
+        FixedPoint memory minPrice =
+            FixedPointLib.divIntegers(obligation.amountOut, obligation.amountIn).divByInteger(2);
 
         // Compute the input amount
         uint256 amountIn = randomUint(obligation.amountIn, 2 ** 100);
@@ -154,6 +153,7 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
         SettlementObligation memory obligation1
     )
         internal
+        pure
         returns (ObligationBundle memory)
     {
         return ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -147,7 +147,8 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
 
         // Encode the obligation and bundle
         return SettlementBundle({
-            bundleType: SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL,
+            isFirstFill: true,
+            bundleType: SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT,
             data: abi.encode(bundleData)
         });
     }
@@ -183,6 +184,7 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
 
         // Encode the obligation and bundle
         return SettlementBundle({
+            isFirstFill: false,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT,
             data: abi.encode(bundleData)
         });

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -82,16 +82,16 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Helper to create a sample settlement bundle
-    function createSampleBundle(bool isFirstFill) internal returns (SettlementBundle memory) {
+    function createSampleBundle(bool isFirstFill)
+        internal
+        returns (ObligationBundle memory obligationBundle, SettlementBundle memory bundle)
+    {
         // Create obligation
-        SettlementObligation memory obligation = SettlementObligation({
-            inputToken: address(baseToken),
-            outputToken: address(quoteToken),
-            amountIn: 100,
-            amountOut: 200
-        });
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
+        obligationBundle =
+            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
 
-        return createSettlementBundle(isFirstFill, obligation, intentOwner);
+        bundle = createSettlementBundle(isFirstFill, obligation0, intentOwner);
     }
 
     /// @dev Create a complete settlement bundle given an obligation
@@ -146,10 +146,7 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
         });
 
         // Encode the obligation and bundle
-        ObligationBundle memory obligationBundle =
-            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation) });
         return SettlementBundle({
-            obligation: obligationBundle,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT_FIRST_FILL,
             data: abi.encode(bundleData)
         });
@@ -185,10 +182,7 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
         });
 
         // Encode the obligation and bundle
-        ObligationBundle memory obligationBundle =
-            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation) });
         return SettlementBundle({
-            obligation: obligationBundle,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT,
             data: abi.encode(bundleData)
         });

--- a/test/darkpool/v2/settlement/native-settled-public-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/FullMatchTests.t.sol
@@ -35,10 +35,6 @@ contract FullMatchTests is SettlementTestUtils {
         uint256 baseAmount = obligation0.amountIn;
         uint256 quoteAmount = obligation0.amountOut;
 
-        // Calculate price from obligations
-        FixedPoint memory baseAmtFixed = FixedPointLib.integerToFixedPoint(baseAmount);
-        FixedPoint memory quoteAmtFixed = FixedPointLib.integerToFixedPoint(quoteAmount);
-
         // Create intent 0, sell the base for the quote
         uint256 minPriceRepr = price.repr / 2;
         uint256 intentSize0 = vm.randomUint(baseAmount, baseAmount * 2);
@@ -54,7 +50,7 @@ contract FullMatchTests is SettlementTestUtils {
         // Create intent 1, buy the base for the quote
         uint256 minIntentSize1 = price.unsafeFixedPointMul(intentSize0);
         uint256 intentSize1 = vm.randomUint(minIntentSize1, minIntentSize1 * 2);
-        FixedPoint memory minPriceFixed = baseAmtFixed.div(quoteAmtFixed);
+        FixedPoint memory minPriceFixed = FixedPointLib.divIntegers(baseAmount, quoteAmount);
         uint256 minPriceRepr1 = minPriceFixed.repr / 2;
         Intent memory intent1 = Intent({
             inToken: address(quoteToken),

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -149,9 +149,8 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         obligation0.amountIn = randomUint(1, amountRemaining);
         uint256 minAmountOut = authBundle2.permit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
         obligation0.amountOut = minAmountOut + 1;
-
-        ObligationBundle memory obligationBundle2 = buildObligationBundle(obligation0, obligation1);
         authBundle2.executorSignature = signObligation(obligation0, executor.privateKey);
+        ObligationBundle memory obligationBundle2 = buildObligationBundle(obligation0, obligation1);
 
         // Create the second bundle
         PublicIntentPublicBalanceBundle memory bundleData2 = PublicIntentPublicBalanceBundle({ auth: authBundle2 });
@@ -161,6 +160,6 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         });
 
         // Should not revert even with invalid intent signature because it's cached
-        authorizeIntentHelper(obligationBundle, bundle2);
+        authorizeIntentHelper(obligationBundle2, bundle2);
     }
 }

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -155,6 +155,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         // Create the second bundle
         PublicIntentPublicBalanceBundle memory bundleData2 = PublicIntentPublicBalanceBundle({ auth: authBundle2 });
         SettlementBundle memory bundle2 = SettlementBundle({
+            isFirstFill: false,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,
             data: abi.encode(bundleData2)
         });

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 /* solhint-disable func-name-mixedcase */
 
 import {
+    PartyId,
     SettlementBundle,
     SettlementBundleType,
     PublicIntentPublicBalanceBundle
@@ -14,9 +15,9 @@ import {
     PublicIntentPermitLib,
     SignatureWithNonce
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
-import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
@@ -25,24 +26,36 @@ import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 contract IntentAuthorizationTest is SettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
+    using ObligationLib for ObligationBundle;
 
     // -----------
     // | Helpers |
     // -----------
 
     /// @notice Wrapper to convert memory to calldata for library call
-    function _executeSettlementBundle(SettlementBundle calldata bundle) external returns (SettlementContext memory) {
+    function _executeSettlementBundle(
+        SettlementBundle calldata bundle,
+        ObligationBundle calldata obligationBundle
+    )
+        external
+        returns (SettlementContext memory)
+    {
         SettlementContext memory settlementContext = _createSettlementContext();
-        SettlementLib.executeSettlementBundle(bundle, settlementContext, darkpoolState, hasher);
+        NativeSettledPublicIntentLib.execute(
+            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, darkpoolState
+        );
         return settlementContext;
     }
 
     /// @notice Helper that accepts memory and calls library with calldata
-    function authorizeIntentHelper(SettlementBundle memory bundle)
+    function authorizeIntentHelper(
+        ObligationBundle memory obligationBundle,
+        SettlementBundle memory bundle
+    )
         internal
         returns (SettlementContext memory context)
     {
-        context = this._executeSettlementBundle(bundle);
+        context = this._executeSettlementBundle(bundle, obligationBundle);
     }
 
     // ---------
@@ -51,23 +64,23 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
     function test_validSignatures() public {
         // Should not revert
-        SettlementBundle memory bundle = createSampleBundle();
-        authorizeIntentHelper(bundle);
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 
     function test_intentReplay() public {
         // Create bundle and authorize it once
-        SettlementBundle memory bundle = createSampleBundle();
-        authorizeIntentHelper(bundle);
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        authorizeIntentHelper(obligationBundle, bundle);
 
         // Try settling the same bundle again, the intent should be replayed
         vm.expectRevert(DarkpoolStateLib.NonceAlreadySpent.selector);
-        authorizeIntentHelper(bundle);
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 
     function test_invalidIntentSignature_wrongSigner() public {
         // Create bundle and replace the intent signature with a wrong signature
-        SettlementBundle memory bundle = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
         SignatureWithNonce memory sig = signIntentPermit(authBundle.permit, wrongSigner.privateKey);
@@ -77,12 +90,12 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
         // Should revert with InvalidIntentSignature
         vm.expectRevert(NativeSettledPublicIntentLib.InvalidIntentSignature.selector);
-        authorizeIntentHelper(bundle);
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 
     function test_invalidIntentSignature_modifiedBytes() public {
         // Create bundle with modified intent signature
-        SettlementBundle memory bundle = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
         authBundle.intentSignature.signature[0] = bytes1(uint8(authBundle.intentSignature.signature[0]) ^ 0xFF); // Modify
@@ -92,37 +105,39 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
         // Should revert with ECDSAInvalidSignature (from OpenZeppelin ECDSA library)
         vm.expectRevert();
-        authorizeIntentHelper(bundle);
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 
     function test_invalidExecutorSignature_wrongSigner() public {
         // Create bundle with executor signature from wrong signer
-        SettlementBundle memory bundle = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
-        PublicIntentAuthBundle memory authBundle = bundleData.auth;
-        SignatureWithNonce memory sig = signObligation(bundle.obligation, wrongSigner.privateKey);
-        authBundle.executorSignature = sig;
-        bundleData.auth = authBundle;
+        SettlementObligation memory obligation0 = obligationBundle.decodePublicObligationMemory(PartyId.PARTY_0);
+
+        // Corrupt the executor signature
+        SignatureWithNonce memory sig = signObligation(obligation0, wrongSigner.privateKey);
+        bundleData.auth.executorSignature = sig;
         bundle.data = abi.encode(bundleData);
 
         // Should revert with InvalidExecutorSignature
         vm.expectRevert(NativeSettledPublicIntentLib.InvalidExecutorSignature.selector);
-        authorizeIntentHelper(bundle);
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 
     function test_cachedIntentSignature() public {
         // Create bundle and authorize it once
-        SettlementBundle memory bundle = createSampleBundle();
-        authorizeIntentHelper(bundle);
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        authorizeIntentHelper(obligationBundle, bundle);
 
         // Verify the intent was cached in the mapping
-        SettlementObligation memory obligation = abi.decode(bundle.obligation.data, (SettlementObligation));
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
+            obligationBundle.decodePublicObligationsMemory();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
 
         bytes32 intentHash = authBundle.permit.computeHash();
         uint256 amountRemaining = darkpoolState.openPublicIntents[intentHash];
-        uint256 expectedAmountRemaining = authBundle.permit.intent.amountIn - obligation.amountIn;
+        uint256 expectedAmountRemaining = authBundle.permit.intent.amountIn - obligation0.amountIn;
         assertEq(amountRemaining, expectedAmountRemaining, "Intent not cached");
 
         // Now create a second bundle with the same intent but invalid owner signature
@@ -131,22 +146,21 @@ contract IntentAuthorizationTest is SettlementTestUtils {
         authBundle2.intentSignature.signature = hex"deadbeef"; // Invalid signature
 
         // Setup an obligation for a smaller amount
-        obligation.amountIn = randomUint(1, amountRemaining);
-        uint256 minAmountOut = authBundle2.permit.intent.minPrice.unsafeFixedPointMul(obligation.amountIn);
-        obligation.amountOut = minAmountOut + 1;
+        obligation0.amountIn = randomUint(1, amountRemaining);
+        uint256 minAmountOut = authBundle2.permit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
+        obligation0.amountOut = minAmountOut + 1;
 
-        bundle.obligation.data = abi.encode(obligation);
-        authBundle2.executorSignature = signObligation(bundle.obligation, executor.privateKey);
+        ObligationBundle memory obligationBundle2 = buildObligationBundle(obligation0, obligation1);
+        authBundle2.executorSignature = signObligation(obligation0, executor.privateKey);
 
         // Create the second bundle
         PublicIntentPublicBalanceBundle memory bundleData2 = PublicIntentPublicBalanceBundle({ auth: authBundle2 });
         SettlementBundle memory bundle2 = SettlementBundle({
-            obligation: bundle.obligation,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,
             data: abi.encode(bundleData2)
         });
 
         // Should not revert even with invalid intent signature because it's cached
-        authorizeIntentHelper(bundle2);
+        authorizeIntentHelper(obligationBundle, bundle2);
     }
 }

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
@@ -3,7 +3,11 @@ pragma solidity ^0.8.24;
 
 /* solhint-disable func-name-mixedcase */
 
-import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    PartyId,
+    SettlementBundle,
+    PublicIntentPublicBalanceBundle
+} from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { PublicIntentPermit, PublicIntentPermitLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
@@ -11,19 +15,27 @@ import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 
 contract IntentConstraintsTest is SettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
+    using ObligationLib for ObligationBundle;
 
     // -----------
     // | Helpers |
     // -----------
 
     /// @notice Wrapper to convert memory to calldata for library call
-    function _validateSettlementBundleCalldata(SettlementBundle calldata bundle) external {
+    function _validateSettlementBundleCalldata(
+        PartyId partyId,
+        ObligationBundle calldata obligationBundle,
+        SettlementBundle calldata bundle
+    )
+        external
+    {
         SettlementContext memory settlementContext = _createSettlementContext();
-        NativeSettledPublicIntentLib.execute(bundle, settlementContext, darkpoolState);
+        NativeSettledPublicIntentLib.execute(partyId, obligationBundle, bundle, settlementContext, darkpoolState);
     }
 
     // ---------
@@ -33,7 +45,9 @@ contract IntentConstraintsTest is SettlementTestUtils {
     /// @notice Test that validation fails when intent and obligation have mismatched token pairs
     function test_validateObligationIntentConstraints_InvalidPair() public {
         // Create an intent for base -> quote
-        Intent memory intent = createSampleIntent();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
+            obligationBundle.decodePublicObligationsMemory();
 
         // Corrupt the token pair
         address inputToken = address(quoteToken);
@@ -44,27 +58,33 @@ contract IntentConstraintsTest is SettlementTestUtils {
             outputToken = address(weth);
         }
 
-        // Create an obligation for the mismatched pair
-        SettlementObligation memory obligation =
-            SettlementObligation({ inputToken: inputToken, outputToken: outputToken, amountIn: 100, amountOut: 200 });
-        SettlementBundle memory bundle = createSettlementBundle(intent, obligation);
+        // Modify the obligation
+        obligation0.inputToken = inputToken;
+        obligation0.outputToken = outputToken;
+        ObligationBundle memory corruptedObligationBundle = buildObligationBundle(obligation0, obligation1);
 
         // Expect the validation to revert with InvalidObligationPair
         vm.expectRevert(NativeSettledPublicIntentLib.InvalidObligationPair.selector);
-        this._validateSettlementBundleCalldata(bundle);
+        this._validateSettlementBundleCalldata(PartyId.PARTY_0, corruptedObligationBundle, bundle);
     }
 
     /// @notice Test that validation fails when the input amount is larger than the intent amount
     function test_validateObligationIntentConstraints_InvalidAmountIn() public {
         // Create an intent and an obligation which is too large
-        Intent memory intent = createSampleIntent();
-        SettlementObligation memory obligation = SettlementObligation({
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
+        Intent memory intent = bundleData.auth.permit.intent;
+
+        // Decode and corrupt the obligation
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
+            obligationBundle.decodePublicObligationsMemory();
+        SettlementObligation memory corruptObligation0 = SettlementObligation({
             inputToken: address(baseToken),
             outputToken: address(quoteToken),
             amountIn: intent.amountIn + 1,
             amountOut: 200
         });
-        SettlementBundle memory bundle = createSettlementBundle(intent, obligation);
+        ObligationBundle memory corruptedObligationBundle = buildObligationBundle(corruptObligation0, obligation1);
 
         // Expect the validation to revert with InvalidObligationAmountIn
         vm.expectRevert(
@@ -74,7 +94,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
                 intent.amountIn + 1 // amountIn (from obligation)
             )
         );
-        this._validateSettlementBundleCalldata(bundle);
+        this._validateSettlementBundleCalldata(PartyId.PARTY_0, corruptedObligationBundle, bundle);
     }
 
     /// TODO: Add a test which fills a public intent multiple times, overfilling the intent
@@ -84,8 +104,13 @@ contract IntentConstraintsTest is SettlementTestUtils {
     /// price
     function test_validateObligationIntentConstraints_InvalidPrice() public {
         // Create an intent and an obligation which has a bad price
-        Intent memory intent = createSampleIntent();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
+        Intent memory intent = bundleData.auth.permit.intent;
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
+            obligationBundle.decodePublicObligationsMemory();
 
+        // Corrupt the obligation
         uint256 amountIn = vm.randomUint(1, intent.amountIn);
         uint256 minAmountOut = intent.minPrice.unsafeFixedPointMul(amountIn);
         uint256 amountOut = minAmountOut - 1;
@@ -95,7 +120,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
             amountIn: amountIn,
             amountOut: amountOut
         });
-        SettlementBundle memory bundle = createSettlementBundle(intent, obligation);
+        ObligationBundle memory corruptedObligationBundle = buildObligationBundle(obligation0, obligation1);
 
         // Expect the validation to revert with InvalidObligationPrice
         vm.expectRevert(
@@ -103,6 +128,6 @@ contract IntentConstraintsTest is SettlementTestUtils {
                 NativeSettledPublicIntentLib.InvalidObligationPrice.selector, amountOut, minAmountOut
             )
         );
-        this._validateSettlementBundleCalldata(bundle);
+        this._validateSettlementBundleCalldata(PartyId.PARTY_0, corruptedObligationBundle, bundle);
     }
 }

--- a/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
@@ -135,6 +135,7 @@ contract SettlementTestUtils is DarkpoolV2TestUtils {
 
         // Create the complete settlement bundle
         return SettlementBundle({
+            isFirstFill: false,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,
             data: abi.encode(bundleData)
         });

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
@@ -4,10 +4,12 @@ pragma solidity ^0.8.24;
 /* solhint-disable func-name-mixedcase */
 
 import {
+    PartyId,
     SettlementBundle,
     SettlementBundleLib,
     RenegadeSettledIntentBundleFirstFill
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     SignatureWithNonce, RenegadeSettledIntentAuthBundleFirstFill
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
@@ -27,18 +29,29 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
     // -----------
 
     /// @notice Wrapper to convert memory to calldata for library call
-    function _executeSettlementBundle(SettlementBundle calldata bundle) external returns (SettlementContext memory) {
+    function _executeSettlementBundle(
+        ObligationBundle calldata obligationBundle,
+        SettlementBundle calldata bundle
+    )
+        external
+        returns (SettlementContext memory)
+    {
         SettlementContext memory settlementContext = _createSettlementContext();
-        SettlementLib.executeSettlementBundle(bundle, settlementContext, darkpoolState, hasher);
+        SettlementLib.executeSettlementBundle(
+            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, darkpoolState, hasher
+        );
         return settlementContext;
     }
 
     /// @notice Helper that accepts memory and calls library with calldata
-    function authorizeIntentHelper(SettlementBundle memory bundle)
+    function authorizeIntentHelper(
+        ObligationBundle memory obligationBundle,
+        SettlementBundle memory bundle
+    )
         internal
         returns (SettlementContext memory context)
     {
-        context = this._executeSettlementBundle(bundle);
+        context = this._executeSettlementBundle(obligationBundle, bundle);
     }
 
     // ---------
@@ -49,14 +62,15 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
     function test_validSignature() public {
         // Should not revert
         bool isFirstFill = vm.randomBool();
-        SettlementBundle memory bundle = createSampleBundle(isFirstFill);
-        authorizeIntentHelper(bundle);
+        (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) = createSampleBundle(isFirstFill);
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 
     /// @dev Test a bundle verification case with an invalid owner signature
     function test_invalidOwnerSignature_wrongSigner() public {
         // Create bundle and replace the owner signature with a signature from wrong signer
-        SettlementBundle memory bundle = createSampleBundle(true /* isFirstFill */ );
+        (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
+            createSampleBundle(true /* isFirstFill */ );
         RenegadeSettledIntentBundleFirstFill memory bundleData =
             abi.decode(bundle.data, (RenegadeSettledIntentBundleFirstFill));
         RenegadeSettledIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
@@ -71,25 +85,21 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
 
         // Should revert with InvalidOwnerSignature
         vm.expectRevert(RenegadeSettledPrivateIntentLib.InvalidOwnerSignature.selector);
-        authorizeIntentHelper(bundle);
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 
     /// @dev Test a bundle verification case with an invalid Merkle depth
     function test_invalidMerkleDepth() public {
         // Create bundle with invalid Merkle depth
-        SettlementObligation memory obligation = SettlementObligation({
-            inputToken: address(baseToken),
-            outputToken: address(quoteToken),
-            amountIn: 100,
-            amountOut: 200
-        });
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
+        ObligationBundle memory obligationBundle = buildObligationBundle(obligation0, obligation1);
 
         // Use an invalid Merkle depth (not the default)
         uint256 invalidDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH + 1;
-        SettlementBundle memory bundle = createSettlementBundleSubsequentFill(invalidDepth, obligation);
+        SettlementBundle memory bundle = createSettlementBundleSubsequentFill(invalidDepth, obligation0);
 
         // Should revert with InvalidMerkleDepthRequested
         vm.expectRevert(IDarkpool.InvalidMerkleDepthRequested.selector);
-        authorizeIntentHelper(bundle);
+        authorizeIntentHelper(obligationBundle, bundle);
     }
 }

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -169,7 +169,8 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
 
         // Encode the obligation and bundle
         return SettlementBundle({
-            bundleType: SettlementBundleType.RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL,
+            isFirstFill: true,
+            bundleType: SettlementBundleType.RENEGADE_SETTLED_INTENT,
             data: abi.encode(bundleData)
         });
     }
@@ -200,7 +201,10 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         });
 
         // Encode the obligation and bundle
-        return
-            SettlementBundle({ bundleType: SettlementBundleType.RENEGADE_SETTLED_INTENT, data: abi.encode(bundleData) });
+        return SettlementBundle({
+            isFirstFill: false,
+            bundleType: SettlementBundleType.RENEGADE_SETTLED_INTENT,
+            data: abi.encode(bundleData)
+        });
     }
 }

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -105,16 +105,16 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Helper to create a sample settlement bundle
-    function createSampleBundle(bool isFirstFill) internal returns (SettlementBundle memory) {
+    function createSampleBundle(bool isFirstFill)
+        internal
+        returns (ObligationBundle memory obligationBundle, SettlementBundle memory bundle)
+    {
         // Create obligation
-        SettlementObligation memory obligation = SettlementObligation({
-            inputToken: address(baseToken),
-            outputToken: address(quoteToken),
-            amountIn: 100,
-            amountOut: 200
-        });
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
+        obligationBundle =
+            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
 
-        return createSettlementBundle(isFirstFill, obligation, intentOwner);
+        bundle = createSettlementBundle(isFirstFill, obligation0, intentOwner);
     }
 
     /// @dev Create a complete settlement bundle given an obligation
@@ -168,10 +168,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         });
 
         // Encode the obligation and bundle
-        ObligationBundle memory obligationBundle =
-            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation) });
         return SettlementBundle({
-            obligation: obligationBundle,
             bundleType: SettlementBundleType.RENEGADE_SETTLED_PRIVATE_INTENT_FIRST_FILL,
             data: abi.encode(bundleData)
         });
@@ -203,12 +200,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         });
 
         // Encode the obligation and bundle
-        ObligationBundle memory obligationBundle =
-            ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation) });
-        return SettlementBundle({
-            obligation: obligationBundle,
-            bundleType: SettlementBundleType.RENEGADE_SETTLED_INTENT,
-            data: abi.encode(bundleData)
-        });
+        return
+            SettlementBundle({ bundleType: SettlementBundleType.RENEGADE_SETTLED_INTENT, data: abi.encode(bundleData) });
     }
 }


### PR DESCRIPTION
### Purpose
This PR updates the obligation bundle to store _both_ the obligations in a trade, rather than encoding the obligation bundle _within_ a settlement bundle. We will use this pattern to encode a settlement proof in the case that the obligation is private. 

This will be used in place of bundle-specific settlement proofs currently in use.

### Testing
- [x] All unit tests pass