### PR TITLE
darkpoolv2: settlement: Validate private obligation bundle

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -191,7 +191,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable {
             SettlementLib.allocateSettlementContext(party0SettlementBundle, party1SettlementBundle);
 
         // 2. Validate that the settlement obligations are compatible with one another
-        SettlementLib.validateObligationBundle(obligationBundle);
+        SettlementLib.validateObligationBundle(obligationBundle, settlementContext);
 
         // 3. Validate and authorize the settlement bundles
         SettlementLib.executeSettlementBundle(

--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -247,6 +247,26 @@ library PublicInputsLib {
         publicInputs[3] = statement.balanceNullifier;
     }
 
+    /// @notice Serialize the public inputs for a proof of Renegade settled private fill settlement
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(RenegadeSettledPrivateFillSettlementStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 8;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = statement.party0NewIntentAmountPublicShare;
+        publicInputs[1] = statement.party0NewBalancePublicShares[0];
+        publicInputs[2] = statement.party0NewBalancePublicShares[1];
+        publicInputs[3] = statement.party0NewBalancePublicShares[2];
+        publicInputs[4] = statement.party1NewIntentAmountPublicShare;
+        publicInputs[5] = statement.party1NewBalancePublicShares[0];
+        publicInputs[6] = statement.party1NewBalancePublicShares[1];
+        publicInputs[7] = statement.party1NewBalancePublicShares[2];
+    }
+
     /// @notice Get a dummy verification key for testing
     /// @return A dummy verification key
     /// @dev TODO: Replace with real verification key

--- a/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.24;
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementTestUtils } from "./Utils.sol";
 
 contract ObligationCompatibilityTest is SettlementTestUtils {
@@ -15,7 +16,8 @@ contract ObligationCompatibilityTest is SettlementTestUtils {
 
     /// @notice Wrapper to convert memory to calldata for library call
     function _validateObligationBundle(ObligationBundle calldata bundle) public pure {
-        SettlementLib.validateObligationBundle(bundle);
+        SettlementContext memory settlementContext = _createSettlementContext();
+        SettlementLib.validateObligationBundle(bundle, settlementContext);
     }
 
     /// @notice Helper that accepts memory and calls library with calldata


### PR DESCRIPTION
### Purpose
This PR adds validation logic for a private obligation bundle. This simply enqueues the settlement proof (which encodes the obligation constraints) for verification in the `SettlementContext`.

### Testing
- [x] All tests pass