### PR TITLE
connectors: Rename to `connectors`

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -19,7 +19,7 @@ darkpoolv1-types/=src/darkpool/v1/types
 darkpoolv1-proxies/=src/darkpool/v1/proxies
 darkpoolv1-lib/=src/darkpool/v1/libraries
 darkpoolv1-interfaces/=src/darkpool/v1/interfaces
-darkpoolv1-executor/=src/uniswapx_executor
+renegade-connectors/=src/connectors
 darkpoolv1-test/=test/darkpool/v1
 
 darkpoolv2-contracts/=src/darkpool/v2/contracts

--- a/src/connectors/DarkpoolUniswapExecutor.sol
+++ b/src/connectors/DarkpoolUniswapExecutor.sol
@@ -27,13 +27,13 @@ import { SafeTransferLib } from "solmate/src/utils/SafeTransferLib.sol";
 import { ERC20 } from "solmate/src/tokens/ERC20.sol";
 
 /**
- * @title DarkpoolExecutor
+ * @title DarkpoolUniswapExecutor
  * @author Renegade Eng
  * @notice A wrapper contract that acts as a UniswapX executor for the darkpool
  * @dev This contract implements IReactorCallback to handle order execution callbacks from UniswapX
  * and routes them to the darkpool for settlement
  */
-contract DarkpoolExecutor is IReactorCallback, Initializable, Ownable2Step, Pausable, AccessControl {
+contract DarkpoolUniswapExecutor is IReactorCallback, Initializable, Ownable2Step, Pausable, AccessControl {
     using SafeTransferLib for ERC20;
 
     // --- State Variables --- //

--- a/src/connectors/MalleableMatchConnector.sol
+++ b/src/connectors/MalleableMatchConnector.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Initializable } from "oz-contracts/proxy/utils/Initializable.sol";
+import { IGasSponsor } from "darkpoolv1-interfaces/IGasSponsor.sol";
+import { IERC20 } from "oz-contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "oz-contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {
+    PartyMatchPayload,
+    ExternalMatchDirection,
+    MalleableMatchAtomicProofs,
+    MatchAtomicLinkingProofs
+} from "darkpoolv1-types/Settlement.sol";
+
+import { ValidMalleableMatchSettleAtomicStatement } from "darkpoolv1-lib/PublicInputs.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolConstants } from "darkpoolv1-lib/Constants.sol";
+
+/// @title MalleableMatchConnector
+/// @author Renegade Eng
+/// @notice This contract is a connector for the malleable match settlement.
+contract MalleableMatchConnector is Initializable {
+    using FixedPointLib for FixedPoint;
+
+    /// @notice The gas sponsor contract
+    IGasSponsor public gasSponsor;
+
+    /// @notice Constructor that disables initializers for the implementation contract
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initializes the malleable match connector with the given gas sponsor address
+     * @param _gasSponsor The address of the gas sponsor contract
+     */
+    function initialize(address _gasSponsor) public initializer {
+        gasSponsor = IGasSponsor(_gasSponsor);
+    }
+
+    /// @notice Sets the base and quote amounts for the malleable match based on the input amount parameter, then
+    /// forwards the remaining calldata to the gas sponsor contract
+    /// @param inputAmount The input amount for the malleable match
+    /// @param receiver The address to receive the tokens
+    /// @param internalPartyMatchPayload The internal party match payload
+    /// @param malleableMatchSettleStatement The malleable match settle statement
+    /// @param matchProofs The match proofs
+    /// @param matchLinkingProofs The match linking proofs
+    /// @param refundAddress The address to refund gas costs to
+    /// @param refundNativeEth Whether to refund gas costs in native ETH
+    /// @param refundAmount The amount to refund
+    /// @param nonce A unique nonce for this sponsorship
+    /// @param signature The signature authorizing the sponsorship
+    /// @return The amount received by the external party
+    function executeMalleableAtomicMatchWithInput(
+        uint256 inputAmount,
+        address receiver,
+        PartyMatchPayload calldata internalPartyMatchPayload,
+        ValidMalleableMatchSettleAtomicStatement calldata malleableMatchSettleStatement,
+        MalleableMatchAtomicProofs calldata matchProofs,
+        MatchAtomicLinkingProofs calldata matchLinkingProofs,
+        address refundAddress,
+        bool refundNativeEth,
+        uint256 refundAmount,
+        uint256 nonce,
+        bytes calldata signature
+    )
+        external
+        payable
+        returns (uint256)
+    {
+        // Calculate the amounts based on direction
+        ExternalMatchDirection direction = malleableMatchSettleStatement.matchResult.direction;
+        FixedPoint memory price = malleableMatchSettleStatement.matchResult.price;
+
+        uint256 quoteAmount;
+        uint256 baseAmount;
+        if (direction == ExternalMatchDirection.InternalPartyBuy) {
+            // The external (calling) party inputs the base to sell for the quote
+            baseAmount = inputAmount;
+            quoteAmount = price.unsafeFixedPointMul(inputAmount);
+        } else {
+            // The external (calling) party inputs the quote to buy the base
+            baseAmount = FixedPointLib.divIntegerByFixedPoint(inputAmount, price);
+            quoteAmount = inputAmount;
+        }
+
+        // Take custody of tokens from the caller and approve gas sponsor
+        _custodyTokens(quoteAmount, baseAmount, malleableMatchSettleStatement);
+
+        // Call the gas sponsor contract
+        return gasSponsor.sponsorMalleableAtomicMatchSettle{ value: msg.value }(
+            quoteAmount,
+            baseAmount,
+            receiver,
+            internalPartyMatchPayload,
+            malleableMatchSettleStatement,
+            matchProofs,
+            matchLinkingProofs,
+            refundAddress,
+            refundNativeEth,
+            refundAmount,
+            nonce,
+            signature
+        );
+    }
+
+    /// @notice Take custody of tokens from the caller and approve gas sponsor
+    /// @param quoteAmount The quote amount
+    /// @param baseAmount The base amount
+    /// @param statement The malleable match settle statement
+    function _custodyTokens(
+        uint256 quoteAmount,
+        uint256 baseAmount,
+        ValidMalleableMatchSettleAtomicStatement calldata statement
+    )
+        internal
+    {
+        // Determine which token the external party is selling
+        address sellToken;
+        uint256 sellAmount;
+
+        if (statement.matchResult.direction == ExternalMatchDirection.InternalPartyBuy) {
+            // External party sells base
+            sellToken = statement.matchResult.baseMint;
+            sellAmount = baseAmount;
+        } else {
+            // External party sells quote
+            sellToken = statement.matchResult.quoteMint;
+            sellAmount = quoteAmount;
+        }
+
+        // Only handle ERC20 transfers (native ETH is passed via msg.value)
+        if (!DarkpoolConstants.isNativeToken(sellToken)) {
+            IERC20 token = IERC20(sellToken);
+            // Pull tokens from the caller, then increase the allowance for the gas sponsor
+            SafeERC20.safeTransferFrom(token, msg.sender, address(this), sellAmount);
+            SafeERC20.safeIncreaseAllowance(token, address(gasSponsor), sellAmount);
+        }
+    }
+}

--- a/src/connectors/MalleableMatchConnectorProxy.sol
+++ b/src/connectors/MalleableMatchConnectorProxy.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { TransparentUpgradeableProxy } from "oz-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { MalleableMatchConnector } from "./MalleableMatchConnector.sol";
+
+/// @title MalleableMatchConnectorProxy
+/// @author Renegade Eng
+/// @notice This contract is a TransparentUpgradeableProxy for the MalleableMatchConnector contract.
+/// It simplifies deployment by accepting MalleableMatchConnector-specific initialization parameters
+/// and encoding them appropriately.
+contract MalleableMatchConnectorProxy is TransparentUpgradeableProxy {
+    /// @notice Initializes a TransparentUpgradeableProxy for a MalleableMatchConnector implementation.
+    /// @param implementation The MalleableMatchConnector implementation address
+    /// @param admin The admin address - serves as ProxyAdmin owner and can manage proxy upgrades
+    /// @param gasSponsor The address of the gas sponsor contract
+    constructor(
+        address implementation,
+        address admin,
+        address gasSponsor
+    )
+        payable
+        TransparentUpgradeableProxy(
+            implementation,
+            admin,
+            abi.encodeWithSelector(MalleableMatchConnector.initialize.selector, gasSponsor)
+        )
+    { }
+}

--- a/src/darkpool/v1/interfaces/IDarkpoolUniswapExecutor.sol
+++ b/src/darkpool/v1/interfaces/IDarkpoolUniswapExecutor.sol
@@ -13,15 +13,15 @@ import {
     ValidMatchSettleAtomicStatement, ValidMalleableMatchSettleAtomicStatement
 } from "darkpoolv1-lib/PublicInputs.sol";
 
-/// @title IDarkpoolExecutor
+/// @title IDarkpoolUniswapExecutor
 /// @author Renegade Eng
-/// @notice Interface for the DarkpoolExecutor contract
-interface IDarkpoolExecutor is IReactorCallback {
+/// @notice Interface for the DarkpoolUniswapExecutor contract
+interface IDarkpoolUniswapExecutor is IReactorCallback {
     /// @notice Returns the address of the current owner
     /// @return The address of the current owner
     function owner() external view returns (address);
 
-    /// @notice Initializes the DarkpoolExecutor
+    /// @notice Initializes the DarkpoolUniswapExecutor
     /// @param initialOwner The address that will own the contract
     /// @param darkpool_ The darkpool address
     /// @param uniswapXReactor_ The UniswapX reactor address

--- a/src/darkpool/v1/proxies/UniswapXExecutorProxy.sol
+++ b/src/darkpool/v1/proxies/UniswapXExecutorProxy.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import { TransparentUpgradeableProxy } from "oz-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import { IDarkpoolExecutor } from "darkpoolv1-interfaces/IDarkpoolExecutor.sol";
+import { IDarkpoolUniswapExecutor } from "darkpoolv1-interfaces/IDarkpoolUniswapExecutor.sol";
 
 /// @title UniswapXExecutorProxy
 /// @author Renegade Eng
@@ -25,7 +25,7 @@ contract UniswapXExecutorProxy is TransparentUpgradeableProxy {
         TransparentUpgradeableProxy(
             implementation,
             admin,
-            abi.encodeWithSelector(IDarkpoolExecutor.initialize.selector, admin, darkpool, uniswapXReactor)
+            abi.encodeWithSelector(IDarkpoolUniswapExecutor.initialize.selector, admin, darkpool, uniswapXReactor)
         )
     { }
 }

--- a/src/libraries/FixedPoint.sol
+++ b/src/libraries/FixedPoint.sol
@@ -86,4 +86,14 @@ library FixedPointLib {
         /// forge-lint: disable-next-line(incorrect-shift)
         return (self.repr * scalar) / (1 << FIXED_POINT_PRECISION_BITS);
     }
+
+    /// @notice Divide an integer by a fixed point number and return the truncated integer result
+    /// @dev Computes `(x * 2^FIXED_POINT_PRECISION_BITS) / y.repr`
+    /// @dev Since y.repr = y_real * 2^FIXED_POINT_PRECISION_BITS, this gives us x / y_real
+    /// @param x The integer numerator
+    /// @param y The fixed point denominator
+    /// @return The truncated integer result of x / y
+    function divIntegerByFixedPoint(uint256 x, FixedPoint memory y) public pure returns (uint256) {
+        return (x * (1 << FIXED_POINT_PRECISION_BITS)) / y.repr;
+    }
 }

--- a/test/FixedPoint.t.sol
+++ b/test/FixedPoint.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/* solhint-disable var-name-mixedcase */
+// forge-lint: disable-start(mixed-case-variable)
+
+import { TestUtils } from "./utils/TestUtils.sol";
+import { FixedPoint, FixedPointLib } from "../src/libraries/FixedPoint.sol";
+
+contract FixedPointTest is TestUtils {
+    using FixedPointLib for FixedPoint;
+
+    uint256 internal constant PRECISION = FixedPointLib.FIXED_POINT_PRECISION_BITS;
+
+    /// @notice Test integer to fixed point conversion
+    function testIntegerConversionRoundTrip() public {
+        // Wrap a random integer, then convert it back
+        uint256 randomInt = randomAmount();
+        FixedPoint memory fp = FixedPointLib.integerToFixedPoint(randomInt);
+        uint256 result = FixedPointLib.fixedPointToInteger(fp);
+        assertEq(result, randomInt);
+    }
+
+    /// @notice Test division of two fixed points
+    function testDiv() public pure {
+        // Test 10 / 2 = 5
+        FixedPoint memory fp10 = FixedPointLib.integerToFixedPoint(10);
+        FixedPoint memory fp2 = FixedPointLib.integerToFixedPoint(2);
+        FixedPoint memory result = FixedPointLib.div(fp10, fp2);
+        assertEq(FixedPointLib.fixedPointToInteger(result), 5);
+
+        // Test 100 / 4 = 25
+        FixedPoint memory fp100 = FixedPointLib.integerToFixedPoint(100);
+        FixedPoint memory fp4 = FixedPointLib.integerToFixedPoint(4);
+        result = FixedPointLib.div(fp100, fp4);
+        assertEq(FixedPointLib.fixedPointToInteger(result), 25);
+
+        // Test 1 / 2 = 0.5
+        FixedPoint memory fp1 = FixedPointLib.integerToFixedPoint(1);
+        result = FixedPointLib.div(fp1, fp2);
+        // 0.5 in fixed point is 2^62
+        assertEq(result.repr, 1 << (PRECISION - 1));
+    }
+
+    /// @notice Test division of two integers returning fixed point
+    function testDivIntegers() public pure {
+        // Test 10 / 2 = 5
+        FixedPoint memory result = FixedPointLib.divIntegers(10, 2);
+        assertEq(FixedPointLib.fixedPointToInteger(result), 5);
+
+        // Test 100 / 4 = 25
+        result = FixedPointLib.divIntegers(100, 4);
+        assertEq(FixedPointLib.fixedPointToInteger(result), 25);
+
+        // Test 1 / 2 = 0.5
+        result = FixedPointLib.divIntegers(1, 2);
+        // 0.5 in fixed point is 2^62
+        assertEq(result.repr, 1 << (PRECISION - 1));
+
+        // Test 3 / 2 = 1.5
+        result = FixedPointLib.divIntegers(3, 2);
+        // 1.5 in fixed point is 2^63 + 2^62
+        assertEq(result.repr, (1 << PRECISION) + (1 << (PRECISION - 1)));
+    }
+
+    /// @notice Test division of fixed point by integer
+    function testDivByInteger() public pure {
+        // Test 10 / 2 = 5
+        FixedPoint memory fp10 = FixedPointLib.integerToFixedPoint(10);
+        FixedPoint memory result = FixedPointLib.divByInteger(fp10, 2);
+        assertEq(FixedPointLib.fixedPointToInteger(result), 5);
+
+        // Test 100 / 4 = 25
+        FixedPoint memory fp100 = FixedPointLib.integerToFixedPoint(100);
+        result = FixedPointLib.divByInteger(fp100, 4);
+        assertEq(FixedPointLib.fixedPointToInteger(result), 25);
+
+        // Test truncation: 100 / 3 = 33.333...
+        result = FixedPointLib.divByInteger(fp100, 3);
+        assertEq(FixedPointLib.fixedPointToInteger(result), 33);
+    }
+
+    /// @notice Test multiplication of fixed point by integer
+    function testUnsafeFixedPointMul() public pure {
+        // Test 5 * 2 = 10
+        FixedPoint memory fp5 = FixedPointLib.integerToFixedPoint(5);
+        uint256 result = FixedPointLib.unsafeFixedPointMul(fp5, 2);
+        assertEq(result, 10);
+
+        // Test 100 * 3 = 300
+        FixedPoint memory fp100 = FixedPointLib.integerToFixedPoint(100);
+        result = FixedPointLib.unsafeFixedPointMul(fp100, 3);
+        assertEq(result, 300);
+
+        // Test 0.5 * 10 = 5
+        FixedPoint memory fp0_5 = FixedPoint({ repr: 1 << (PRECISION - 1) });
+        result = FixedPointLib.unsafeFixedPointMul(fp0_5, 10);
+        assertEq(result, 5);
+
+        // Test 1.5 * 4 = 6
+        FixedPoint memory fp1_5 = FixedPoint({ repr: (1 << PRECISION) + (1 << (PRECISION - 1)) });
+        result = FixedPointLib.unsafeFixedPointMul(fp1_5, 4);
+        assertEq(result, 6);
+    }
+
+    /// @notice Test division of integer by fixed point
+    function testDivIntegerByFixedPoint() public pure {
+        // Test 10 / 2 = 5
+        FixedPoint memory fp2 = FixedPointLib.integerToFixedPoint(2);
+        uint256 result = FixedPointLib.divIntegerByFixedPoint(10, fp2);
+        assertEq(result, 5);
+
+        // Test 100 / 4 = 25
+        FixedPoint memory fp4 = FixedPointLib.integerToFixedPoint(4);
+        result = FixedPointLib.divIntegerByFixedPoint(100, fp4);
+        assertEq(result, 25);
+
+        // Test 10 / 0.5 = 20
+        FixedPoint memory fp0_5 = FixedPoint({ repr: 1 << (PRECISION - 1) });
+        result = FixedPointLib.divIntegerByFixedPoint(10, fp0_5);
+        assertEq(result, 20);
+
+        // Test 100 / 1.5 = 66 (truncated from 66.666...)
+        FixedPoint memory fp1_5 = FixedPoint({ repr: (1 << PRECISION) + (1 << (PRECISION - 1)) });
+        result = FixedPointLib.divIntegerByFixedPoint(100, fp1_5);
+        assertEq(result, 66);
+
+        // Test 50 / 2.5 = 20
+        FixedPoint memory fp2_5 = FixedPoint({ repr: (2 << PRECISION) + (1 << (PRECISION - 1)) });
+        result = FixedPointLib.divIntegerByFixedPoint(50, fp2_5);
+        assertEq(result, 20);
+    }
+
+    /// @notice Test edge case: division by 1
+    function testDivIntegerByFixedPointDivByOne() public {
+        FixedPoint memory fp1 = FixedPointLib.integerToFixedPoint(1);
+        uint256 dividend = randomAmount();
+        uint256 result = FixedPointLib.divIntegerByFixedPoint(dividend, fp1);
+        assertEq(result, dividend);
+    }
+
+    /// @notice Test dividing an integer by a fixed point value less than 1
+    function testDivIntegerByFixedPointLessThanOne() public {
+        FixedPoint memory fp0_5 = FixedPoint({ repr: 1 << (PRECISION - 1) });
+        uint256 dividend = randomAmount();
+        uint256 result = FixedPointLib.divIntegerByFixedPoint(dividend, fp0_5);
+        assertEq(result, dividend * 2);
+    }
+}

--- a/test/connectors/MalleableMatchConnector.t.sol
+++ b/test/connectors/MalleableMatchConnector.t.sol
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { DarkpoolTestBase } from "darkpoolv1-test/DarkpoolTestBase.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { TypesLib } from "darkpoolv1-types/TypesLib.sol";
+import {
+    PartyMatchPayload,
+    MalleableMatchAtomicProofs,
+    MatchAtomicLinkingProofs,
+    ExternalMatchDirection,
+    ExternalMatchResult,
+    BoundedMatchResult
+} from "darkpoolv1-types/Settlement.sol";
+import { FeeTake, FeeTakeRate } from "darkpoolv1-types/Fees.sol";
+import { ValidMalleableMatchSettleAtomicStatement } from "darkpoolv1-lib/PublicInputs.sol";
+import { MalleableMatchConnector } from "renegade-connectors/MalleableMatchConnector.sol";
+import { MalleableMatchConnectorProxy } from "renegade-connectors/MalleableMatchConnectorProxy.sol";
+
+contract MalleableMatchConnectorTest is DarkpoolTestBase {
+    using TypesLib for FeeTake;
+    using TypesLib for FeeTakeRate;
+    using TypesLib for BoundedMatchResult;
+    using TypesLib for ExternalMatchResult;
+    using FixedPointLib for FixedPoint;
+
+    uint256 constant REFUND_AMT = 100_000;
+
+    MalleableMatchConnector public connector;
+    address public connectorAdmin;
+    address public externalPartyAddr;
+    address public receiver;
+
+    struct SponsorshipParams {
+        uint256 nonce;
+        address refundAddress;
+        bool refundNativeEth;
+        bytes signature;
+    }
+
+    function setUp() public override {
+        super.setUp();
+
+        // Set up addresses
+        connectorAdmin = vm.randomAddress();
+        externalPartyAddr = vm.randomAddress();
+        receiver = vm.randomAddress();
+
+        // Deploy connector implementation and proxy
+        MalleableMatchConnector impl = new MalleableMatchConnector();
+        MalleableMatchConnectorProxy proxy =
+            new MalleableMatchConnectorProxy(address(impl), connectorAdmin, address(gasSponsor));
+        connector = MalleableMatchConnector(address(proxy));
+
+        // Fund the gas sponsor
+        vm.deal(address(gasSponsor), REFUND_AMT * 10);
+        quoteToken.mint(address(gasSponsor), REFUND_AMT * 10);
+        baseToken.mint(address(gasSponsor), REFUND_AMT * 10);
+    }
+
+    // --- Buy Side Tests (External Party Buys Base) --- //
+
+    /// @notice Test connector with external party on buy side (sells quote, buys base)
+    /// @dev External party inputs quote amount, connector calculates base amount
+    function test_sponsorMalleableMatch_externalPartyBuySide() public {
+        // Setup the malleable match with external party buy side
+        (
+            uint256 baseAmount,
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = setupMalleableMatch(ExternalMatchDirection.InternalPartySell);
+
+        // Input amount is quote amount for buy side
+        uint256 expectedQuoteAmount = statement.matchResult.price.unsafeFixedPointMul(baseAmount);
+        uint256 expectedBaseAmount = baseAmount;
+        uint256 inputAmount = expectedQuoteAmount;
+
+        // Execute and verify
+        executeMalleableMatchSponsorship(
+            inputAmount, expectedQuoteAmount, expectedBaseAmount, internalPartyPayload, statement, proofs, linkingProofs
+        );
+    }
+
+    // --- Sell Side Tests (External Party Sells Base) --- //
+
+    /// @notice Test connector with external party on sell side (sells base, buys quote)
+    /// @dev External party inputs base amount, connector calculates quote amount
+    function test_sponsorMalleableMatch_externalPartySellSide() public {
+        // Setup the malleable match with external party sell side
+        (
+            uint256 baseAmount,
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = setupMalleableMatch(ExternalMatchDirection.InternalPartyBuy);
+
+        // Input amount is base amount for sell side
+        uint256 expectedBaseAmount = baseAmount;
+        uint256 expectedQuoteAmount = statement.matchResult.price.unsafeFixedPointMul(baseAmount);
+        uint256 inputAmount = expectedBaseAmount;
+
+        // Execute and verify
+        executeMalleableMatchSponsorship(
+            inputAmount, expectedQuoteAmount, expectedBaseAmount, internalPartyPayload, statement, proofs, linkingProofs
+        );
+    }
+
+    // --- Calculation Verification Tests --- //
+
+    /// @notice Test that connector calculations match expected formulas for buy side
+    function test_connectorCalculations_buySide() public {
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleMalleableAtomicMatchCalldata(ExternalMatchDirection.InternalPartySell, merkleRoot);
+
+        statement.matchResult.quoteMint = address(quoteToken);
+        statement.matchResult.baseMint = address(baseToken);
+
+        // Pick a quote amount in the middle of the range
+        uint256 minBase = statement.matchResult.minBaseAmount;
+        uint256 maxBase = statement.matchResult.maxBaseAmount;
+        uint256 targetBase = (minBase + maxBase) / 2;
+        uint256 inputQuote = statement.matchResult.price.unsafeFixedPointMul(targetBase);
+
+        // Calculate what the connector should produce
+        uint256 expectedBase = FixedPointLib.divIntegerByFixedPoint(inputQuote, statement.matchResult.price);
+
+        // Verify the calculation is correct (should equal our target within rounding)
+        uint256 diff = targetBase > expectedBase ? targetBase - expectedBase : expectedBase - targetBase;
+        assertLt(diff, 10, "Base amount calculation should be close to target");
+    }
+
+    /// @notice Test that connector calculations match expected formulas for sell side
+    function test_connectorCalculations_sellSide() public {
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        ) = settleMalleableAtomicMatchCalldata(ExternalMatchDirection.InternalPartyBuy, merkleRoot);
+
+        statement.matchResult.quoteMint = address(quoteToken);
+        statement.matchResult.baseMint = address(baseToken);
+
+        // Pick a base amount in the middle of the range
+        uint256 minBase = statement.matchResult.minBaseAmount;
+        uint256 maxBase = statement.matchResult.maxBaseAmount;
+        uint256 inputBase = (minBase + maxBase) / 2;
+
+        // Calculate what the connector should produce
+        uint256 expectedQuote = statement.matchResult.price.unsafeFixedPointMul(inputBase);
+
+        // Verify calculation is consistent with price * base (allow 1 unit difference for rounding)
+        FixedPoint memory backCalculatedPrice = FixedPointLib.divIntegers(expectedQuote, inputBase);
+        uint256 priceDiff = backCalculatedPrice.repr > statement.matchResult.price.repr
+            ? backCalculatedPrice.repr - statement.matchResult.price.repr
+            : statement.matchResult.price.repr - backCalculatedPrice.repr;
+        assertLe(priceDiff, 1, "Price calculation should be consistent within rounding");
+    }
+
+    // --- Helper Functions --- //
+
+    /// @notice Sample a random base amount between the bounds
+    function sampleBaseAmount(BoundedMatchResult memory matchResult) internal returns (uint256) {
+        uint256 min = matchResult.minBaseAmount;
+        uint256 max = matchResult.maxBaseAmount;
+        return min + (randomFelt() % (max - min + 1));
+    }
+
+    /// @notice Set up a malleable match and return an input amount
+    function setupMalleableMatch(ExternalMatchDirection direction)
+        internal
+        returns (
+            uint256 baseAmount,
+            PartyMatchPayload memory internalPartyPayload,
+            ValidMalleableMatchSettleAtomicStatement memory statement,
+            MalleableMatchAtomicProofs memory proofs,
+            MatchAtomicLinkingProofs memory linkingProofs
+        )
+    {
+        // Setup calldata
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot();
+        (internalPartyPayload, statement, proofs, linkingProofs) =
+            settleMalleableAtomicMatchCalldata(direction, merkleRoot);
+
+        // Modify token addresses
+        statement.matchResult.quoteMint = address(quoteToken);
+        statement.matchResult.baseMint = address(baseToken);
+
+        // Sample a base amount
+        baseAmount = sampleBaseAmount(statement.matchResult);
+    }
+
+    /// @notice Create gas sponsorship parameters
+    function createSponsorshipParams() internal returns (SponsorshipParams memory) {
+        SponsorshipParams memory params;
+        params.nonce = randomUint();
+        params.refundAddress = receiver;
+        params.refundNativeEth = false;
+        params.signature = signGasSponsorshipPayload(params.nonce, params.refundAddress, REFUND_AMT);
+        return params;
+    }
+
+    /// @notice Fund and approve tokens for the external party
+    function fundAndApprove(ExternalMatchDirection direction, uint256 quoteAmount, uint256 baseAmount) internal {
+        if (direction == ExternalMatchDirection.InternalPartySell) {
+            // External party buys base, sells quote
+            quoteToken.mint(externalPartyAddr, quoteAmount);
+            baseToken.mint(address(darkpool), baseAmount);
+            vm.startBroadcast(externalPartyAddr);
+            quoteToken.approve(address(connector), quoteAmount);
+            vm.stopBroadcast();
+        } else {
+            // External party sells base, buys quote
+            baseToken.mint(externalPartyAddr, baseAmount);
+            quoteToken.mint(address(darkpool), quoteAmount);
+            vm.startBroadcast(externalPartyAddr);
+            baseToken.approve(address(connector), baseAmount);
+            vm.stopBroadcast();
+        }
+    }
+
+    /// @notice Execute a malleable match sponsorship and verify results
+    function executeMalleableMatchSponsorship(
+        uint256 inputAmount,
+        uint256 expectedQuoteAmount,
+        uint256 expectedBaseAmount,
+        PartyMatchPayload memory internalPartyPayload,
+        ValidMalleableMatchSettleAtomicStatement memory statement,
+        MalleableMatchAtomicProofs memory proofs,
+        MatchAtomicLinkingProofs memory linkingProofs
+    )
+        internal
+    {
+        // Get balances before and fund the external party
+        (uint256 receiverBase1, uint256 receiverQuote1) = baseQuoteBalances(receiver);
+        fundAndApprove(statement.matchResult.direction, expectedQuoteAmount, expectedBaseAmount);
+
+        // Execute through connector
+        vm.startBroadcast(externalPartyAddr);
+        SponsorshipParams memory params = createSponsorshipParams();
+        uint256 receivedAmount = connector.executeMalleableAtomicMatchWithInput(
+            inputAmount,
+            receiver,
+            internalPartyPayload,
+            statement,
+            proofs,
+            linkingProofs,
+            params.refundAddress,
+            params.refundNativeEth,
+            REFUND_AMT,
+            params.nonce,
+            params.signature
+        );
+        vm.stopBroadcast();
+
+        // Get balances after
+        (uint256 receiverBase2, uint256 receiverQuote2) = baseQuoteBalances(receiver);
+
+        // Build match result for verification
+        ExternalMatchResult memory matchResult =
+            TypesLib.buildExternalMatchResult(expectedQuoteAmount, expectedBaseAmount, statement.matchResult);
+
+        // Calculate fees
+        (, uint256 tradeRecv) = matchResult.externalPartyBuyMintAmount();
+        FeeTake memory fees = statement.externalFeeRates.computeFeeTake(tradeRecv);
+
+        // Verify received amount (allow ±1 for rounding)
+        uint256 expectedTotalReceived = tradeRecv + REFUND_AMT - fees.total();
+        assertApproxEqAbs(receivedAmount, expectedTotalReceived, 1, "Received amount incorrect");
+
+        // Verify token balances (allow ±1 for rounding)
+        bool receivingBase = matchResult.direction == ExternalMatchDirection.InternalPartySell;
+        if (receivingBase) {
+            uint256 expectedBase = receiverBase1 + expectedTotalReceived;
+            assertApproxEqAbs(receiverBase2, expectedBase, 1, "Receiver base balance incorrect");
+            assertEq(receiverQuote2, receiverQuote1, "Receiver quote balance should not change");
+        } else {
+            uint256 expectedQuote = receiverQuote1 + expectedTotalReceived;
+            assertApproxEqAbs(receiverBase2, receiverBase1, 1, "Receiver base balance should not change");
+            assertApproxEqAbs(receiverQuote2, expectedQuote, 1, "Receiver quote balance incorrect");
+        }
+    }
+}

--- a/test/connectors/UniswapXExecutor.t.sol
+++ b/test/connectors/UniswapXExecutor.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.27;
 
-import { DarkpoolExecutor } from "darkpoolv1-executor/DarkpoolExecutor.sol";
+import { DarkpoolUniswapExecutor } from "renegade-connectors/DarkpoolUniswapExecutor.sol";
 import { Vm } from "forge-std/Vm.sol";
 import { UniswapXExecutorProxy } from "darkpoolv1-proxies/UniswapXExecutorProxy.sol";
-import { IDarkpoolExecutor } from "darkpoolv1-interfaces/IDarkpoolExecutor.sol";
+import { IDarkpoolUniswapExecutor } from "darkpoolv1-interfaces/IDarkpoolUniswapExecutor.sol";
 import { IReactorCallback } from "uniswapx/interfaces/IReactorCallback.sol";
 import { ResolvedOrder, SignedOrder } from "uniswapx/base/ReactorStructs.sol";
 import { ERC20 } from "solmate/src/tokens/ERC20.sol";
@@ -37,10 +37,10 @@ import { ISignatureTransfer } from "permit2/src/interfaces/ISignatureTransfer.so
 import { TypesLib } from "darkpoolv1-types/TypesLib.sol";
 import { FeeTake } from "darkpoolv1-types/Fees.sol";
 
-/// @title DarkpoolExecutorTest
-/// @notice Test contract for the DarkpoolExecutor
-/// @dev This contract tests the DarkpoolExecutor contract
-contract DarkpoolExecutorTest is DarkpoolTestBase, PermitSignature {
+/// @title DarkpoolUniswapExecutorTest
+/// @notice Test contract for the DarkpoolUniswapExecutor
+/// @dev This contract tests the DarkpoolUniswapExecutor contract
+contract DarkpoolUniswapExecutorTest is DarkpoolTestBase, PermitSignature {
     using Permit2Lib for ResolvedOrder;
     using PriorityOrderLib for PriorityOrder;
     using PriorityFeeLib for PriorityInput;
@@ -49,7 +49,7 @@ contract DarkpoolExecutorTest is DarkpoolTestBase, PermitSignature {
     using TypesLib for FeeTake;
 
     PriorityOrderReactor reactor;
-    IDarkpoolExecutor executor;
+    IDarkpoolUniswapExecutor executor;
 
     /// @notice Sets up the test environment
     /// @dev For now we test against a `PriorityOrderReactor`, which is the flavor deployed on Base
@@ -62,10 +62,10 @@ contract DarkpoolExecutorTest is DarkpoolTestBase, PermitSignature {
         reactor = new PriorityOrderReactor(permit2, protocolFeeOwner);
 
         // Initialize the UniswapXExecutorProxy
-        DarkpoolExecutor executorImpl = new DarkpoolExecutor();
+        DarkpoolUniswapExecutor executorImpl = new DarkpoolUniswapExecutor();
         UniswapXExecutorProxy executorProxy =
             new UniswapXExecutorProxy(address(executorImpl), darkpoolOwner, address(darkpool), address(reactor));
-        executor = IDarkpoolExecutor(address(executorProxy));
+        executor = IDarkpoolUniswapExecutor(address(executorProxy));
 
         // Whitelist this test contract as a solver for execution tests
         vm.prank(darkpoolOwner);
@@ -86,7 +86,7 @@ contract DarkpoolExecutorTest is DarkpoolTestBase, PermitSignature {
 
         ResolvedOrder[] memory resolvedOrders = new ResolvedOrder[](0);
 
-        vm.expectRevert(DarkpoolExecutor.UnauthorizedCaller.selector);
+        vm.expectRevert(DarkpoolUniswapExecutor.UnauthorizedCaller.selector);
         IReactorCallback(address(executor)).reactorCallback(resolvedOrders, callbackData);
     }
 

--- a/test/darkpool/v2/Deposit.t.sol
+++ b/test/darkpool/v2/Deposit.t.sol
@@ -11,9 +11,7 @@ import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { DarkpoolV2TestUtils } from "./DarkpoolV2TestUtils.sol";
 import { DepositProofBundle, NewBalanceDepositProofBundle } from "darkpoolv2-types/ProofBundles.sol";
 import { MerkleMountainLib } from "renegade-lib/merkle/MerkleMountain.sol";
-import {
-    Deposit, DepositAuth, DepositWitness, DEPOSIT_WITNESS_TYPE_STRING
-} from "darkpoolv2-types/transfers/Deposit.sol";
+import { Deposit, DepositAuth, DEPOSIT_WITNESS_TYPE_STRING } from "darkpoolv2-types/transfers/Deposit.sol";
 import {
     ExistingBalanceDepositValidityStatement,
     NewBalanceDepositValidityStatement

--- a/test/darkpool/v2/FeePayment.t.sol
+++ b/test/darkpool/v2/FeePayment.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { Vm } from "forge-std/Vm.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";


### PR DESCRIPTION
### Purpose
This PR adds a connector to the contracts repo which exposes a simpler interface over malleable matches. In particular, it accepts an `inputAmount` rather than a base and quote amount. This means that the calling contract need only modify their input amount.

### Testing
- [x] Unit tests pass