### PR TITLE
darkpoolv2: settlement: Add cross-bundle-type tests

### DIFF
--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -174,21 +174,6 @@ library SettlementBundleLib {
             || bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
     }
 
-    // forge-lint: disable-next-item(mixed-case-function)
-    /// @notice Return the EOA address of a natively settled bundle
-    /// @param bundle The settlement bundle to return the EOA address for
-    /// @return eoa The EOA address of the natively settled bundle
-    function getEOAAddress(SettlementBundle calldata bundle) internal pure returns (address eoa) {
-        require(isNativelySettled(bundle), InvalidSettlementBundleType());
-
-        if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
-            PublicIntentPublicBalanceBundle memory bundleData = decodePublicBundleData(bundle);
-            eoa = bundleData.auth.permit.intent.owner;
-        } else if (bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
-            revert("Not implemented");
-        }
-    }
-
     // --- Commitments --- //
 
     /// @notice Compute the full commitment to the updated intent for a natively settled public intent bundle

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -132,7 +132,7 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
         )
     {
         price = randomPrice();
-        uint256 baseAmount = randomAmount();
+        uint256 baseAmount = randomUint(0, 2 ** 50);
         uint256 quoteAmount = price.unsafeFixedPointMul(baseAmount);
 
         obligation0 = SettlementObligation({
@@ -141,11 +141,19 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
             amountIn: baseAmount,
             amountOut: quoteAmount
         });
-        obligation1 = SettlementObligation({
-            inputToken: address(quoteToken),
-            outputToken: address(baseToken),
-            amountIn: quoteAmount,
-            amountOut: baseAmount
+        obligation1 = createMatchingObligation(obligation0);
+    }
+
+    /// @dev Create a matching obligation for a given obligation
+    function createMatchingObligation(SettlementObligation memory obligation)
+        internal
+        returns (SettlementObligation memory)
+    {
+        return SettlementObligation({
+            inputToken: obligation.outputToken,
+            outputToken: obligation.inputToken,
+            amountIn: obligation.amountOut,
+            amountOut: obligation.amountIn
         });
     }
 

--- a/test/darkpool/v2/settlement/cross-bundle-types/CrossBundleTests.t.sol
+++ b/test/darkpool/v2/settlement/cross-bundle-types/CrossBundleTests.t.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/* solhint-disable func-name-mixedcase */
+
+import { PartyId } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+
+import { CrossBundleTypesTestUtils } from "./Utils.sol";
+
+/// @title Cross Bundle Tests
+/// @author Renegade Eng
+/// @notice Tests for settling matches that cross different bundle types
+contract CrossBundleTests is CrossBundleTypesTestUtils {
+    /// @notice Cross a natively-settled public intent with a natively-settled private intent
+    function test_mixedBundleTypes_nativePublicIntent_nativePrivateIntent() public {
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
+        ObligationBundle memory obligationBundle = buildObligationBundle(obligation0, obligation1);
+
+        // Create a natively-settled public intent
+        bool party0IsPublic = vm.randomBool();
+        SettlementBundle memory bundle0;
+        SettlementBundle memory bundle1;
+        if (party0IsPublic) {
+            bundle0 = _createNativePublicIntentBundle(PartyId.PARTY_0, obligation0);
+            bundle1 = _createNativePrivateIntentBundle(PartyId.PARTY_1, obligation1);
+        } else {
+            bundle0 = _createNativePrivateIntentBundle(PartyId.PARTY_0, obligation0);
+            bundle1 = _createNativePublicIntentBundle(PartyId.PARTY_1, obligation1);
+        }
+
+        // Check the balances before settling
+        (uint256 party0InputBefore, uint256 party0OutputBefore) = _getInputOutputBalances(party0.addr, obligation0);
+        (uint256 party1InputBefore, uint256 party1OutputBefore) = _getInputOutputBalances(party1.addr, obligation1);
+
+        // Settle the trade
+        darkpool.settleMatch(obligationBundle, bundle0, bundle1);
+
+        // Check the resulting balances
+        (uint256 party0InputAfter, uint256 party0OutputAfter) = _getInputOutputBalances(party0.addr, obligation0);
+        (uint256 party1InputAfter, uint256 party1OutputAfter) = _getInputOutputBalances(party1.addr, obligation1);
+
+        assertEq(party0InputAfter, party0InputBefore - obligation0.amountIn, "party0 input after");
+        assertEq(party0OutputAfter, party0OutputBefore + obligation0.amountOut, "party0 output after");
+        assertEq(party1InputAfter, party1InputBefore - obligation1.amountIn, "party1 input after");
+        assertEq(party1OutputAfter, party1OutputBefore + obligation1.amountOut, "party1 output after");
+    }
+
+    /// @notice Cross a natively-settled public intent with a renegade settled private intent
+    function test_mixedBundleTypes_nativePublicIntent_renegadeSettledIntent() public {
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
+        ObligationBundle memory obligationBundle = buildObligationBundle(obligation0, obligation1);
+
+        // Create a natively-settled public intent and a renegade settled intent
+        bool party0IsPublic = vm.randomBool();
+        SettlementBundle memory bundle0;
+        SettlementBundle memory bundle1;
+        if (party0IsPublic) {
+            bundle0 = _createNativePublicIntentBundle(PartyId.PARTY_0, obligation0);
+            bundle1 = _createRenegadeSettledPrivateIntentBundle(PartyId.PARTY_1, obligation1);
+        } else {
+            bundle0 = _createRenegadeSettledPrivateIntentBundle(PartyId.PARTY_0, obligation0);
+            bundle1 = _createNativePublicIntentBundle(PartyId.PARTY_1, obligation1);
+        }
+
+        // Check the balances before settling
+        address publicPartyAddr = party0IsPublic ? party0.addr : party1.addr;
+        address privatePartyAddr = party0IsPublic ? party1.addr : party0.addr;
+        SettlementObligation memory publicBundle = party0IsPublic ? obligation0 : obligation1;
+
+        (uint256 publicPartyInputBefore, uint256 publicPartyOutputBefore) =
+            _getInputOutputBalances(publicPartyAddr, publicBundle);
+        (uint256 privatePartyBaseBefore, uint256 privatePartyQuoteBefore) = baseQuoteBalances(privatePartyAddr);
+        (uint256 darkpoolInBefore, uint256 darkpoolOutBefore) = _getInputOutputBalances(address(darkpool), publicBundle);
+
+        // Settle the trade
+        darkpool.settleMatch(obligationBundle, bundle0, bundle1);
+
+        // Check the resulting balances
+        (uint256 publicPartyInputAfter, uint256 publicPartyOutputAfter) =
+            _getInputOutputBalances(publicPartyAddr, publicBundle);
+        (uint256 privatePartyBaseAfter, uint256 privatePartyQuoteAfter) = baseQuoteBalances(privatePartyAddr);
+        (uint256 darkpoolInAfter, uint256 darkpoolOutAfter) = _getInputOutputBalances(address(darkpool), publicBundle);
+
+        // Verify the balance updates
+        // 1. The public party should see transfers corresponding to the obligation
+        assertEq(publicPartyInputAfter, publicPartyInputBefore - publicBundle.amountIn, "public party input after");
+        assertEq(publicPartyOutputAfter, publicPartyOutputBefore + publicBundle.amountOut, "public party output after");
+
+        // 2. The private party should see no change in ERC20 balances
+        assertEq(privatePartyBaseAfter, privatePartyBaseBefore, "private party base after");
+        assertEq(privatePartyQuoteAfter, privatePartyQuoteBefore, "private party quote after");
+
+        // 3. The darkpool should see transfers opposite to the public party
+        assertEq(darkpoolInAfter, darkpoolInBefore + publicBundle.amountIn, "darkpool input after");
+        assertEq(darkpoolOutAfter, darkpoolOutBefore - publicBundle.amountOut, "darkpool output after");
+    }
+
+    /// @notice Cross a natively-settled private intent with a renegade settled private intent
+    function test_mixedBundleTypes_nativePrivateIntent_renegadeSettledIntent() public {
+        (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
+        ObligationBundle memory obligationBundle = buildObligationBundle(obligation0, obligation1);
+
+        // Create a natively-settled private intent and a renegade settled intent
+        bool party0IsPrivate = vm.randomBool();
+        SettlementBundle memory bundle0;
+        SettlementBundle memory bundle1;
+        if (party0IsPrivate) {
+            bundle0 = _createNativePrivateIntentBundle(PartyId.PARTY_0, obligation0);
+            bundle1 = _createRenegadeSettledPrivateIntentBundle(PartyId.PARTY_1, obligation1);
+        } else {
+            bundle0 = _createRenegadeSettledPrivateIntentBundle(PartyId.PARTY_0, obligation0);
+            bundle1 = _createNativePrivateIntentBundle(PartyId.PARTY_1, obligation1);
+        }
+
+        // Check the balances before settling
+        address privatePartyAddr = party0IsPrivate ? party0.addr : party1.addr;
+        address renegadePartyAddr = party0IsPrivate ? party1.addr : party0.addr;
+        SettlementObligation memory privateBundle = party0IsPrivate ? obligation0 : obligation1;
+
+        (uint256 privatePartyInputBefore, uint256 privatePartyOutputBefore) =
+            _getInputOutputBalances(privatePartyAddr, privateBundle);
+        (uint256 renegadePartyBaseBefore, uint256 renegadePartyQuoteBefore) = baseQuoteBalances(renegadePartyAddr);
+        (uint256 darkpoolInBefore, uint256 darkpoolOutBefore) =
+            _getInputOutputBalances(address(darkpool), privateBundle);
+
+        // Settle the trade
+        darkpool.settleMatch(obligationBundle, bundle0, bundle1);
+
+        // Check the resulting balances
+        (uint256 privatePartyInputAfter, uint256 privatePartyOutputAfter) =
+            _getInputOutputBalances(privatePartyAddr, privateBundle);
+        (uint256 renegadePartyBaseAfter, uint256 renegadePartyQuoteAfter) = baseQuoteBalances(renegadePartyAddr);
+        (uint256 darkpoolInAfter, uint256 darkpoolOutAfter) = _getInputOutputBalances(address(darkpool), privateBundle);
+
+        // Verify the balance updates
+        // 1. The natively-settled private party should see transfers corresponding to the obligation
+        assertEq(privatePartyInputAfter, privatePartyInputBefore - privateBundle.amountIn, "private party input after");
+        assertEq(
+            privatePartyOutputAfter, privatePartyOutputBefore + privateBundle.amountOut, "private party output after"
+        );
+
+        // 2. The renegade-settled party should see no change in ERC20 balances
+        assertEq(renegadePartyBaseAfter, renegadePartyBaseBefore, "renegade party base after");
+        assertEq(renegadePartyQuoteAfter, renegadePartyQuoteBefore, "renegade party quote after");
+
+        // 3. The darkpool should see transfers opposite to the natively-settled private party
+        assertEq(darkpoolInAfter, darkpoolInBefore + privateBundle.amountIn, "darkpool input after");
+        assertEq(darkpoolOutAfter, darkpoolOutBefore - privateBundle.amountOut, "darkpool output after");
+    }
+}

--- a/test/darkpool/v2/settlement/cross-bundle-types/Utils.sol
+++ b/test/darkpool/v2/settlement/cross-bundle-types/Utils.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { Vm } from "forge-std/Vm.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
+
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { Intent } from "darkpoolv2-types/Intent.sol";
+import { SettlementBundle, PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+
+import { PublicIntentSettlementTestUtils } from "../native-settled-public-intents/Utils.sol";
+import { PrivateIntentSettlementTestUtils } from "../native-settled-private-intents/Utils.sol";
+import { RenegadeSettledPrivateIntentTestUtils } from "../renegade-settled-private-intents/Utils.sol";
+
+contract CrossBundleTypesTestUtils is
+    PublicIntentSettlementTestUtils,
+    PrivateIntentSettlementTestUtils,
+    RenegadeSettledPrivateIntentTestUtils
+{
+    // Override the conflicting _createSettlementContext function from all base classes
+    function _createSettlementContext()
+        internal
+        pure
+        override(PublicIntentSettlementTestUtils, PrivateIntentSettlementTestUtils, RenegadeSettledPrivateIntentTestUtils)
+        returns (SettlementContext memory context)
+    {
+        return PublicIntentSettlementTestUtils._createSettlementContext();
+    }
+
+    // --- Native Settled Public Intents --- //
+
+    /// @dev Create a natively-settled public intent bundle
+    function _createNativePublicIntentBundle(
+        PartyId partyId,
+        SettlementObligation memory obligation
+    )
+        internal
+        returns (SettlementBundle memory bundle)
+    {
+        // Create a natively-settled public intent
+        bool firstFill = vm.randomBool();
+        Vm.Wallet memory partyWallet = _getPartyWallet(partyId);
+        Intent memory intent = createIntentForObligation(obligation);
+        intent.owner = partyWallet.addr;
+
+        // If we want to simulate a subsequent fill, we need to trade against this intent to setup its state in
+        // the darkpool. So we add an extra `obligation.amountIn` to the intent, which we'll trade into.
+        if (!firstFill) {
+            intent.amountIn += obligation.amountIn;
+            _matchNativePublicIntent(partyId, obligation, intent);
+        }
+
+        // Capitalize the party and create the settlement bundle
+        _capitalizeParty(partyId, obligation);
+        bundle = createPublicIntentSettlementBundleWithSigners(
+            intent, obligation, partyWallet.privateKey, executor.privateKey
+        );
+    }
+
+    /// @dev Match a natively settled public intent to setup a subsequent fill test
+    function _matchNativePublicIntent(
+        PartyId partyId,
+        SettlementObligation memory obligation,
+        Intent memory intent
+    )
+        internal
+    {
+        PartyId oppositePartyId = _getOppositePartyId(partyId);
+        Vm.Wallet memory oppositePartyWallet = _getPartyWallet(oppositePartyId);
+        Vm.Wallet memory partyWallet = _getPartyWallet(partyId);
+
+        // Create a matching obligation and intent
+        SettlementObligation memory matchingObligation = createMatchingObligation(obligation);
+        Intent memory matchingIntent = createIntentForObligation(matchingObligation);
+        matchingIntent.owner = oppositePartyWallet.addr;
+
+        // Fund the trader
+        _capitalizeParty(partyId, obligation);
+        _capitalizeParty(oppositePartyId, matchingObligation);
+
+        // Create two settlement bundles
+        SettlementBundle memory bundle0 = createPublicIntentSettlementBundleWithSigners(
+            intent, obligation, partyWallet.privateKey, executor.privateKey
+        );
+        SettlementBundle memory bundle1 = createPublicIntentSettlementBundleWithSigners(
+            matchingIntent, matchingObligation, oppositePartyWallet.privateKey, executor.privateKey
+        );
+
+        // Create an obligation bundle and settle the trade
+        ObligationBundle memory obligationBundle = buildObligationBundle(obligation, matchingObligation);
+        darkpool.settleMatch(obligationBundle, bundle0, bundle1);
+    }
+
+    // --- Native Settled Private Intents --- //
+
+    /// @dev Create a natively-settled private intent bundle
+    function _createNativePrivateIntentBundle(
+        PartyId partyId,
+        SettlementObligation memory obligation
+    )
+        internal
+        returns (SettlementBundle memory bundle)
+    {
+        bool isFirstFill = vm.randomBool();
+        Vm.Wallet memory partyWallet = _getPartyWallet(partyId);
+        bundle = createPrivateIntentSettlementBundle(isFirstFill, obligation, partyWallet);
+        _capitalizeParty(partyId, obligation);
+    }
+
+    // --- Renegade Settled Private Intents --- //
+
+    /// @dev Create a renegade settled private intent bundle
+    function _createRenegadeSettledPrivateIntentBundle(
+        PartyId partyId,
+        SettlementObligation memory obligation
+    )
+        internal
+        returns (SettlementBundle memory bundle)
+    {
+        bool isFirstFill = vm.randomBool();
+        Vm.Wallet memory partyWallet = _getPartyWallet(partyId);
+        bundle = createRenegadeSettledBundle(isFirstFill, obligation, partyWallet);
+
+        // For renegade-settled bundles, the tokens this party contributes are managed internally by the darkpool
+        // We mint these tokens to the darkpool so it can transfer them to the other party
+        // (In production, these would come from the party's internal balance in the darkpool)
+        ERC20Mock(obligation.inputToken).mint(address(darkpool), obligation.amountIn);
+    }
+
+    // --- General Helpers --- //
+
+    /// @dev Get the wallet for a given party ID
+    function _getPartyWallet(PartyId partyId) internal returns (Vm.Wallet memory wallet) {
+        if (partyId == PartyId.PARTY_0) {
+            return party0;
+        } else {
+            return party1;
+        }
+    }
+
+    /// @dev Get the opposite party ID
+    function _getOppositePartyId(PartyId partyId) internal returns (PartyId oppositePartyId) {
+        if (partyId == PartyId.PARTY_0) {
+            return PartyId.PARTY_1;
+        } else {
+            return PartyId.PARTY_0;
+        }
+    }
+
+    /// @dev Capitalize the given party for an obligation
+    function _capitalizeParty(PartyId partyId, SettlementObligation memory obligation) internal {
+        address partyAddr;
+        if (partyId == PartyId.PARTY_0) {
+            partyAddr = party0.addr;
+        } else {
+            partyAddr = party1.addr;
+        }
+
+        capitalizeParty(partyAddr, obligation);
+    }
+
+    /// @dev Get the input and output balance for a given address using the given obligation
+    function _getInputOutputBalances(
+        address addr,
+        SettlementObligation memory obligation
+    )
+        internal
+        returns (uint256 inputBalance, uint256 outputBalance)
+    {
+        ERC20Mock inputToken = ERC20Mock(obligation.inputToken);
+        ERC20Mock outputToken = ERC20Mock(obligation.outputToken);
+        inputBalance = inputToken.balanceOf(addr);
+        outputBalance = outputToken.balanceOf(addr);
+    }
+}

--- a/test/darkpool/v2/settlement/native-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/FullMatchTests.t.sol
@@ -43,8 +43,8 @@ contract FullMatchTests is PrivateIntentSettlementTestUtils {
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
 
         // Create two settlement bundles
-        bundle0 = createSettlementBundle(isFirstFill, obligation0, party0);
-        bundle1 = createSettlementBundle(isFirstFill, obligation1, party1);
+        bundle0 = createPrivateIntentSettlementBundle(isFirstFill, obligation0, party0);
+        bundle1 = createPrivateIntentSettlementBundle(isFirstFill, obligation1, party1);
         capitalizeParty(party0.addr, obligation0);
         capitalizeParty(party1.addr, obligation1);
     }

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -61,7 +61,8 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
     function test_validSignature() public {
         // Should not revert
         bool isFirstFill = vm.randomBool();
-        (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) = createSampleBundle(isFirstFill);
+        (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
+            createSamplePrivateIntentBundle(isFirstFill);
         authorizeIntentHelper(obligationBundle, bundle);
     }
 
@@ -72,7 +73,8 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
         ObligationBundle memory obligationBundle =
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
-        SettlementBundle memory bundle = createSettlementBundle(false, /* isFirstFill */ obligation0, intentOwner);
+        SettlementBundle memory bundle =
+            createPrivateIntentSettlementBundle(false, /* isFirstFill */ obligation0, intentOwner);
 
         // Should not revert even though we're not checking the signature
         authorizeIntentHelper(obligationBundle, bundle);
@@ -82,7 +84,7 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
     function test_invalidIntentCommitmentSignature_wrongSigner() public {
         // Create bundle and replace the intent commitment signature with a signature from wrong signer
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
-            createSampleBundle(true /* isFirstFill */ );
+            createSamplePrivateIntentBundle(true /* isFirstFill */ );
         PrivateIntentPublicBalanceFirstFillBundle memory bundleData =
             abi.decode(bundle.data, (PrivateIntentPublicBalanceFirstFillBundle));
         PrivateIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
@@ -110,7 +112,8 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
 
         // Use an invalid Merkle depth (not the default)
         uint256 invalidDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH + 1;
-        SettlementBundle memory bundle = createSettlementBundleSubsequentFill(invalidDepth, obligation0, intentOwner);
+        SettlementBundle memory bundle =
+            createPrivateIntentSettlementBundleSubsequentFill(invalidDepth, obligation0, intentOwner);
 
         // Should revert with InvalidMerkleDepthRequested
         vm.expectRevert(IDarkpool.InvalidMerkleDepthRequested.selector);

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -59,7 +59,7 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
     // --- Dummy Data --- //
 
     /// @dev Create a dummy `SettlementContext` for the test
-    function _createSettlementContext() internal pure returns (SettlementContext memory context) {
+    function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
         context = SettlementContextLib.newContext(2, /* transferCapacity */ 2 /* verificationCapacity */ );
     }
 
@@ -82,7 +82,7 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Helper to create a sample settlement bundle
-    function createSampleBundle(bool isFirstFill)
+    function createSamplePrivateIntentBundle(bool isFirstFill)
         internal
         returns (ObligationBundle memory obligationBundle, SettlementBundle memory bundle)
     {
@@ -91,11 +91,11 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
         obligationBundle =
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
 
-        bundle = createSettlementBundle(isFirstFill, obligation0, intentOwner);
+        bundle = createPrivateIntentSettlementBundle(isFirstFill, obligation0, intentOwner);
     }
 
     /// @dev Create a complete settlement bundle given an obligation
-    function createSettlementBundle(
+    function createPrivateIntentSettlementBundle(
         bool isFirstFill,
         SettlementObligation memory obligation,
         Vm.Wallet memory owner
@@ -105,14 +105,14 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
     {
         uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
         if (isFirstFill) {
-            return createSettlementBundleFirstFill(merkleDepth, obligation, owner);
+            return createPrivateIntentSettlementBundleFirstFill(merkleDepth, obligation, owner);
         } else {
-            return createSettlementBundleSubsequentFill(merkleDepth, obligation, owner);
+            return createPrivateIntentSettlementBundleSubsequentFill(merkleDepth, obligation, owner);
         }
     }
 
     /// @dev Create a complete settlement bundle with custom signer for the first fill
-    function createSettlementBundleFirstFill(
+    function createPrivateIntentSettlementBundleFirstFill(
         uint256 merkleDepth,
         SettlementObligation memory obligation,
         Vm.Wallet memory owner
@@ -154,7 +154,7 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Create a complete settlement bundle with custom signer and parameters
-    function createSettlementBundleSubsequentFill(
+    function createPrivateIntentSettlementBundleSubsequentFill(
         uint256 merkleDepth,
         SettlementObligation memory obligation,
         Vm.Wallet memory owner

--- a/test/darkpool/v2/settlement/native-settled-public-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/FullMatchTests.t.sol
@@ -9,9 +9,9 @@ import { ObligationBundle, ObligationType } from "darkpoolv2-types/settlement/Ob
 import { PublicIntentPermit, PublicIntentPermitLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { SettlementTestUtils } from "./Utils.sol";
+import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 
-contract FullMatchTests is SettlementTestUtils {
+contract FullMatchTests is PublicIntentSettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
 
@@ -82,10 +82,12 @@ contract FullMatchTests is SettlementTestUtils {
 
         ObligationBundle memory obligationBundle =
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
-        SettlementBundle memory party0Bundle =
-            createSettlementBundleWithSigners(permit0.intent, obligation0, party0.privateKey, executor.privateKey);
-        SettlementBundle memory party1Bundle =
-            createSettlementBundleWithSigners(permit1.intent, obligation1, party1.privateKey, executor.privateKey);
+        SettlementBundle memory party0Bundle = createPublicIntentSettlementBundleWithSigners(
+            permit0.intent, obligation0, party0.privateKey, executor.privateKey
+        );
+        SettlementBundle memory party1Bundle = createPublicIntentSettlementBundleWithSigners(
+            permit1.intent, obligation1, party1.privateKey, executor.privateKey
+        );
 
         // Record balances before settlement
         (uint256 party0BaseBefore, uint256 party0QuoteBefore) = baseQuoteBalances(party0.addr);
@@ -132,10 +134,12 @@ contract FullMatchTests is SettlementTestUtils {
             obligationType: ObligationType.PUBLIC,
             data: abi.encode(trade1Obligation0, trade1Obligation1)
         });
-        SettlementBundle memory party0Bundle =
-            createSettlementBundleWithSigners(permit0.intent, trade1Obligation0, party0.privateKey, executor.privateKey);
-        SettlementBundle memory party1Bundle =
-            createSettlementBundleWithSigners(permit1.intent, trade1Obligation1, party1.privateKey, executor.privateKey);
+        SettlementBundle memory party0Bundle = createPublicIntentSettlementBundleWithSigners(
+            permit0.intent, trade1Obligation0, party0.privateKey, executor.privateKey
+        );
+        SettlementBundle memory party1Bundle = createPublicIntentSettlementBundleWithSigners(
+            permit1.intent, trade1Obligation1, party1.privateKey, executor.privateKey
+        );
 
         // Check balances before first settlement
         (uint256 party0BaseBefore, uint256 party0QuoteBefore) = baseQuoteBalances(party0.addr);
@@ -169,10 +173,12 @@ contract FullMatchTests is SettlementTestUtils {
             data: abi.encode(trade2Obligation0, trade2Obligation1)
         });
 
-        SettlementBundle memory party0Bundle2 =
-            createSettlementBundleWithSigners(permit0.intent, trade2Obligation0, party0.privateKey, executor.privateKey);
-        SettlementBundle memory party1Bundle2 =
-            createSettlementBundleWithSigners(permit1.intent, trade2Obligation1, party1.privateKey, executor.privateKey);
+        SettlementBundle memory party0Bundle2 = createPublicIntentSettlementBundleWithSigners(
+            permit0.intent, trade2Obligation0, party0.privateKey, executor.privateKey
+        );
+        SettlementBundle memory party1Bundle2 = createPublicIntentSettlementBundleWithSigners(
+            permit1.intent, trade2Obligation1, party1.privateKey, executor.privateKey
+        );
 
         // Execute the second match
         darkpool.settleMatch(obligationBundle2, party0Bundle2, party1Bundle2);

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -19,11 +19,11 @@ import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/Obl
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
-import { SettlementTestUtils } from "./Utils.sol";
+import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 
-contract IntentAuthorizationTest is SettlementTestUtils {
+contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
     using ObligationLib for ObligationBundle;
@@ -64,13 +64,13 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
     function test_validSignatures() public {
         // Should not revert
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         authorizeIntentHelper(obligationBundle, bundle);
     }
 
     function test_intentReplay() public {
         // Create bundle and authorize it once
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         authorizeIntentHelper(obligationBundle, bundle);
 
         // Try settling the same bundle again, the intent should be replayed
@@ -80,7 +80,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
     function test_invalidIntentSignature_wrongSigner() public {
         // Create bundle and replace the intent signature with a wrong signature
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
         SignatureWithNonce memory sig = signIntentPermit(authBundle.permit, wrongSigner.privateKey);
@@ -95,7 +95,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
     function test_invalidIntentSignature_modifiedBytes() public {
         // Create bundle with modified intent signature
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
         authBundle.intentSignature.signature[0] = bytes1(uint8(authBundle.intentSignature.signature[0]) ^ 0xFF); // Modify
@@ -110,7 +110,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
     function test_invalidExecutorSignature_wrongSigner() public {
         // Create bundle with executor signature from wrong signer
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         SettlementObligation memory obligation0 = obligationBundle.decodePublicObligationMemory(PartyId.PARTY_0);
 
@@ -126,7 +126,7 @@ contract IntentAuthorizationTest is SettlementTestUtils {
 
     function test_cachedIntentSignature() public {
         // Create bundle and authorize it once
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         authorizeIntentHelper(obligationBundle, bundle);
 
         // Verify the intent was cached in the mapping

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
@@ -13,11 +13,11 @@ import { Intent } from "darkpoolv2-types/Intent.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
-import { SettlementTestUtils } from "./Utils.sol";
+import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 
-contract IntentConstraintsTest is SettlementTestUtils {
+contract IntentConstraintsTest is PublicIntentSettlementTestUtils {
     using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
     using ObligationLib for ObligationBundle;
@@ -45,7 +45,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
     /// @notice Test that validation fails when intent and obligation have mismatched token pairs
     function test_validateObligationIntentConstraints_InvalidPair() public {
         // Create an intent for base -> quote
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         (SettlementObligation memory obligation0, SettlementObligation memory obligation1) =
             obligationBundle.decodePublicObligationsMemory();
 
@@ -65,7 +65,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
 
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         Intent memory intent = bundleData.auth.permit.intent;
-        SettlementBundle memory newBundle = createSettlementBundle(intent, obligation0);
+        SettlementBundle memory newBundle = createPublicIntentSettlementBundle(intent, obligation0);
 
         // Expect the validation to revert with InvalidObligationPair
         vm.expectRevert(NativeSettledPublicIntentLib.InvalidObligationPair.selector);
@@ -75,7 +75,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
     /// @notice Test that validation fails when the input amount is larger than the intent amount
     function test_validateObligationIntentConstraints_InvalidAmountIn() public {
         // Create an intent and an obligation which is too large
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         Intent memory intent = bundleData.auth.permit.intent;
 
@@ -88,7 +88,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
             amountOut: 200
         });
         ObligationBundle memory corruptedObligationBundle = buildObligationBundle(corruptObligation0, obligation1);
-        SettlementBundle memory newBundle = createSettlementBundle(intent, corruptObligation0);
+        SettlementBundle memory newBundle = createPublicIntentSettlementBundle(intent, corruptObligation0);
 
         // Expect the validation to revert with InvalidObligationAmountIn
         vm.expectRevert(
@@ -108,7 +108,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
     /// price
     function test_validateObligationIntentConstraints_InvalidPrice() public {
         // Create an intent and an obligation which has a bad price
-        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSampleBundle();
+        (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         Intent memory intent = bundleData.auth.permit.intent;
         (, SettlementObligation memory obligation1) = obligationBundle.decodePublicObligationsMemory();
@@ -124,7 +124,7 @@ contract IntentConstraintsTest is SettlementTestUtils {
             amountOut: amountOut
         });
         ObligationBundle memory corruptedObligationBundle = buildObligationBundle(obligation, obligation1);
-        SettlementBundle memory newBundle = createSettlementBundle(intent, obligation);
+        SettlementBundle memory newBundle = createPublicIntentSettlementBundle(intent, obligation);
 
         // Expect the validation to revert with InvalidObligationPrice
         vm.expectRevert(

--- a/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
@@ -7,9 +7,9 @@ import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.s
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
-import { SettlementTestUtils } from "./Utils.sol";
+import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 
-contract ObligationCompatibilityTest is SettlementTestUtils {
+contract ObligationCompatibilityTest is PublicIntentSettlementTestUtils {
     // -----------
     // | Helpers |
     // -----------

--- a/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
@@ -20,7 +20,7 @@ import {
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 
-contract SettlementTestUtils is DarkpoolV2TestUtils {
+contract PublicIntentSettlementTestUtils is DarkpoolV2TestUtils {
     using ObligationLib for ObligationBundle;
     using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
@@ -81,35 +81,37 @@ contract SettlementTestUtils is DarkpoolV2TestUtils {
     // --- Dummy Data --- //
 
     /// @dev Create a dummy `SettlementTransfers` list for the test
-    function _createSettlementContext() internal pure returns (SettlementContext memory context) {
+    function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
         context = SettlementContextLib.newContext(1, /* transferCapacity */ 1 /* verificationCapacity */ );
     }
 
     /// @dev Helper to create a sample settlement bundle
-    function createSampleBundle()
+    function createSamplePublicIntentBundle()
         internal
         returns (SettlementBundle memory settlementBundle, ObligationBundle memory obligationBundle)
     {
         (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
         Intent memory intent0 = createIntentForObligation(obligation0);
-        settlementBundle = createSettlementBundle(intent0, obligation0);
+        settlementBundle = createPublicIntentSettlementBundle(intent0, obligation0);
         obligationBundle =
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
     }
 
     /// @dev Create a complete settlement bundle given an intent and an obligation
-    function createSettlementBundle(
+    function createPublicIntentSettlementBundle(
         Intent memory intent,
         SettlementObligation memory obligation
     )
-        internal
+        public
         returns (SettlementBundle memory)
     {
-        return createSettlementBundleWithSigners(intent, obligation, intentOwner.privateKey, executor.privateKey);
+        return createPublicIntentSettlementBundleWithSigners(
+            intent, obligation, intentOwner.privateKey, executor.privateKey
+        );
     }
 
     /// @dev Create a complete settlement bundle with custom signers
-    function createSettlementBundleWithSigners(
+    function createPublicIntentSettlementBundleWithSigners(
         Intent memory intent,
         SettlementObligation memory obligation,
         uint256 intentOwnerPrivateKey,

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/FullMatchTests.t.sol
@@ -52,8 +52,8 @@ contract FullMatchTests is RenegadeSettledPrivateFillTestUtils {
             ObligationBundle({ obligationType: ObligationType.PRIVATE, data: abi.encode(privateObligation) });
 
         // Create two settlement bundles
-        bundle0 = createSettlementBundle(isFirstFill, party0);
-        bundle1 = createSettlementBundle(isFirstFill, party1);
+        bundle0 = createRenegadeSettledPrivateFillBundle(isFirstFill, party0);
+        bundle1 = createRenegadeSettledPrivateFillBundle(isFirstFill, party1);
     }
 
     // ---------
@@ -78,8 +78,8 @@ contract FullMatchTests is RenegadeSettledPrivateFillTestUtils {
             ObligationBundle({ obligationType: ObligationType.PRIVATE, data: abi.encode(privateObligation) });
 
         // Create two settlement bundles with different fill types
-        SettlementBundle memory bundle0 = createSettlementBundle(true, party0);
-        SettlementBundle memory bundle1 = createSettlementBundle(false, party1);
+        SettlementBundle memory bundle0 = createRenegadeSettledPrivateFillBundle(true, party0);
+        SettlementBundle memory bundle1 = createRenegadeSettledPrivateFillBundle(false, party1);
         darkpool.settleMatch(obligationBundle, bundle0, bundle1);
     }
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
@@ -91,7 +91,7 @@ contract RenegadeSettledPrivateFillAuthorizationTest is RenegadeSettledPrivateFi
     function test_invalidMerkleDepth() public {
         // Create bundle with invalid Merkle depth (not the default)
         uint256 invalidDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH + 1;
-        SettlementBundle memory bundle = createSettlementBundleSubsequentFill(invalidDepth);
+        SettlementBundle memory bundle = createRenegadeSettledPrivateFillBundleSubsequentFill(invalidDepth);
 
         ObligationBundle memory obligationBundle;
         obligationBundle.obligationType = ObligationType.PRIVATE;

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
@@ -123,11 +123,11 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
         obligationBundle =
             ObligationBundle({ obligationType: ObligationType.PRIVATE, data: abi.encode(privateObligation) });
 
-        bundle = createSettlementBundle(isFirstFill, oneTimeOwner);
+        bundle = createRenegadeSettledPrivateFillBundle(isFirstFill, oneTimeOwner);
     }
 
     /// @dev Create a complete settlement bundle given an owner
-    function createSettlementBundle(
+    function createRenegadeSettledPrivateFillBundle(
         bool isFirstFill,
         Vm.Wallet memory owner
     )
@@ -136,14 +136,14 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
     {
         uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
         if (isFirstFill) {
-            return createSettlementBundleFirstFill(merkleDepth, owner);
+            return createRenegadeSettledPrivateFillBundleFirstFill(merkleDepth, owner);
         } else {
-            return createSettlementBundleSubsequentFill(merkleDepth);
+            return createRenegadeSettledPrivateFillBundleSubsequentFill(merkleDepth);
         }
     }
 
     /// @dev Create a complete settlement bundle for the first fill
-    function createSettlementBundleFirstFill(
+    function createRenegadeSettledPrivateFillBundleFirstFill(
         uint256 merkleDepth,
         Vm.Wallet memory oneTimeKey
     )
@@ -177,7 +177,10 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Create a complete settlement bundle for a subsequent fill
-    function createSettlementBundleSubsequentFill(uint256 merkleDepth) internal returns (SettlementBundle memory) {
+    function createRenegadeSettledPrivateFillBundleSubsequentFill(uint256 merkleDepth)
+        internal
+        returns (SettlementBundle memory)
+    {
         // Create the statement
         IntentAndBalanceValidityStatement memory validityStatement = createSampleStatement();
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/FullMatchTests.t.sol
@@ -48,8 +48,8 @@ contract FullMatchTests is RenegadeSettledPrivateIntentTestUtils {
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
 
         // Create two settlement bundles
-        bundle0 = createSettlementBundle(isFirstFill, obligation0, party0);
-        bundle1 = createSettlementBundle(isFirstFill, obligation1, party1);
+        bundle0 = createRenegadeSettledBundle(isFirstFill, obligation0, party0);
+        bundle1 = createRenegadeSettledBundle(isFirstFill, obligation1, party1);
     }
 
     // ---------
@@ -74,8 +74,8 @@ contract FullMatchTests is RenegadeSettledPrivateIntentTestUtils {
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
 
         // Create two settlement bundles
-        SettlementBundle memory bundle0 = createSettlementBundle(true, obligation0, party0);
-        SettlementBundle memory bundle1 = createSettlementBundle(false, obligation1, party1);
+        SettlementBundle memory bundle0 = createRenegadeSettledBundle(true, obligation0, party0);
+        SettlementBundle memory bundle1 = createRenegadeSettledBundle(false, obligation1, party1);
         darkpool.settleMatch(obligationBundle, bundle0, bundle1);
     }
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
@@ -62,7 +62,8 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
     function test_validSignature() public {
         // Should not revert
         bool isFirstFill = vm.randomBool();
-        (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) = createSampleBundle(isFirstFill);
+        (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
+            createSampleRenegadeSettledBundle(isFirstFill);
         authorizeIntentHelper(obligationBundle, bundle);
     }
 
@@ -70,7 +71,7 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
     function test_invalidOwnerSignature_wrongSigner() public {
         // Create bundle and replace the owner signature with a signature from wrong signer
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
-            createSampleBundle(true /* isFirstFill */ );
+            createSampleRenegadeSettledBundle(true /* isFirstFill */ );
         RenegadeSettledIntentFirstFillBundle memory bundleData =
             abi.decode(bundle.data, (RenegadeSettledIntentFirstFillBundle));
         RenegadeSettledIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
@@ -96,7 +97,7 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
 
         // Use an invalid Merkle depth (not the default)
         uint256 invalidDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH + 1;
-        SettlementBundle memory bundle = createSettlementBundleSubsequentFill(invalidDepth, obligation0);
+        SettlementBundle memory bundle = createRenegadeSettledBundleSubsequentFill(invalidDepth, obligation0);
 
         // Should revert with InvalidMerkleDepthRequested
         vm.expectRevert(IDarkpool.InvalidMerkleDepthRequested.selector);

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -61,7 +61,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
     // --- Dummy Data --- //
 
     /// @dev Create a dummy `SettlementContext` for the test
-    function _createSettlementContext() internal pure returns (SettlementContext memory context) {
+    function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
         context = SettlementContextLib.newContext(2, /* transferCapacity */ 2 /* verificationCapacity */ );
     }
 
@@ -87,8 +87,8 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         });
     }
 
-    /// @dev Create a dummy settlement statement
-    function createSampleSettlementStatement(SettlementObligation memory obligation)
+    /// @dev Create a dummy settlement statement for renegade settled
+    function createSampleRenegadeSettlementStatement(SettlementObligation memory obligation)
         internal
         returns (RenegadeSettledPrivateIntentPublicSettlementStatement memory)
     {
@@ -105,7 +105,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Helper to create a sample settlement bundle
-    function createSampleBundle(bool isFirstFill)
+    function createSampleRenegadeSettledBundle(bool isFirstFill)
         internal
         returns (ObligationBundle memory obligationBundle, SettlementBundle memory bundle)
     {
@@ -114,11 +114,11 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         obligationBundle =
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
 
-        bundle = createSettlementBundle(isFirstFill, obligation0, oneTimeOwner);
+        bundle = createRenegadeSettledBundle(isFirstFill, obligation0, oneTimeOwner);
     }
 
     /// @dev Create a complete settlement bundle given an obligation
-    function createSettlementBundle(
+    function createRenegadeSettledBundle(
         bool isFirstFill,
         SettlementObligation memory obligation,
         Vm.Wallet memory owner
@@ -128,14 +128,14 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
     {
         uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
         if (isFirstFill) {
-            return createSettlementBundleFirstFill(merkleDepth, obligation, owner);
+            return createRenegadeSettledBundleFirstFill(merkleDepth, obligation, owner);
         } else {
-            return createSettlementBundleSubsequentFill(merkleDepth, obligation);
+            return createRenegadeSettledBundleSubsequentFill(merkleDepth, obligation);
         }
     }
 
     /// @dev Create a complete settlement bundle with custom signer for the first fill
-    function createSettlementBundleFirstFill(
+    function createRenegadeSettledBundleFirstFill(
         uint256 merkleDepth,
         SettlementObligation memory obligation,
         Vm.Wallet memory oneTimeKey
@@ -147,7 +147,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         IntentAndBalanceValidityStatementFirstFill memory validityStatement = createSampleStatementFirstFill();
         validityStatement.oneTimeAuthorizingAddress = oneTimeKey.addr;
         RenegadeSettledPrivateIntentPublicSettlementStatement memory settlementStatement =
-            createSampleSettlementStatement(obligation);
+            createSampleRenegadeSettlementStatement(obligation);
 
         // Sign the owner signature digest
         SignatureWithNonce memory ownerSignature = createOwnerSignature(
@@ -176,7 +176,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
     }
 
     /// @dev Create a complete settlement bundle with custom signer and parameters
-    function createSettlementBundleSubsequentFill(
+    function createRenegadeSettledBundleSubsequentFill(
         uint256 merkleDepth,
         SettlementObligation memory obligation
     )
@@ -186,7 +186,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         // Create the statement types
         IntentAndBalanceValidityStatement memory validityStatement = createSampleStatement();
         RenegadeSettledPrivateIntentPublicSettlementStatement memory settlementStatement =
-            createSampleSettlementStatement(obligation);
+            createSampleRenegadeSettlementStatement(obligation);
 
         // Create auth bundle (no signature needed for subsequent fills)
         RenegadeSettledIntentAuthBundle memory auth = RenegadeSettledIntentAuthBundle({


### PR DESCRIPTION
### Purpose
This PR adds a test suite which crosses orders of different settlement bundle types. All combinations are implemented; note that private fills may only cross with one another, so no extra tests are needed for that case.

### Testing
- [x] All unit tests pass