### PR TITLE
darkpoolv2: settlement: Introduce private fill handler path

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -172,11 +172,13 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
     // --------------
 
     /// @notice Settle a trade
-    /// @param obligationBundle The obligation bundle for the trade. In the case of a public trade, this
-    /// encodes the settlement obligations for each party in the trade. If the trade is private, this bundle holds
-    /// a proof attesting to the validity of the settlement.
-    /// @param party0SettlementBundle The settlement bundle for the first party
-    /// @param party1SettlementBundle The settlement bundle for the second party
+    /// @param obligationBundle The obligation bundle for the trade. This type encodes the result of the trade.
+    /// In the case of a public trade, this value encodes the settlement obligations for each party in the trade.
+    /// If the trade is private, this bundle holds a proof attesting to the validity of the settlement.
+    /// @param party0SettlementBundle The settlement bundle for the first party. This type validates the first user's
+    /// state elements which are input to the trade.
+    /// @param party1SettlementBundle The settlement bundle for the second party. This type validates the second user's
+    /// state elements which are input to the trade.
     function settleMatch(
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata party0SettlementBundle,

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -53,11 +53,13 @@ interface IDarkpoolV2 {
     function openPublicIntents(bytes32 intentHash) external view returns (uint256);
 
     /// @notice Settle a trade
-    /// @param obligationBundle The obligation bundle for the trade. In the case of a public trade, this
-    /// encodes the settlement obligations for each party in the trade. If the trade is private, this bundle holds
-    /// a proof attesting to the validity of the settlement.
-    /// @param party0SettlementBundle The settlement bundle for the first party
-    /// @param party1SettlementBundle The settlement bundle for the second party
+    /// @param obligationBundle The obligation bundle for the trade. This type encodes the result of the trade.
+    /// In the case of a public trade, this value encodes the settlement obligations for each party in the trade.
+    /// If the trade is private, this bundle holds a proof attesting to the validity of the settlement.
+    /// @param party0SettlementBundle The settlement bundle for the first party. This type validates the first user's
+    /// state elements which are input to the trade.
+    /// @param party1SettlementBundle The settlement bundle for the second party. This type validates the second user's
+    /// state elements which are input to the trade.
     function settleMatch(
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata party0SettlementBundle,

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -8,7 +8,7 @@ import {
     SettlementBundle,
     SettlementBundleLib,
     PrivateIntentPublicBalanceBundle,
-    PrivateIntentPublicBalanceBundleFirstFill
+    PrivateIntentPublicBalanceFirstFillBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
@@ -37,7 +37,7 @@ library NativeSettledPrivateIntentLib {
     using SignatureWithNonceLib for SignatureWithNonce;
     using SettlementBundleLib for SettlementBundle;
     using SettlementBundleLib for PrivateIntentPublicBalanceBundle;
-    using SettlementBundleLib for PrivateIntentPublicBalanceBundleFirstFill;
+    using SettlementBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
     using ObligationLib for ObligationBundle;
     using SettlementObligationLib for SettlementObligation;
     using SettlementContextLib for SettlementContext;
@@ -99,7 +99,7 @@ library NativeSettledPrivateIntentLib {
         internal
     {
         // Decode the bundle data
-        PrivateIntentPublicBalanceBundleFirstFill memory bundleData =
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData =
             settlementBundle.decodePrivateIntentBundleDataFirstFill();
         SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
@@ -238,7 +238,7 @@ library NativeSettledPrivateIntentLib {
     /// @dev On the first fill, no state needs to be nullified. We must only insert the new intent commitment and
     /// allocate the transfers.
     function executeStateUpdatesFirstFill(
-        PrivateIntentPublicBalanceBundleFirstFill memory bundleData,
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
         SettlementObligation memory obligation,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -138,6 +138,10 @@ library SettlementLib {
             RenegadeSettledPrivateIntentLib.execute(
                 partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
             );
+        } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL) {
+            RenegadeSettledPrivateIntentLib.execute(
+                partyId, obligationBundle, settlementBundle, settlementContext, state, hasher
+            );
         } else {
             revert InvalidSettlementBundleType();
         }

--- a/src/darkpool/v2/types/settlement/ObligationBundle.sol
+++ b/src/darkpool/v2/types/settlement/ObligationBundle.sol
@@ -12,6 +12,8 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 /// @dev This data represents the following based on the obligation type:
 /// 1. *Public Obligation*: A plaintext settlement obligation for each party in the trade
 /// 2. *Private Obligation* A proof attesting to the validity of the _private_ settlement obligations in the trade.
+/// @dev In essence, this type captures the result of a trade and hides it behind a ZKP in the case of a private
+/// obligation.
 struct ObligationBundle {
     /// @dev The type of obligation
     ObligationType obligationType;

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -9,7 +9,7 @@ import {
     PartyId,
     SettlementBundle,
     SettlementBundleLib,
-    PrivateIntentPublicBalanceBundleFirstFill
+    PrivateIntentPublicBalanceFirstFillBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SignatureWithNonce, PrivateIntentAuthBundleFirstFill } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
@@ -21,7 +21,7 @@ import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
 import { PrivateIntentSettlementTestUtils } from "./Utils.sol";
 
 contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
-    using SettlementBundleLib for PrivateIntentPublicBalanceBundleFirstFill;
+    using SettlementBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
 
     // -----------
     // | Helpers |
@@ -83,8 +83,8 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         // Create bundle and replace the intent commitment signature with a signature from wrong signer
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
             createSampleBundle(true /* isFirstFill */ );
-        PrivateIntentPublicBalanceBundleFirstFill memory bundleData =
-            abi.decode(bundle.data, (PrivateIntentPublicBalanceBundleFirstFill));
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData =
+            abi.decode(bundle.data, (PrivateIntentPublicBalanceFirstFillBundle));
         PrivateIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
 
         // Compute the full intent commitment

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -9,7 +9,7 @@ import {
     SettlementBundle,
     SettlementBundleType,
     PrivateIntentPublicBalanceBundle,
-    PrivateIntentPublicBalanceBundleFirstFill
+    PrivateIntentPublicBalanceFirstFillBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { ObligationBundle, ObligationType, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
@@ -139,7 +139,7 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
             statement: validityStatement,
             validityProof: createDummyProof()
         });
-        PrivateIntentPublicBalanceBundleFirstFill memory bundleData = PrivateIntentPublicBalanceBundleFirstFill({
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData = PrivateIntentPublicBalanceFirstFillBundle({
             auth: auth,
             settlementStatement: settlementStatement,
             settlementProof: createDummyProof()

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/FullMatchTests.t.sol
@@ -10,7 +10,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { ObligationBundle, ObligationType, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     RenegadeSettledIntentBundle,
-    RenegadeSettledIntentBundleFirstFill,
+    RenegadeSettledIntentFirstFillBundle,
     SettlementBundleLib
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { RenegadeSettledPrivateIntentTestUtils } from "./Utils.sol";
@@ -23,7 +23,7 @@ import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 contract FullMatchTests is RenegadeSettledPrivateIntentTestUtils {
     using ObligationLib for ObligationBundle;
     using SettlementBundleLib for RenegadeSettledIntentBundle;
-    using SettlementBundleLib for RenegadeSettledIntentBundleFirstFill;
+    using SettlementBundleLib for RenegadeSettledIntentFirstFillBundle;
     using FixedPointLib for FixedPoint;
     using MerkleTreeLib for MerkleTreeLib.MerkleTree;
 
@@ -84,10 +84,10 @@ contract FullMatchTests is RenegadeSettledPrivateIntentTestUtils {
         // Create match data (first fill)
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle0, SettlementBundle memory bundle1) =
             _createMatchData(true);
-        RenegadeSettledIntentBundleFirstFill memory bundleData0 =
-            abi.decode(bundle0.data, (RenegadeSettledIntentBundleFirstFill));
-        RenegadeSettledIntentBundleFirstFill memory bundleData1 =
-            abi.decode(bundle1.data, (RenegadeSettledIntentBundleFirstFill));
+        RenegadeSettledIntentFirstFillBundle memory bundleData0 =
+            abi.decode(bundle0.data, (RenegadeSettledIntentFirstFillBundle));
+        RenegadeSettledIntentFirstFillBundle memory bundleData1 =
+            abi.decode(bundle1.data, (RenegadeSettledIntentFirstFillBundle));
 
         // Settle the match
         darkpool.settleMatch(obligationBundle, bundle0, bundle1);
@@ -199,10 +199,10 @@ contract FullMatchTests is RenegadeSettledPrivateIntentTestUtils {
             _createMatchData(true);
 
         // Replace the balance nullifier in bundle2 with the one from bundle0 (already spent)
-        RenegadeSettledIntentBundleFirstFill memory bundleData0 =
-            abi.decode(bundle0.data, (RenegadeSettledIntentBundleFirstFill));
-        RenegadeSettledIntentBundleFirstFill memory bundleData2 =
-            abi.decode(bundle2.data, (RenegadeSettledIntentBundleFirstFill));
+        RenegadeSettledIntentFirstFillBundle memory bundleData0 =
+            abi.decode(bundle0.data, (RenegadeSettledIntentFirstFillBundle));
+        RenegadeSettledIntentFirstFillBundle memory bundleData2 =
+            abi.decode(bundle2.data, (RenegadeSettledIntentFirstFillBundle));
         bundleData2.auth.statement.balanceNullifier = bundleData0.auth.statement.balanceNullifier;
         bundle2.data = abi.encode(bundleData2);
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
@@ -7,7 +7,7 @@ import {
     PartyId,
     SettlementBundle,
     SettlementBundleLib,
-    RenegadeSettledIntentBundleFirstFill
+    RenegadeSettledIntentFirstFillBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
@@ -22,7 +22,7 @@ import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
 import { RenegadeSettledPrivateIntentTestUtils } from "./Utils.sol";
 
 contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivateIntentTestUtils {
-    using SettlementBundleLib for RenegadeSettledIntentBundleFirstFill;
+    using SettlementBundleLib for RenegadeSettledIntentFirstFillBundle;
 
     // -----------
     // | Helpers |
@@ -71,8 +71,8 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
         // Create bundle and replace the owner signature with a signature from wrong signer
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
             createSampleBundle(true /* isFirstFill */ );
-        RenegadeSettledIntentBundleFirstFill memory bundleData =
-            abi.decode(bundle.data, (RenegadeSettledIntentBundleFirstFill));
+        RenegadeSettledIntentFirstFillBundle memory bundleData =
+            abi.decode(bundle.data, (RenegadeSettledIntentFirstFillBundle));
         RenegadeSettledIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
 
         // Sign with wrong signer

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -8,7 +8,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import {
     SettlementBundle,
     SettlementBundleType,
-    RenegadeSettledIntentBundleFirstFill,
+    RenegadeSettledIntentFirstFillBundle,
     RenegadeSettledIntentBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { ObligationBundle, ObligationType, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
@@ -161,7 +161,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
             statement: validityStatement,
             validityProof: createDummyProof()
         });
-        RenegadeSettledIntentBundleFirstFill memory bundleData = RenegadeSettledIntentBundleFirstFill({
+        RenegadeSettledIntentFirstFillBundle memory bundleData = RenegadeSettledIntentFirstFillBundle({
             auth: auth,
             settlementStatement: settlementStatement,
             settlementProof: createDummyProof()


### PR DESCRIPTION
### Purpose
This PR adds a new bundle type for renegade-settled private fills. These are private-balance, private-intent trades which are settled via a ZKP that hides the settlement obligation.

### Todo
- Implement handler methods

### Testing
- [x] Unit tests pass