### PR TITLE
darkpoolv2: SettlementLib: Validate `SettlementObligation` bitlengths

### DIFF
--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -5,16 +5,29 @@ pragma solidity ^0.8.24;
 /// @author Renegade Eng
 /// @notice This library contains constants for the darkpool
 library DarkpoolConstants {
+    /// @notice Error thrown when an amount is invalid
+    error AmountTooLarge(uint256 amount);
+
     /// @notice The address used for native tokens in trade settlement
     /// @dev This is currently just ETH, but intentionally written abstractly
     address internal constant NATIVE_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     /// @notice The default depth Merkle tree to insert state elements into
     uint256 internal constant DEFAULT_MERKLE_DEPTH = 10;
+    /// @notice The maximum bitlength of an amount in the darkpool
+    uint256 internal constant AMOUNT_BITS = 100;
 
     /// @notice Check whether an address is the native token address
     /// @param addr The address to check
     /// @return True if the address is the native token address, false otherwise
     function isNativeToken(address addr) public pure returns (bool) {
         return addr == NATIVE_TOKEN_ADDRESS;
+    }
+
+    /// @notice Check whether an amount is valid
+    /// @param amount The amount to check
+    function validateAmount(uint256 amount) public pure {
+        if (amount > 2 ** AMOUNT_BITS - 1) {
+            revert AmountTooLarge(amount);
+        }
     }
 }

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -6,6 +6,7 @@ import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { IPermit2 } from "permit2-lib/interfaces/IPermit2.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 
 import {
     PartyId,
@@ -123,6 +124,11 @@ library SettlementLib {
         if (!amountCompatible) {
             revert IncompatibleAmounts();
         }
+
+        // 3. The input and output amounts must be valid
+        // We only need to validate the input and output of one party as the checks above ensure they're symmetric
+        DarkpoolConstants.validateAmount(obligation0.amountIn);
+        DarkpoolConstants.validateAmount(obligation0.amountOut);
     }
 
     /// @notice Validate a private obligation bundle


### PR DESCRIPTION
### Purpose
This PR validates that the amounts on the `SettlementObligation` type are in the valid amount range of $[0, 2^{100}]$ for public obligations. This removes the need for the circuits to validate this condition--where it is much more expensive.

### Testing
- [x] Added a test for invalid amounts.
- [x] All tests pass.