### PR TITLE
darkpoolv2: withdrawal: Add withdrawal implementation

### DIFF
--- a/src/darkpool/v2/contracts/Verifier.sol
+++ b/src/darkpool/v2/contracts/Verifier.sol
@@ -7,10 +7,13 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verifier/Types.sol";
 import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
 
-import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import {
+    DepositProofBundle, NewBalanceDepositProofBundle, WithdrawalProofBundle
+} from "darkpoolv2-types/ProofBundles.sol";
 import {
     ExistingBalanceDepositValidityStatement,
     NewBalanceDepositValidityStatement,
+    WithdrawalValidityStatement,
     PublicInputsLib
 } from "darkpoolv2-lib/PublicInputs.sol";
 
@@ -20,6 +23,7 @@ import {
 contract Verifier is IVerifier {
     using PublicInputsLib for ExistingBalanceDepositValidityStatement;
     using PublicInputsLib for NewBalanceDepositValidityStatement;
+    using PublicInputsLib for WithdrawalValidityStatement;
 
     /// @inheritdoc IVerifier
     function verifyExistingBalanceDepositValidity(DepositProofBundle calldata depositProofBundle)
@@ -41,6 +45,17 @@ contract Verifier is IVerifier {
         VerificationKey memory vk = PublicInputsLib.dummyVkey();
         BN254.ScalarField[] memory publicInputs = newBalanceProofBundle.statement.statementSerialize();
         return VerifierCore.verify(newBalanceProofBundle.proof, publicInputs, vk);
+    }
+
+    /// @inheritdoc IVerifier
+    function verifyWithdrawalValidity(WithdrawalProofBundle calldata withdrawalProofBundle)
+        external
+        view
+        returns (bool)
+    {
+        VerificationKey memory vk = PublicInputsLib.dummyVkey();
+        BN254.ScalarField[] memory publicInputs = withdrawalProofBundle.statement.statementSerialize();
+        return VerifierCore.verify(withdrawalProofBundle.proof, publicInputs, vk);
     }
 
     /// @inheritdoc IVerifier

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -4,8 +4,11 @@ pragma solidity ^0.8.24;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import {
+    DepositProofBundle, NewBalanceDepositProofBundle, WithdrawalProofBundle
+} from "darkpoolv2-types/ProofBundles.sol";
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
+import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { EncryptionKey } from "darkpoolv1-types/Ciphertext.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
@@ -69,10 +72,9 @@ interface IDarkpoolV2 {
         external;
 
     /// @notice Withdraw from a balance in the darkpool
-    /// @param token The token to withdraw
-    /// @param amount The amount to withdraw
-    /// @param to The address to which to withdraw
-    function withdraw(address token, uint256 amount, address to) external;
+    /// @param auth The authorization for the withdrawal
+    /// @param withdrawalProofBundle The proof bundle for the withdrawal
+    function withdraw(WithdrawalAuth memory auth, WithdrawalProofBundle calldata withdrawalProofBundle) external;
 
     /// @notice Pay fees on a balance
     /// @param token The token to pay fees on

--- a/src/darkpool/v2/interfaces/IVerifier.sol
+++ b/src/darkpool/v2/interfaces/IVerifier.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.24;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verifier/Types.sol";
 
-import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import {
+    DepositProofBundle, NewBalanceDepositProofBundle, WithdrawalProofBundle
+} from "darkpoolv2-types/ProofBundles.sol";
 
 /// @title IVerifier
 /// @author Renegade Eng
@@ -22,6 +24,14 @@ interface IVerifier {
     /// @param newBalanceProofBundle The proof bundle for the new balance deposit
     /// @return True if the proof is valid, false otherwise
     function verifyNewBalanceDepositValidity(NewBalanceDepositProofBundle calldata newBalanceProofBundle)
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a proof of `WITHDRAWAL VALIDITY`
+    /// @param withdrawalProofBundle The proof bundle for the withdrawal
+    /// @return True if the proof is valid, false otherwise
+    function verifyWithdrawalValidity(WithdrawalProofBundle calldata withdrawalProofBundle)
         external
         view
         returns (bool);

--- a/src/darkpool/v2/types/ProofBundles.sol
+++ b/src/darkpool/v2/types/ProofBundles.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.24;
 
 import {
     ExistingBalanceDepositValidityStatement,
-    NewBalanceDepositValidityStatement
+    NewBalanceDepositValidityStatement,
+    WithdrawalValidityStatement
 } from "darkpoolv2-lib/PublicInputs.sol";
 
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
@@ -24,5 +25,13 @@ struct NewBalanceDepositProofBundle {
     /// @dev The statement of the new balance deposit validity
     NewBalanceDepositValidityStatement statement;
     /// @dev The proof of the new balance deposit validity
+    PlonkProof proof;
+}
+
+/// @notice A bundle of proofs for a withdrawal validity
+struct WithdrawalProofBundle {
+    /// @dev The statement of the withdrawal validity
+    WithdrawalValidityStatement statement;
+    /// @dev The proof of the withdrawal validity
     PlonkProof proof;
 }

--- a/src/darkpool/v2/types/transfers/Withdrawal.sol
+++ b/src/darkpool/v2/types/transfers/Withdrawal.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title Withdrawal
+/// @author Renegade Eng
+/// @notice A withdrawal from a balance in the darkpool
+struct Withdrawal {
+    /// @dev The token to withdraw
+    address token;
+    /// @dev The address from which to withdraw
+    address to;
+    /// @dev The amount to withdraw
+    uint256 amount;
+}
+
+/// @notice The authorization for a withdrawal
+/// @dev This authorizes a signature transfer of the withdrawal amount
+/// @dev The signature here is over the commitment to the updated balance after the withdrawal executes
+struct WithdrawalAuth {
+    /// @dev The signature of the post-withdrawal balance commitment
+    bytes signature;
+}

--- a/test/darkpool/v2/Withdrawal.t.sol
+++ b/test/darkpool/v2/Withdrawal.t.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Vm } from "forge-std/Vm.sol";
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { DarkpoolV2TestUtils } from "./DarkpoolV2TestUtils.sol";
+import { WithdrawalProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import { MerkleMountainLib } from "renegade-lib/merkle/MerkleMountain.sol";
+import { Withdrawal, WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
+import { WithdrawalValidityStatement } from "darkpoolv2-lib/PublicInputs.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
+/// @title WithdrawalTest
+/// @notice Tests for the withdrawal functionality in DarkpoolV2
+contract WithdrawalTest is DarkpoolV2TestUtils {
+    using MerkleMountainLib for MerkleMountainLib.MerkleMountainRange;
+
+    // Test wallets
+    Vm.Wallet internal balanceOwner;
+    ERC20Mock internal withdrawalToken;
+
+    // Test state
+    MerkleMountainLib.MerkleMountainRange private testMountain;
+
+    function setUp() public override {
+        super.setUp();
+        balanceOwner = vm.createWallet("balance_owner");
+        withdrawalToken = baseToken;
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @notice Generate random withdrawal calldata (auth + proof bundle)
+    /// @return withdrawal The withdrawal struct
+    /// @return auth The withdrawal authorization
+    /// @return proofBundle The withdrawal proof bundle
+    function generateRandomWithdrawalCalldata()
+        internal
+        returns (Withdrawal memory withdrawal, WithdrawalAuth memory auth, WithdrawalProofBundle memory proofBundle)
+    {
+        withdrawal = createTestWithdrawal();
+        proofBundle = createWithdrawalProofBundle(withdrawal);
+        auth = createWithdrawalAuth(proofBundle.statement.newBalanceCommitment);
+        capitalizeDarkpool(withdrawal);
+    }
+
+    /// @notice Create a withdrawal for testing
+    function createTestWithdrawal() internal returns (Withdrawal memory) {
+        uint256 amount = randomAmount();
+        return Withdrawal({ to: balanceOwner.addr, token: address(withdrawalToken), amount: amount });
+    }
+
+    /// @notice Create a withdrawal auth for testing
+    /// @param newBalanceCommitment The new balance commitment to sign
+    function createWithdrawalAuth(BN254.ScalarField newBalanceCommitment) internal returns (WithdrawalAuth memory) {
+        // Sign the new balance commitment
+        // The signature must be from the owner (withdrawal.to address)
+        bytes32 commitmentHash = EfficientHashLib.hash(BN254.ScalarField.unwrap(newBalanceCommitment));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(balanceOwner.privateKey, commitmentHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        return WithdrawalAuth({ signature: signature });
+    }
+
+    /// @notice Create a withdrawal proof bundle for testing
+    function createWithdrawalProofBundle(Withdrawal memory withdrawal)
+        internal
+        returns (WithdrawalProofBundle memory)
+    {
+        BN254.ScalarField balanceNullifier = randomScalar();
+        BN254.ScalarField newBalanceCommitment = randomScalar();
+        BN254.ScalarField newAmountPublicShare = randomScalar();
+        uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
+
+        WithdrawalValidityStatement memory statement = WithdrawalValidityStatement({
+            merkleDepth: merkleDepth,
+            withdrawal: withdrawal,
+            balanceNullifier: balanceNullifier,
+            newBalanceCommitment: newBalanceCommitment,
+            newAmountPublicShare: newAmountPublicShare
+        });
+
+        return WithdrawalProofBundle({ statement: statement, proof: createDummyProof() });
+    }
+
+    /// @notice Capitalize the darkpool's balance so it can fulfill withdrawals
+    function capitalizeDarkpool(Withdrawal memory withdrawal) internal {
+        withdrawalToken.mint(address(darkpool), withdrawal.amount);
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// @notice Test a successful withdrawal
+    function test_withdrawal_success() public {
+        // Generate test data
+        (Withdrawal memory withdrawal, WithdrawalAuth memory auth, WithdrawalProofBundle memory proofBundle) =
+            generateRandomWithdrawalCalldata();
+        uint256 withdrawalAmount = withdrawal.amount;
+
+        // Record balances before
+        uint256 recipientBalanceBefore = withdrawalToken.balanceOf(balanceOwner.addr);
+        uint256 darkpoolBalanceBefore = withdrawalToken.balanceOf(address(darkpool));
+
+        // Execute the withdrawal
+        darkpool.withdraw(auth, proofBundle);
+
+        // Check balances after
+        uint256 recipientBalanceAfter = withdrawalToken.balanceOf(balanceOwner.addr);
+        uint256 darkpoolBalanceAfter = withdrawalToken.balanceOf(address(darkpool));
+
+        assertEq(recipientBalanceAfter, recipientBalanceBefore + withdrawalAmount, "Recipient balance should increase");
+        assertEq(darkpoolBalanceAfter, darkpoolBalanceBefore - withdrawalAmount, "Darkpool balance should decrease");
+
+        // Check that the nullifier was spent
+        assertTrue(darkpool.nullifierSpent(proofBundle.statement.balanceNullifier), "Balance nullifier should be spent");
+    }
+
+    /// @notice Test the Merkle root after a withdrawal
+    function test_withdrawal_merkleRoot() public {
+        // Generate test data
+        (Withdrawal memory withdrawal, WithdrawalAuth memory auth, WithdrawalProofBundle memory proofBundle) =
+            generateRandomWithdrawalCalldata();
+
+        // Execute the withdrawal
+        darkpool.withdraw(auth, proofBundle);
+
+        // Check that the Merkle root is in the history
+        // Build a parallel merkle tree with the same operation
+        uint256 depth = proofBundle.statement.merkleDepth;
+        testMountain.insertLeaf(depth, proofBundle.statement.newBalanceCommitment, hasher);
+        BN254.ScalarField root = testMountain.getRoot(depth);
+
+        // The root should be in the darkpool's history
+        bool rootInHistory = darkpool.rootInHistory(root);
+        assertTrue(rootInHistory, "Merkle root should be in history");
+    }
+
+    /// @notice Test withdrawal with zero amount
+    function test_withdrawal_zeroAmount() public {
+        // Generate test data
+        Withdrawal memory withdrawal = Withdrawal({ to: balanceOwner.addr, token: address(withdrawalToken), amount: 0 });
+        WithdrawalProofBundle memory proofBundle = createWithdrawalProofBundle(withdrawal);
+        WithdrawalAuth memory auth = createWithdrawalAuth(proofBundle.statement.newBalanceCommitment);
+
+        // Should succeed with zero amount
+        darkpool.withdraw(auth, proofBundle);
+    }
+
+    /// @notice Test that a nullifier cannot be reused
+    function test_withdrawal_duplicateNullifier_reverts() public {
+        // Generate test data
+        (Withdrawal memory withdrawal, WithdrawalAuth memory auth, WithdrawalProofBundle memory proofBundle) =
+            generateRandomWithdrawalCalldata();
+
+        // Execute the withdrawal once
+        darkpool.withdraw(auth, proofBundle);
+
+        // Capitalize the darkpool again for a second withdrawal
+        capitalizeDarkpool(withdrawal);
+
+        // Try to execute the same withdrawal again with the same nullifier
+        // Should revert because the nullifier is already spent
+        vm.expectRevert();
+        darkpool.withdraw(auth, proofBundle);
+    }
+}

--- a/test/test-contracts/TestVerifierV2.sol
+++ b/test/test-contracts/TestVerifierV2.sol
@@ -5,7 +5,9 @@ import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verifier/Types.sol";
-import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import {
+    DepositProofBundle, NewBalanceDepositProofBundle, WithdrawalProofBundle
+} from "darkpoolv2-types/ProofBundles.sol";
 
 /// @title Test Verifier Implementation
 /// @notice This is a test implementation of the `IVerifier` interface that always returns true
@@ -18,6 +20,11 @@ contract TestVerifierV2 is IVerifier {
 
     /// @inheritdoc IVerifier
     function verifyNewBalanceDepositValidity(NewBalanceDepositProofBundle calldata) external pure returns (bool) {
+        return true;
+    }
+
+    /// @inheritdoc IVerifier
+    function verifyWithdrawalValidity(WithdrawalProofBundle calldata) external pure returns (bool) {
         return true;
     }
 


### PR DESCRIPTION
### Purpose
This PR implements the withdrawal entrypoint with appropriate auth and state updates.

A withdrawal is authorized by the balance owner signing the updated commitment to the balance.

### Testing
- [x] Unit tests pass 