### PR TITLE
darkpoolv2: settlement: Implement private fill handler

### DIFF
--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -114,6 +114,19 @@ struct RenegadeSettledPrivateIntentPublicSettlementStatement {
     SettlementObligation obligation;
 }
 
+/// @notice A statement for a proof of Renegade settled private fill settlement
+/// @dev This statement type hides the obligations and emits updated shares for both parties' balances and intents
+struct RenegadeSettledPrivateFillSettlementStatement {
+    /// @dev The first party's updated public intent shares
+    BN254.ScalarField party0NewIntentAmountPublicShare;
+    /// @dev The first party's updated public balance shares
+    BN254.ScalarField[3] party0NewBalancePublicShares;
+    /// @dev The second party's updated public intent shares
+    BN254.ScalarField party1NewIntentAmountPublicShare;
+    /// @dev The second party's updated public balance shares
+    BN254.ScalarField[3] party1NewBalancePublicShares;
+}
+
 // -------------------------
 // | Public Inputs Library |
 // -------------------------

--- a/src/darkpool/v2/types/settlement/ObligationBundle.sol
+++ b/src/darkpool/v2/types/settlement/ObligationBundle.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.24;
 import { PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 
+import { RenegadeSettledPrivateFillSettlementStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import { PlonkProof } from "renegade-lib/verifier/Types.sol";
+
 // --------------------
 // | Obligation Types |
 // --------------------
@@ -25,6 +28,14 @@ struct ObligationBundle {
 enum ObligationType {
     PUBLIC,
     PRIVATE
+}
+
+/// @notice The data for a private obligation
+struct PrivateObligationBundle {
+    /// @dev The statement for the proof of private fill settlement
+    RenegadeSettledPrivateFillSettlementStatement statement;
+    /// @dev The proof of the obligation
+    PlonkProof proof;
 }
 
 /// @title Obligation Library
@@ -106,5 +117,17 @@ library ObligationLib {
         } else {
             revert InvalidObligationType();
         }
+    }
+
+    /// @notice Decode a private obligation
+    /// @param bundle The obligation bundle to decode
+    /// @return obligation The decoded obligation
+    function decodePrivateObligation(ObligationBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateObligationBundle memory obligation)
+    {
+        require(bundle.obligationType == ObligationType.PRIVATE, InvalidObligationType());
+        obligation = abi.decode(bundle.data, (PrivateObligationBundle));
     }
 }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -308,6 +308,94 @@ library SettlementBundleLib {
         newBalanceCommitment = BN254.ScalarField.wrap(hasher.spongeHash(hashInputs));
     }
 
+    /// @notice Compute the full commitment to the updated intent for a renegade settled private fill bundle
+    /// on its first fill
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newIntentAmountPublicShare The updated intent amount public share
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        RenegadeSettledPrivateFirstFillBundle memory bundleData,
+        BN254.ScalarField newIntentAmountPublicShare,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        uint256[] memory hashInputs = new uint256[](2);
+        hashInputs[0] = BN254.ScalarField.unwrap(bundleData.auth.statement.newIntentPartialCommitment);
+        hashInputs[1] = BN254.ScalarField.unwrap(newIntentAmountPublicShare);
+        newIntentCommitment = BN254.ScalarField.wrap(hasher.spongeHash(hashInputs));
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a renegade settled private fill bundle
+    /// on its first fill
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newBalancePublicShares The updated balance public shares
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledPrivateFirstFillBundle memory bundleData,
+        BN254.ScalarField[3] memory newBalancePublicShares,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        uint256[] memory hashInputs = new uint256[](PublicInputsLib.N_MODIFIED_BALANCE_SHARES + 1);
+        hashInputs[0] = BN254.ScalarField.unwrap(bundleData.auth.statement.balancePartialCommitment);
+        for (uint256 i = 1; i < PublicInputsLib.N_MODIFIED_BALANCE_SHARES + 1; ++i) {
+            hashInputs[i] = BN254.ScalarField.unwrap(newBalancePublicShares[i - 1]);
+        }
+        newBalanceCommitment = BN254.ScalarField.wrap(hasher.spongeHash(hashInputs));
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a renegade settled private fill bundle
+    /// on its subsequent fill
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newIntentAmountPublicShare The updated intent amount public share
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        RenegadeSettledPrivateFillBundle memory bundleData,
+        BN254.ScalarField newIntentAmountPublicShare,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        uint256[] memory hashInputs = new uint256[](2);
+        hashInputs[0] = BN254.ScalarField.unwrap(bundleData.auth.statement.newIntentPartialCommitment);
+        hashInputs[1] = BN254.ScalarField.unwrap(newIntentAmountPublicShare);
+        newIntentCommitment = BN254.ScalarField.wrap(hasher.spongeHash(hashInputs));
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a renegade settled private fill bundle
+    /// on its subsequent fill
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newBalancePublicShares The updated balance public shares
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledPrivateFillBundle memory bundleData,
+        BN254.ScalarField[3] memory newBalancePublicShares,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        uint256[] memory hashInputs = new uint256[](PublicInputsLib.N_MODIFIED_BALANCE_SHARES + 1);
+        hashInputs[0] = BN254.ScalarField.unwrap(bundleData.auth.statement.balancePartialCommitment);
+        for (uint256 i = 1; i < PublicInputsLib.N_MODIFIED_BALANCE_SHARES + 1; ++i) {
+            hashInputs[i] = BN254.ScalarField.unwrap(newBalancePublicShares[i - 1]);
+        }
+        newBalanceCommitment = BN254.ScalarField.wrap(hasher.spongeHash(hashInputs));
+    }
+
     // --- Bundle Decoding --- //
 
     /// @notice Decode a public settlement bundle
@@ -382,11 +470,11 @@ library SettlementBundleLib {
     function decodeRenegadeSettledPrivateFirstFillBundle(SettlementBundle calldata bundle)
         internal
         pure
-        returns (RenegadeSettledIntentFirstFillBundle memory bundleData)
+        returns (RenegadeSettledPrivateFirstFillBundle memory bundleData)
     {
         bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
         require(validType, InvalidSettlementBundleType());
-        bundleData = abi.decode(bundle.data, (RenegadeSettledIntentFirstFillBundle));
+        bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFirstFillBundle));
     }
 
     /// @notice Decode a renegade settled private fill settlement bundle


### PR DESCRIPTION
### Purpose
This PR implements the private fill handler path. This is mostly the same as the ring 2 path, except that we settlement proof comes from the `ObligationBundle` in order to unify across the two proofs.

### Todo
- Add proof linking
- Add the proof from the `ObligationBundle`
- Create a test suite for private fills

### Testing
- [x] All unit tests pass