### PR TITLE
darkpoolv2: Move merkle depth off of statements

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -191,7 +191,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         TransferLib.executePermit2SignatureDeposit(depositInfo, newBalanceCommitment, auth, permit2);
 
         // 3. Update the state; nullify the previous balance and insert the new balance
-        uint256 merkleDepth = depositProofBundle.statement.merkleDepth;
+        uint256 merkleDepth = depositProofBundle.merkleDepth;
         BN254.ScalarField balanceNullifier = depositProofBundle.statement.balanceNullifier;
         _state.spendNullifier(balanceNullifier);
         _state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
@@ -214,7 +214,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         TransferLib.executePermit2SignatureDeposit(depositInfo, newBalanceCommitment, auth, permit2);
 
         // 3. Update the state; nullify the previous balance and insert the new balance
-        uint256 merkleDepth = newBalanceProofBundle.statement.merkleDepth;
+        uint256 merkleDepth = newBalanceProofBundle.merkleDepth;
         _state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
     }
 
@@ -232,7 +232,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         TransferLib.executeSignedWithdrawal(newBalanceCommitment, auth, withdrawal);
 
         // 3. Update the state; nullify the previous balance and insert the new balance
-        uint256 merkleDepth = withdrawalProofBundle.statement.merkleDepth;
+        uint256 merkleDepth = withdrawalProofBundle.merkleDepth;
         BN254.ScalarField balanceNullifier = withdrawalProofBundle.statement.balanceNullifier;
         _state.spendNullifier(balanceNullifier);
         _state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
@@ -247,7 +247,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         if (!valid) revert FeePaymentVerificationFailed();
 
         // Update the state; nullify the previous balance and commit to the new balance and the note
-        uint256 merkleDepth = feePaymentProofBundle.statement.merkleDepth;
+        uint256 merkleDepth = feePaymentProofBundle.merkleDepth;
         BN254.ScalarField balanceNullifier = feePaymentProofBundle.statement.balanceNullifier;
         BN254.ScalarField newBalanceCommitment = feePaymentProofBundle.statement.newBalanceCommitment;
         BN254.ScalarField noteCommitment = feePaymentProofBundle.statement.noteCommitment;

--- a/src/darkpool/v2/libraries/PublicInputs.sol
+++ b/src/darkpool/v2/libraries/PublicInputs.sol
@@ -16,8 +16,6 @@ import { Withdrawal } from "darkpoolv2-types/transfers/Withdrawal.sol";
 
 /// @notice A statement proving validity of a deposit into an existing balance
 struct ExistingBalanceDepositValidityStatement {
-    /// @dev The Merkle depth of the balance
-    uint256 merkleDepth;
     /// @dev The deposit to execute
     Deposit deposit;
     /// @dev The nullifier of the previous version of the balance
@@ -32,8 +30,6 @@ struct ExistingBalanceDepositValidityStatement {
 
 /// @notice A statement proving validity of a deposit into a new balance
 struct NewBalanceDepositValidityStatement {
-    /// @dev The Merkle depth of the balance
-    uint256 merkleDepth;
     /// @dev The deposit to execute
     Deposit deposit;
     /// @dev A commitment to the updated balance
@@ -48,8 +44,6 @@ struct NewBalanceDepositValidityStatement {
 
 /// @notice A statement proving validity of a withdrawal from a balance
 struct WithdrawalValidityStatement {
-    /// @dev The Merkle depth of the balance
-    uint256 merkleDepth;
     /// @dev The withdrawal to execute
     Withdrawal withdrawal;
     /// @dev The nullifier of the previous version of the balance
@@ -67,8 +61,6 @@ struct WithdrawalValidityStatement {
 /// @notice A statement proving validity of a fee payment
 /// TODO: Add note ciphertext here
 struct FeePaymentValidityStatement {
-    /// @dev The Merkle depth at which to re-commit the balance
-    uint256 merkleDepth;
     /// @dev The nullifier of the previous version of the balance
     BN254.ScalarField balanceNullifier;
     /// @dev The commitment to the updated balance after the fee payment

--- a/src/darkpool/v2/types/ProofBundles.sol
+++ b/src/darkpool/v2/types/ProofBundles.sol
@@ -15,6 +15,8 @@ import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
 /// @notice A bundle of proofs for a deposit
 struct DepositProofBundle {
+    /// @dev The Merkle depth of the balance
+    uint256 merkleDepth;
     /// @dev The statement of the deposit validity
     ExistingBalanceDepositValidityStatement statement;
     /// @dev The proof of the deposit validity
@@ -23,6 +25,8 @@ struct DepositProofBundle {
 
 /// @notice A bundle of proofs for _new_ balance deposit validity
 struct NewBalanceDepositProofBundle {
+    /// @dev The Merkle depth of the balance
+    uint256 merkleDepth;
     /// @dev The statement of the new balance deposit validity
     NewBalanceDepositValidityStatement statement;
     /// @dev The proof of the new balance deposit validity
@@ -31,6 +35,8 @@ struct NewBalanceDepositProofBundle {
 
 /// @notice A bundle of proofs for a withdrawal validity
 struct WithdrawalProofBundle {
+    /// @dev The Merkle depth of the balance
+    uint256 merkleDepth;
     /// @dev The statement of the withdrawal validity
     WithdrawalValidityStatement statement;
     /// @dev The proof of the withdrawal validity
@@ -39,6 +45,8 @@ struct WithdrawalProofBundle {
 
 /// @notice A bundle of proofs for a fee payment validity
 struct FeePaymentProofBundle {
+    /// @dev The Merkle depth at which to re-commit the balance
+    uint256 merkleDepth;
     /// @dev The statement of the fee payment validity
     FeePaymentValidityStatement statement;
     /// @dev The proof of the fee payment validity

--- a/test/darkpool/v2/Deposit.t.sol
+++ b/test/darkpool/v2/Deposit.t.sol
@@ -142,14 +142,13 @@ contract DepositTest is DarkpoolV2TestUtils {
         BN254.ScalarField newAmountPublicShare = randomScalar();
         uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
         ExistingBalanceDepositValidityStatement memory statement = ExistingBalanceDepositValidityStatement({
-            merkleDepth: merkleDepth,
             deposit: deposit,
             balanceNullifier: balanceNullifier,
             newBalanceCommitment: newBalanceCommitment,
             newAmountPublicShare: newAmountPublicShare
         });
 
-        return DepositProofBundle({ statement: statement, proof: createDummyProof() });
+        return DepositProofBundle({ merkleDepth: merkleDepth, statement: statement, proof: createDummyProof() });
     }
 
     /// @notice Capitalize the depositor's balance
@@ -191,13 +190,13 @@ contract DepositTest is DarkpoolV2TestUtils {
         }
 
         NewBalanceDepositValidityStatement memory statement = NewBalanceDepositValidityStatement({
-            merkleDepth: merkleDepth,
             deposit: deposit,
             newBalanceCommitment: newBalanceCommitment,
             newBalancePublicShares: newBalancePublicShares
         });
 
-        return NewBalanceDepositProofBundle({ statement: statement, proof: createDummyProof() });
+        return
+            NewBalanceDepositProofBundle({ merkleDepth: merkleDepth, statement: statement, proof: createDummyProof() });
     }
 
     // ----------------------------------
@@ -239,7 +238,7 @@ contract DepositTest is DarkpoolV2TestUtils {
 
         // Check that the Merkle root is in the history
         // Build a parallel merkle tree with the same operation
-        uint256 depth = proofBundle.statement.merkleDepth;
+        uint256 depth = proofBundle.merkleDepth;
         testMountain.insertLeaf(depth, proofBundle.statement.newBalanceCommitment, hasher);
         BN254.ScalarField root = testMountain.getRoot(depth);
 
@@ -341,7 +340,7 @@ contract DepositTest is DarkpoolV2TestUtils {
 
         // Check that the Merkle root is in the history
         // Build a parallel merkle tree with the same operation
-        uint256 depth = proofBundle.statement.merkleDepth;
+        uint256 depth = proofBundle.merkleDepth;
         testMountain.insertLeaf(depth, proofBundle.statement.newBalanceCommitment, hasher);
         BN254.ScalarField root = testMountain.getRoot(depth);
 

--- a/test/darkpool/v2/FeePayment.t.sol
+++ b/test/darkpool/v2/FeePayment.t.sol
@@ -41,14 +41,13 @@ contract FeePaymentTest is DarkpoolV2TestUtils {
         BN254.ScalarField[3] memory newBalancePublicShares = [randomScalar(), randomScalar(), randomScalar()];
 
         FeePaymentValidityStatement memory statement = FeePaymentValidityStatement({
-            merkleDepth: merkleDepth,
             balanceNullifier: balanceNullifier,
             newBalanceCommitment: newBalanceCommitment,
             noteCommitment: noteCommitment,
             newBalancePublicShares: newBalancePublicShares
         });
 
-        return FeePaymentProofBundle({ statement: statement, proof: createDummyProof() });
+        return FeePaymentProofBundle({ merkleDepth: merkleDepth, statement: statement, proof: createDummyProof() });
     }
 
     // ---------
@@ -73,7 +72,7 @@ contract FeePaymentTest is DarkpoolV2TestUtils {
 
         // Check that the Merkle root is in the history
         // Build a parallel merkle tree with the same operations
-        uint256 depth = proofBundle.statement.merkleDepth;
+        uint256 depth = proofBundle.merkleDepth;
         testMountain.insertLeaf(depth, proofBundle.statement.newBalanceCommitment, hasher);
         testMountain.insertLeaf(depth, proofBundle.statement.noteCommitment, hasher);
         BN254.ScalarField root = testMountain.getRoot(depth);

--- a/test/darkpool/v2/Withdrawal.t.sol
+++ b/test/darkpool/v2/Withdrawal.t.sol
@@ -84,14 +84,13 @@ contract WithdrawalTest is DarkpoolV2TestUtils {
         uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
 
         WithdrawalValidityStatement memory statement = WithdrawalValidityStatement({
-            merkleDepth: merkleDepth,
             withdrawal: withdrawal,
             balanceNullifier: balanceNullifier,
             newBalanceCommitment: newBalanceCommitment,
             newAmountPublicShare: newAmountPublicShare
         });
 
-        return WithdrawalProofBundle({ statement: statement, proof: createDummyProof() });
+        return WithdrawalProofBundle({ merkleDepth: merkleDepth, statement: statement, proof: createDummyProof() });
     }
 
     /// @notice Capitalize the darkpool's balance so it can fulfill withdrawals
@@ -138,7 +137,7 @@ contract WithdrawalTest is DarkpoolV2TestUtils {
 
         // Check that the Merkle root is in the history
         // Build a parallel merkle tree with the same operation
-        uint256 depth = proofBundle.statement.merkleDepth;
+        uint256 depth = proofBundle.merkleDepth;
         testMountain.insertLeaf(depth, proofBundle.statement.newBalanceCommitment, hasher);
         BN254.ScalarField root = testMountain.getRoot(depth);
 


### PR DESCRIPTION
### Purpose
This PR moves the Merkle depth off of the statement types and onto proof bundle types. This is more faithful to the in-circuit statement types.

### Testing
- [x] Unit tests pass