### PR TITLE
darkpoolv2: interface: IDarkpoolV2: Add `RecoveryIdRegistered` event

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -998,6 +998,19 @@
     "anonymous": false
   },
   {
+    "type": "event",
+    "name": "RecoveryIdRegistered",
+    "inputs": [
+      {
+        "name": "recoveryId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "BN254.ScalarField"
+      }
+    ],
+    "anonymous": false
+  },
+  {
     "type": "function",
     "name": "batchVerify",
     "inputs": [

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -38,6 +38,9 @@ interface IDarkpoolV2 {
     /// @notice Emitted when a nullifier is spent
     /// @param nullifier The nullifier that was spent
     event NullifierSpent(BN254.ScalarField nullifier);
+    /// @notice Emitted when a new recovery ID is registered on-chain
+    /// @param recoveryId The recovery ID that was registered
+    event RecoveryIdRegistered(BN254.ScalarField indexed recoveryId);
 
     /// @notice Initialize the darkpool contract
     /// @param initialOwner The initial owner of the contract


### PR DESCRIPTION
### Purpose
This PR adds a `RecoveryIdRegistered` event to the `IDarkpoolV2` ABI and re-generates the `abi` crate's JSON source. 