### PR TITLE
darkpoolv2: interfaces: ISettlementTypes: Add settlement types interface

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -3099,5 +3099,6170 @@
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "exposeObligationBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ObligationBundle",
+        "components": [
+          {
+            "name": "obligationType",
+            "type": "uint8",
+            "internalType": "enum ObligationType"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ObligationBundle",
+        "components": [
+          {
+            "name": "obligationType",
+            "type": "uint8",
+            "internalType": "enum ObligationType"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeObligationType",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum ObligationType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum ObligationType"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePartyId",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum PartyId"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum PartyId"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePrivateIntentAuthBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentAuthBundle",
+        "components": [
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentOnlyValidityStatement",
+            "components": [
+              {
+                "name": "intentOwner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "nullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentAuthBundle",
+        "components": [
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentOnlyValidityStatement",
+            "components": [
+              {
+                "name": "intentOwner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "nullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePrivateIntentAuthBundleFirstFill",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentAuthBundleFirstFill",
+        "components": [
+          {
+            "name": "intentSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentOnlyValidityStatementFirstFill",
+            "components": [
+              {
+                "name": "intentOwner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "initialIntentCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentAuthBundleFirstFill",
+        "components": [
+          {
+            "name": "intentSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentOnlyValidityStatementFirstFill",
+            "components": [
+              {
+                "name": "intentOwner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "initialIntentCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePrivateIntentPublicBalanceBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentPublicBalanceBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct PrivateIntentAuthBundle",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentOnlyValidityStatement",
+                "components": [
+                  {
+                    "name": "intentOwner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "nullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct SingleIntentMatchSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentPublicBalanceBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct PrivateIntentAuthBundle",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentOnlyValidityStatement",
+                "components": [
+                  {
+                    "name": "intentOwner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "nullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct SingleIntentMatchSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePrivateIntentPublicBalanceFirstFillBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentPublicBalanceFirstFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct PrivateIntentAuthBundleFirstFill",
+            "components": [
+              {
+                "name": "intentSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentOnlyValidityStatementFirstFill",
+                "components": [
+                  {
+                    "name": "intentOwner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "initialIntentCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct SingleIntentMatchSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateIntentPublicBalanceFirstFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct PrivateIntentAuthBundleFirstFill",
+            "components": [
+              {
+                "name": "intentSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentOnlyValidityStatementFirstFill",
+                "components": [
+                  {
+                    "name": "intentOwner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "initialIntentCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct SingleIntentMatchSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePrivateObligationBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateObligationBundle",
+        "components": [
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledPrivateFillSettlementStatement",
+            "components": [
+              {
+                "name": "party0NewIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "party0NewBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              },
+              {
+                "name": "party1NewIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "party1NewBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              }
+            ]
+          },
+          {
+            "name": "proof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PrivateObligationBundle",
+        "components": [
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledPrivateFillSettlementStatement",
+            "components": [
+              {
+                "name": "party0NewIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "party0NewBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              },
+              {
+                "name": "party1NewIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "party1NewBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              }
+            ]
+          },
+          {
+            "name": "proof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePublicIntentAuthBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PublicIntentAuthBundle",
+        "components": [
+          {
+            "name": "permit",
+            "type": "tuple",
+            "internalType": "struct PublicIntentPermit",
+            "components": [
+              {
+                "name": "intent",
+                "type": "tuple",
+                "internalType": "struct Intent",
+                "components": [
+                  {
+                    "name": "inToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "owner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "minPrice",
+                    "type": "tuple",
+                    "internalType": "struct FixedPoint",
+                    "components": [
+                      {
+                        "name": "repr",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "executor",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "intentSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "executorSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PublicIntentAuthBundle",
+        "components": [
+          {
+            "name": "permit",
+            "type": "tuple",
+            "internalType": "struct PublicIntentPermit",
+            "components": [
+              {
+                "name": "intent",
+                "type": "tuple",
+                "internalType": "struct Intent",
+                "components": [
+                  {
+                    "name": "inToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "owner",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "minPrice",
+                    "type": "tuple",
+                    "internalType": "struct FixedPoint",
+                    "components": [
+                      {
+                        "name": "repr",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "executor",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "intentSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "executorSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePublicIntentPermit",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PublicIntentPermit",
+        "components": [
+          {
+            "name": "intent",
+            "type": "tuple",
+            "internalType": "struct Intent",
+            "components": [
+              {
+                "name": "inToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "outToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "minPrice",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "amountIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "executor",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PublicIntentPermit",
+        "components": [
+          {
+            "name": "intent",
+            "type": "tuple",
+            "internalType": "struct Intent",
+            "components": [
+              {
+                "name": "inToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "outToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "minPrice",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "amountIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "executor",
+            "type": "address",
+            "internalType": "address"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposePublicIntentPublicBalanceBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PublicIntentPublicBalanceBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct PublicIntentAuthBundle",
+            "components": [
+              {
+                "name": "permit",
+                "type": "tuple",
+                "internalType": "struct PublicIntentPermit",
+                "components": [
+                  {
+                    "name": "intent",
+                    "type": "tuple",
+                    "internalType": "struct Intent",
+                    "components": [
+                      {
+                        "name": "inToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "outToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "owner",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "minPrice",
+                        "type": "tuple",
+                        "internalType": "struct FixedPoint",
+                        "components": [
+                          {
+                            "name": "repr",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "amountIn",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "executor",
+                    "type": "address",
+                    "internalType": "address"
+                  }
+                ]
+              },
+              {
+                "name": "intentSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "executorSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct PublicIntentPublicBalanceBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct PublicIntentAuthBundle",
+            "components": [
+              {
+                "name": "permit",
+                "type": "tuple",
+                "internalType": "struct PublicIntentPermit",
+                "components": [
+                  {
+                    "name": "intent",
+                    "type": "tuple",
+                    "internalType": "struct Intent",
+                    "components": [
+                      {
+                        "name": "inToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "outToken",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "owner",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "minPrice",
+                        "type": "tuple",
+                        "internalType": "struct FixedPoint",
+                        "components": [
+                          {
+                            "name": "repr",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "amountIn",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "executor",
+                    "type": "address",
+                    "internalType": "address"
+                  }
+                ]
+              },
+              {
+                "name": "intentSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "executorSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeRenegadeSettledIntentAuthBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentAuthBundle",
+        "components": [
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentAndBalanceValidityStatement",
+            "components": [
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balancePartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "intentNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balanceNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentAuthBundle",
+        "components": [
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentAndBalanceValidityStatement",
+            "components": [
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balancePartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "intentNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balanceNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeRenegadeSettledIntentAuthBundleFirstFill",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentAuthBundleFirstFill",
+        "components": [
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ownerSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentAndBalanceValidityStatementFirstFill",
+            "components": [
+              {
+                "name": "oneTimeAuthorizingAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "newOneTimeKeyHash",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "initialIntentCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balancePartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balanceNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentAuthBundleFirstFill",
+        "components": [
+          {
+            "name": "merkleDepth",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ownerSignature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "statement",
+            "type": "tuple",
+            "internalType": "struct IntentAndBalanceValidityStatementFirstFill",
+            "components": [
+              {
+                "name": "oneTimeAuthorizingAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "newOneTimeKeyHash",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "initialIntentCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newIntentPartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balancePartialCommitment",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "balanceNullifier",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "validityProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeRenegadeSettledIntentBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundle",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatement",
+                "components": [
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "intentNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledPrivateIntentPublicSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundle",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatement",
+                "components": [
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "intentNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledPrivateIntentPublicSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeRenegadeSettledIntentFirstFillBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentFirstFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundleFirstFill",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "ownerSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatementFirstFill",
+                "components": [
+                  {
+                    "name": "oneTimeAuthorizingAddress",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "newOneTimeKeyHash",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "initialIntentCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledPrivateIntentPublicSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledIntentFirstFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundleFirstFill",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "ownerSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatementFirstFill",
+                "components": [
+                  {
+                    "name": "oneTimeAuthorizingAddress",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "newOneTimeKeyHash",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "initialIntentCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementStatement",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledPrivateIntentPublicSettlementStatement",
+            "components": [
+              {
+                "name": "newIntentAmountPublicShare",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              },
+              {
+                "name": "newBalancePublicShares",
+                "type": "uint256[3]",
+                "internalType": "BN254.ScalarField[3]"
+              },
+              {
+                "name": "obligation",
+                "type": "tuple",
+                "internalType": "struct SettlementObligation",
+                "components": [
+                  {
+                    "name": "inputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "outputToken",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "amountIn",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "amountOut",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "settlementProof",
+            "type": "tuple",
+            "internalType": "struct PlonkProof",
+            "components": [
+              {
+                "name": "wireComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "zComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "quotientComms",
+                "type": "tuple[5]",
+                "internalType": "struct BN254.G1Point[5]",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZeta",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wZetaOmega",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "wireEvals",
+                "type": "uint256[5]",
+                "internalType": "BN254.ScalarField[5]"
+              },
+              {
+                "name": "sigmaEvals",
+                "type": "uint256[4]",
+                "internalType": "BN254.ScalarField[4]"
+              },
+              {
+                "name": "zBar",
+                "type": "uint256",
+                "internalType": "BN254.ScalarField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeRenegadeSettledPrivateFillBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledPrivateFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundle",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatement",
+                "components": [
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "intentNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledPrivateFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundle",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatement",
+                "components": [
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "intentNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeRenegadeSettledPrivateFirstFillBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledPrivateFirstFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundleFirstFill",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "ownerSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatementFirstFill",
+                "components": [
+                  {
+                    "name": "oneTimeAuthorizingAddress",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "newOneTimeKeyHash",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "initialIntentCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct RenegadeSettledPrivateFirstFillBundle",
+        "components": [
+          {
+            "name": "auth",
+            "type": "tuple",
+            "internalType": "struct RenegadeSettledIntentAuthBundleFirstFill",
+            "components": [
+              {
+                "name": "merkleDepth",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "ownerSignature",
+                "type": "tuple",
+                "internalType": "struct SignatureWithNonce",
+                "components": [
+                  {
+                    "name": "nonce",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "statement",
+                "type": "tuple",
+                "internalType": "struct IntentAndBalanceValidityStatementFirstFill",
+                "components": [
+                  {
+                    "name": "oneTimeAuthorizingAddress",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "newOneTimeKeyHash",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "initialIntentCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "newIntentPartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balancePartialCommitment",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  },
+                  {
+                    "name": "balanceNullifier",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "validityProof",
+                "type": "tuple",
+                "internalType": "struct PlonkProof",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeSettlementBundle",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SettlementBundle",
+        "components": [
+          {
+            "name": "isFirstFill",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "bundleType",
+            "type": "uint8",
+            "internalType": "enum SettlementBundleType"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SettlementBundle",
+        "components": [
+          {
+            "name": "isFirstFill",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "bundleType",
+            "type": "uint8",
+            "internalType": "enum SettlementBundleType"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeSettlementBundleType",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum SettlementBundleType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum SettlementBundleType"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeSettlementContext",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SettlementContext",
+        "components": [
+          {
+            "name": "transfers",
+            "type": "tuple",
+            "internalType": "struct SettlementTransfers",
+            "components": [
+              {
+                "name": "deposits",
+                "type": "tuple",
+                "internalType": "struct SettlementTransfersList",
+                "components": [
+                  {
+                    "name": "transfers",
+                    "type": "tuple[]",
+                    "internalType": "struct SimpleTransfer[]",
+                    "components": [
+                      {
+                        "name": "account",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "mint",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "transferType",
+                        "type": "uint8",
+                        "internalType": "enum SimpleTransferType"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "nextIndex",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "withdrawals",
+                "type": "tuple",
+                "internalType": "struct SettlementTransfersList",
+                "components": [
+                  {
+                    "name": "transfers",
+                    "type": "tuple[]",
+                    "internalType": "struct SimpleTransfer[]",
+                    "components": [
+                      {
+                        "name": "account",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "mint",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "transferType",
+                        "type": "uint8",
+                        "internalType": "enum SimpleTransferType"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "nextIndex",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "verifications",
+            "type": "tuple",
+            "internalType": "struct VerificationList",
+            "components": [
+              {
+                "name": "nextIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "proofs",
+                "type": "tuple[]",
+                "internalType": "struct PlonkProof[]",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "publicInputs",
+                "type": "uint256[][]",
+                "internalType": "BN254.ScalarField[][]"
+              },
+              {
+                "name": "vks",
+                "type": "tuple[]",
+                "internalType": "struct VerificationKey[]",
+                "components": [
+                  {
+                    "name": "n",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "l",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "k",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "qComms",
+                    "type": "tuple[13]",
+                    "internalType": "struct BN254.G1Point[13]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "sigmaComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "g",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "h",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G2Point",
+                    "components": [
+                      {
+                        "name": "x0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "x1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "xH",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G2Point",
+                    "components": [
+                      {
+                        "name": "x0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "x1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SettlementContext",
+        "components": [
+          {
+            "name": "transfers",
+            "type": "tuple",
+            "internalType": "struct SettlementTransfers",
+            "components": [
+              {
+                "name": "deposits",
+                "type": "tuple",
+                "internalType": "struct SettlementTransfersList",
+                "components": [
+                  {
+                    "name": "transfers",
+                    "type": "tuple[]",
+                    "internalType": "struct SimpleTransfer[]",
+                    "components": [
+                      {
+                        "name": "account",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "mint",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "transferType",
+                        "type": "uint8",
+                        "internalType": "enum SimpleTransferType"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "nextIndex",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "withdrawals",
+                "type": "tuple",
+                "internalType": "struct SettlementTransfersList",
+                "components": [
+                  {
+                    "name": "transfers",
+                    "type": "tuple[]",
+                    "internalType": "struct SimpleTransfer[]",
+                    "components": [
+                      {
+                        "name": "account",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "mint",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "amount",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "transferType",
+                        "type": "uint8",
+                        "internalType": "enum SimpleTransferType"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "nextIndex",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "verifications",
+            "type": "tuple",
+            "internalType": "struct VerificationList",
+            "components": [
+              {
+                "name": "nextIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "proofs",
+                "type": "tuple[]",
+                "internalType": "struct PlonkProof[]",
+                "components": [
+                  {
+                    "name": "wireComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "zComm",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "quotientComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZeta",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wZetaOmega",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireEvals",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "sigmaEvals",
+                    "type": "uint256[4]",
+                    "internalType": "BN254.ScalarField[4]"
+                  },
+                  {
+                    "name": "zBar",
+                    "type": "uint256",
+                    "internalType": "BN254.ScalarField"
+                  }
+                ]
+              },
+              {
+                "name": "publicInputs",
+                "type": "uint256[][]",
+                "internalType": "BN254.ScalarField[][]"
+              },
+              {
+                "name": "vks",
+                "type": "tuple[]",
+                "internalType": "struct VerificationKey[]",
+                "components": [
+                  {
+                    "name": "n",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "l",
+                    "type": "uint64",
+                    "internalType": "uint64"
+                  },
+                  {
+                    "name": "k",
+                    "type": "uint256[5]",
+                    "internalType": "BN254.ScalarField[5]"
+                  },
+                  {
+                    "name": "qComms",
+                    "type": "tuple[13]",
+                    "internalType": "struct BN254.G1Point[13]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "sigmaComms",
+                    "type": "tuple[5]",
+                    "internalType": "struct BN254.G1Point[5]",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "g",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "h",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G2Point",
+                    "components": [
+                      {
+                        "name": "x0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "x1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "xH",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G2Point",
+                    "components": [
+                      {
+                        "name": "x0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "x1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y0",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y1",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "exposeSignatureWithNonce",
+    "inputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SignatureWithNonce",
+        "components": [
+          {
+            "name": "nonce",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct SignatureWithNonce",
+        "components": [
+          {
+            "name": "nonce",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "pure"
   }
 ]

--- a/abi/generate_abis.sh
+++ b/abi/generate_abis.sh
@@ -108,11 +108,14 @@ echo "Generating IVerifier ABI..."
 echo "Generating IVkeys ABI..."
 (cd "$PROJECT_ROOT" && forge inspect src/darkpool/v2/interfaces/IVkeys.sol:IVkeys abi --json) > IVkeys.json
 
+echo "Generating ISettlementTypes ABI..."
+(cd "$PROJECT_ROOT" && forge inspect src/darkpool/v2/interfaces/ISettlementTypes.sol:ISettlementTypes abi --json) > ISettlementTypes.json
+
 # Combine V2 ABIs
-combine_abis ICombinedV2.json IDarkpoolV2.json IVerifier.json IVkeys.json
+combine_abis ICombinedV2.json IDarkpoolV2.json IVerifier.json IVkeys.json ISettlementTypes.json
 
 # Clean up individual V2 ABI files
 echo "Cleaning up individual V2 ABI files..."
-rm IDarkpoolV2.json IVerifier.json IVkeys.json
+rm IDarkpoolV2.json IVerifier.json IVkeys.json ISettlementTypes.json
 
 echo "Done! Generated combined V2 ABI file: ICombinedV2.json" 

--- a/src/darkpool/v2/interfaces/ISettlementTypes.sol
+++ b/src/darkpool/v2/interfaces/ISettlementTypes.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/* solhint-disable func-named-parameters */
+/* solhint-disable use-natspec */
+
+import { SettlementBundle, SettlementBundleType, PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    PublicIntentPublicBalanceBundle,
+    PrivateIntentPublicBalanceFirstFillBundle,
+    PrivateIntentPublicBalanceBundle,
+    RenegadeSettledIntentFirstFillBundle,
+    RenegadeSettledIntentBundle,
+    RenegadeSettledPrivateFirstFillBundle,
+    RenegadeSettledPrivateFillBundle
+} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    PublicIntentAuthBundle,
+    PublicIntentPermit,
+    PrivateIntentAuthBundleFirstFill,
+    PrivateIntentAuthBundle,
+    RenegadeSettledIntentAuthBundleFirstFill,
+    RenegadeSettledIntentAuthBundle,
+    SignatureWithNonce
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import {
+    ObligationBundle, ObligationType, PrivateObligationBundle
+} from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+
+/// @title ISettlementTypes
+/// @author Renegade Eng
+/// @notice Interface exposing all settlement types for ABI generation
+/// @dev This interface is used solely for generating ABIs for Rust bindings.
+///      All functions are intentionally empty/unimplemented.
+interface ISettlementTypes {
+    // SettlementBundle types
+    function exposeSettlementBundle(SettlementBundle calldata) external pure returns (SettlementBundle memory);
+    function exposeSettlementBundleType(SettlementBundleType) external pure returns (SettlementBundleType);
+    function exposePartyId(PartyId) external pure returns (PartyId);
+
+    // Settlement bundle data types
+    function exposePublicIntentPublicBalanceBundle(PublicIntentPublicBalanceBundle calldata)
+        external
+        pure
+        returns (PublicIntentPublicBalanceBundle memory);
+    function exposePrivateIntentPublicBalanceFirstFillBundle(PrivateIntentPublicBalanceFirstFillBundle calldata)
+        external
+        pure
+        returns (PrivateIntentPublicBalanceFirstFillBundle memory);
+    function exposePrivateIntentPublicBalanceBundle(PrivateIntentPublicBalanceBundle calldata)
+        external
+        pure
+        returns (PrivateIntentPublicBalanceBundle memory);
+    function exposeRenegadeSettledIntentFirstFillBundle(RenegadeSettledIntentFirstFillBundle calldata)
+        external
+        pure
+        returns (RenegadeSettledIntentFirstFillBundle memory);
+    function exposeRenegadeSettledIntentBundle(RenegadeSettledIntentBundle calldata)
+        external
+        pure
+        returns (RenegadeSettledIntentBundle memory);
+    function exposeRenegadeSettledPrivateFirstFillBundle(RenegadeSettledPrivateFirstFillBundle calldata)
+        external
+        pure
+        returns (RenegadeSettledPrivateFirstFillBundle memory);
+    function exposeRenegadeSettledPrivateFillBundle(RenegadeSettledPrivateFillBundle calldata)
+        external
+        pure
+        returns (RenegadeSettledPrivateFillBundle memory);
+
+    // Intent bundle types
+    function exposePublicIntentAuthBundle(PublicIntentAuthBundle calldata)
+        external
+        pure
+        returns (PublicIntentAuthBundle memory);
+    function exposePublicIntentPermit(PublicIntentPermit calldata) external pure returns (PublicIntentPermit memory);
+    function exposePrivateIntentAuthBundleFirstFill(PrivateIntentAuthBundleFirstFill calldata)
+        external
+        pure
+        returns (PrivateIntentAuthBundleFirstFill memory);
+    function exposePrivateIntentAuthBundle(PrivateIntentAuthBundle calldata)
+        external
+        pure
+        returns (PrivateIntentAuthBundle memory);
+    function exposeRenegadeSettledIntentAuthBundleFirstFill(RenegadeSettledIntentAuthBundleFirstFill calldata)
+        external
+        pure
+        returns (RenegadeSettledIntentAuthBundleFirstFill memory);
+    function exposeRenegadeSettledIntentAuthBundle(RenegadeSettledIntentAuthBundle calldata)
+        external
+        pure
+        returns (RenegadeSettledIntentAuthBundle memory);
+    function exposeSignatureWithNonce(SignatureWithNonce calldata) external pure returns (SignatureWithNonce memory);
+
+    // Obligation bundle types
+    function exposeObligationBundle(ObligationBundle calldata) external pure returns (ObligationBundle memory);
+    function exposeObligationType(ObligationType) external pure returns (ObligationType);
+    function exposePrivateObligationBundle(PrivateObligationBundle calldata)
+        external
+        pure
+        returns (PrivateObligationBundle memory);
+
+    // Settlement context types
+    function exposeSettlementContext(SettlementContext calldata) external pure returns (SettlementContext memory);
+}


### PR DESCRIPTION
### Purpose
This PR adds an `ISettlementTypes` interface that exposes types through an unimplemented interface for codegen.

### Testing
- [x] Tested importing new types.