### PR TITLE
darkpoolv2: depositNewBalance: Implement and add tests

### DIFF
--- a/src/darkpool/v2/contracts/Verifier.sol
+++ b/src/darkpool/v2/contracts/Verifier.sol
@@ -7,14 +7,19 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verifier/Types.sol";
 import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
 
-import { DepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
-import { ExistingBalanceDepositValidityStatement, PublicInputsLib } from "darkpoolv2-lib/PublicInputs.sol";
+import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import {
+    ExistingBalanceDepositValidityStatement,
+    NewBalanceDepositValidityStatement,
+    PublicInputsLib
+} from "darkpoolv2-lib/PublicInputs.sol";
 
 /// @title Verifier
 /// @author Renegade Eng
 /// @notice Implementation of the IVerifier interface for the DarkpoolV2 contract
 contract Verifier is IVerifier {
     using PublicInputsLib for ExistingBalanceDepositValidityStatement;
+    using PublicInputsLib for NewBalanceDepositValidityStatement;
 
     /// @inheritdoc IVerifier
     function verifyExistingBalanceDepositValidity(DepositProofBundle calldata depositProofBundle)
@@ -25,6 +30,17 @@ contract Verifier is IVerifier {
         VerificationKey memory vk = PublicInputsLib.dummyVkey();
         BN254.ScalarField[] memory publicInputs = depositProofBundle.statement.statementSerialize();
         return VerifierCore.verify(depositProofBundle.proof, publicInputs, vk);
+    }
+
+    /// @inheritdoc IVerifier
+    function verifyNewBalanceDepositValidity(NewBalanceDepositProofBundle calldata newBalanceProofBundle)
+        external
+        view
+        returns (bool)
+    {
+        VerificationKey memory vk = PublicInputsLib.dummyVkey();
+        BN254.ScalarField[] memory publicInputs = newBalanceProofBundle.statement.statementSerialize();
+        return VerifierCore.verify(newBalanceProofBundle.proof, publicInputs, vk);
     }
 
     /// @inheritdoc IVerifier

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import { DepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { EncryptionKey } from "darkpoolv1-types/Ciphertext.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
@@ -60,10 +60,13 @@ interface IDarkpoolV2 {
     function deposit(DepositAuth memory auth, DepositProofBundle calldata depositProofBundle) external;
 
     /// @notice Deposit a new balance into the darkpool
-    /// @param token The token to deposit
-    /// @param amount The amount to deposit
-    /// @param from The address from which to deposit
-    function depositNewBalance(address token, uint256 amount, address from) external;
+    /// @param auth The authorization for the deposit
+    /// @param newBalanceProofBundle The proof bundle for the new balance deposit
+    function depositNewBalance(
+        DepositAuth memory auth,
+        NewBalanceDepositProofBundle calldata newBalanceProofBundle
+    )
+        external;
 
     /// @notice Withdraw from a balance in the darkpool
     /// @param token The token to withdraw

--- a/src/darkpool/v2/interfaces/IVerifier.sol
+++ b/src/darkpool/v2/interfaces/IVerifier.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verifier/Types.sol";
 
-import { DepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
 
 /// @title IVerifier
 /// @author Renegade Eng
@@ -14,6 +14,14 @@ interface IVerifier {
     /// @param depositProofBundle The proof bundle for the deposit
     /// @return True if the proof is valid, false otherwise
     function verifyExistingBalanceDepositValidity(DepositProofBundle calldata depositProofBundle)
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a proof of `NEW BALANCE DEPOSIT VALIDITY`
+    /// @param newBalanceProofBundle The proof bundle for the new balance deposit
+    /// @return True if the proof is valid, false otherwise
+    function verifyNewBalanceDepositValidity(NewBalanceDepositProofBundle calldata newBalanceProofBundle)
         external
         view
         returns (bool);

--- a/src/darkpool/v2/types/ProofBundles.sol
+++ b/src/darkpool/v2/types/ProofBundles.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { ExistingBalanceDepositValidityStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import {
+    ExistingBalanceDepositValidityStatement,
+    NewBalanceDepositValidityStatement
+} from "darkpoolv2-lib/PublicInputs.sol";
 
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
@@ -13,5 +16,13 @@ struct DepositProofBundle {
     /// @dev The statement of the deposit validity
     ExistingBalanceDepositValidityStatement statement;
     /// @dev The proof of the deposit validity
+    PlonkProof proof;
+}
+
+/// @notice A bundle of proofs for _new_ balance deposit validity
+struct NewBalanceDepositProofBundle {
+    /// @dev The statement of the new balance deposit validity
+    NewBalanceDepositValidityStatement statement;
+    /// @dev The proof of the new balance deposit validity
     PlonkProof proof;
 }

--- a/src/darkpool/v2/types/transfers/Deposit.sol
+++ b/src/darkpool/v2/types/transfers/Deposit.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
 /// @dev The type hash for the DepositWitness struct
 // solhint-disable-next-line gas-small-strings
 bytes32 constant DEPOSIT_WITNESS_TYPEHASH = keccak256("DepositWitness(uint256 newBalanceCommitment)");
@@ -56,6 +58,6 @@ library DepositLib {
     /// @param witness The deposit witness to hash
     /// @return The hash of the deposit witness
     function hashWitness(DepositWitness memory witness) internal pure returns (bytes32) {
-        return keccak256(abi.encode(DEPOSIT_WITNESS_TYPEHASH, witness.newBalanceCommitment));
+        return EfficientHashLib.hash(DEPOSIT_WITNESS_TYPEHASH, bytes32(witness.newBalanceCommitment));
     }
 }

--- a/test/test-contracts/TestVerifierV2.sol
+++ b/test/test-contracts/TestVerifierV2.sol
@@ -5,7 +5,7 @@ import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verifier/Types.sol";
-import { DepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
 
 /// @title Test Verifier Implementation
 /// @notice This is a test implementation of the `IVerifier` interface that always returns true
@@ -13,6 +13,11 @@ import { DepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
 contract TestVerifierV2 is IVerifier {
     /// @inheritdoc IVerifier
     function verifyExistingBalanceDepositValidity(DepositProofBundle calldata) external pure returns (bool) {
+        return true;
+    }
+
+    /// @inheritdoc IVerifier
+    function verifyNewBalanceDepositValidity(NewBalanceDepositProofBundle calldata) external pure returns (bool) {
         return true;
     }
 


### PR DESCRIPTION
### Purpose
This PR adds an implementation and test suite for `depositNewBalance`. This method allocates a new balance in the darkpool which owns the deposit.

### Testing
- [x] Unit tests pass