### PR TITLE
darkpoolv2: settlement: Add validation of `BoundedMatchResult`

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -313,26 +313,23 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         SettlementContext memory settlementContext =
             SettlementLib.allocateExternalSettlementContext(internalPartySettlementBundle);
 
-        // 2. Validate the bounded match result
-        BoundedMatchResultLib.validate(matchResult, inputAmount);
-
-        // 3. Build settlement obligations from the bounded match result and input amount
+        // 2. Build settlement obligations from the bounded match result and input amount
         (SettlementObligation memory externalObligation, SettlementObligation memory internalObligation) =
             BoundedMatchResultLib.buildObligations(matchResult, inputAmount);
 
-        // 4. Validate and authorize the settlement bundles
+        // 3. Validate and authorize the settlement bundles
         SettlementLib.executeExternalSettlementBundle(
             internalObligation, internalPartySettlementBundle, settlementContext, _state, hasher
         );
 
         // TODO: Allocate transfers for external party (authorization implied by virtue of external party being the one
-        // settling) size constrained by `BoundedMatchResult.validate()`.
+        // settling)
 
-        // 5. Execute the transfers necessary for settlement
+        // 4. Execute the transfers necessary for settlement
         // The helpers above will push transfers to the settlement context if necessary
         SettlementLib.executeTransfers(settlementContext, weth, permit2);
 
-        // 6. Verify the proofs necessary for settlement
+        // 5. Verify the proofs necessary for settlement
         // The helpers above will push proofs to the settlement context if necessary
         SettlementLib.verifySettlementProofs(settlementContext, verifier);
     }

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -135,12 +135,14 @@ interface IDarkpoolV2 {
         external;
 
     /// @notice Settle a trade with an external party who decides the trade size
-    /// @param inputAmount The input amount for the trade
-    /// @param matchResult The result of the trade with bounds on the input amount
+    /// @param externalPartyAmountIn The input amount for the trade
+    /// @param recipient The recipient of
+    /// @param matchResult The result of the trade with bounds on the external party's input amount
     /// @param internalPartySettlementBundle The settlement bundle for the internal party. This type validates the
     /// internal user's state elements which are input to the trade.
     function settleExternalMatch(
-        uint256 inputAmount,
+        uint256 externalPartyAmountIn,
+        address recipient,
         BoundedMatchResult calldata matchResult,
         SettlementBundle calldata internalPartySettlementBundle
     )

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -55,8 +55,6 @@ library SettlementLib {
     error InvalidSettlementBundleType();
     /// @notice Error thrown when verification fails for a settlement
     error SettlementVerificationFailed();
-    /// @notice Error thrown when an obligation has expired
-    error ObligationExpired();
 
     // --- Allocation --- //
 
@@ -85,8 +83,7 @@ library SettlementLib {
     }
 
     /// @notice Allocate a settlement context for an external match
-    /// @dev The number of transfers for the external party is known (1 deposit + 1 withdrawal) and does not need to
-    /// be dynamically determined.
+    /// @dev The number of transfers and proofs for the external party is known: (1 deposit + 1 withdrawal + 0 proofs)
     /// @param internalPartySettlementBundle The settlement bundle for the internal party
     /// @return The allocated settlement context
     function allocateExternalSettlementContext(SettlementBundle calldata internalPartySettlementBundle)
@@ -209,7 +206,7 @@ library SettlementLib {
         }
     }
 
-    /// @notice Execute a settlement bundle
+    /// @notice Execute an external settlement bundle
     /// @param obligation The settlement obligation to validate
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.

--- a/src/darkpool/v2/types/Obligation.sol
+++ b/src/darkpool/v2/types/Obligation.sol
@@ -28,7 +28,7 @@ library SettlementObligationLib {
         return EfficientHashLib.hash(obligationBytes);
     }
 
-    /// @notice Get the deposit transfer for a settlement obligation
+    /// @notice Get the deposit transfer for a settlement obligation using a permit2 allowance transfer
     /// @param obligation The settlement obligation to get the deposit transfer for
     /// @param owner The owner of the settlement obligation
     /// @return The deposit transfer
@@ -45,6 +45,26 @@ library SettlementObligationLib {
             mint: obligation.inputToken,
             amount: obligation.amountIn,
             transferType: SimpleTransferType.Permit2AllowanceDeposit
+        });
+    }
+
+    /// @notice Get the deposit transfer for a settlement obligation using an ERC20 approval transfer
+    /// @param obligation The settlement obligation to get the ERC20 approval deposit transfer for
+    /// @param owner The owner of the settlement obligation
+    /// @return The ERC20 approval deposit transfer
+    function buildERC20ApprovalDeposit(
+        SettlementObligation memory obligation,
+        address owner
+    )
+        internal
+        pure
+        returns (SimpleTransfer memory)
+    {
+        return SimpleTransfer({
+            account: owner,
+            mint: obligation.inputToken,
+            amount: obligation.amountIn,
+            transferType: SimpleTransferType.ERC20ApprovalDeposit
         });
     }
 

--- a/src/darkpool/v2/types/Obligation.sol
+++ b/src/darkpool/v2/types/Obligation.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache
-/* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.24;
 
-import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { SimpleTransfer, SimpleTransferType } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 

--- a/src/darkpool/v2/types/settlement/BoundedMatchResult.sol
+++ b/src/darkpool/v2/types/settlement/BoundedMatchResult.sol
@@ -3,8 +3,11 @@ pragma solidity ^0.8.24;
 
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 
 /// @notice A bounded match result for a trade between an internal and external party.
+/// @dev A bounded match result is one in which the size is not known until transaction submission when
+/// the settling (external) party chooses a size within the bounds defined by the match result.
 struct BoundedMatchResult {
     /// @dev The input token of the match
     address internalPartyInputToken;
@@ -27,41 +30,128 @@ struct BoundedMatchResult {
 library BoundedMatchResultLib {
     using FixedPointLib for FixedPoint;
 
-    /// @notice Constructs two `SettlementObligation`s from a `BoundedMatchResult` and an input amount.
-    /// @dev A bounded match result is one in which the size is not known until transaction submission when
-    /// the settling (external) party chooses a size within the bounds defined by the match result.
-    /// @param matchResult The `BoundedMatchResult` to construct the `SettlementObligation`s from
+    /// @notice Error thrown when an amount is out of bounds
+    error AmountOutOfBounds(uint256 amount, uint256 minAmount, uint256 maxAmount);
+    /// @notice Error thrown when the bounds are invalid
+    error InvalidBounds();
+    /// @notice Error thrown when the block deadline has passed
+    error MatchExpired();
+    /// @notice Error thrown when an amount is zero
+    error ZeroAmount();
+
+    /// @notice Build two `SettlementObligation`s from a `BoundedMatchResult` and an input amount.
+    /// @param boundedMatchResult The `BoundedMatchResult` to build the `SettlementObligation`s from
     /// @param externalPartyAmountIn The amount of the input token to trade for the external party
     /// @return externalObligation The `SettlementObligation` for the external party
     /// @return internalObligation The `SettlementObligation` for the internal party
     function buildObligations(
-        BoundedMatchResult memory matchResult,
+        BoundedMatchResult calldata boundedMatchResult,
         uint256 externalPartyAmountIn
     )
         internal
-        pure
+        view
         returns (SettlementObligation memory externalObligation, SettlementObligation memory internalObligation)
     {
-        // `externalPartyAmountIn`, from the perspective of the internal party, is the output amount of the match.
-        uint256 internalPartyAmountOut = externalPartyAmountIn;
+        // Validate the bounded match result
+        validateBoundedMatchResult(boundedMatchResult, externalPartyAmountIn);
 
-        // We divide by the price (outToken/inToken) to get the input amount for the internal party.
-        uint256 internalPartyAmountIn = FixedPointLib.divIntegerByFixedPoint(internalPartyAmountOut, matchResult.price);
+        uint256 internalPartyAmountIn = computeInternalPartyAmountIn(boundedMatchResult, externalPartyAmountIn);
 
         internalObligation = SettlementObligation({
-            inputToken: matchResult.internalPartyInputToken,
-            outputToken: matchResult.internalPartyOutputToken,
+            inputToken: boundedMatchResult.internalPartyInputToken,
+            outputToken: boundedMatchResult.internalPartyOutputToken,
             amountIn: internalPartyAmountIn,
-            amountOut: internalPartyAmountOut
+            amountOut: externalPartyAmountIn
         });
         externalObligation = buildMatchingExternalObligation(internalObligation);
 
         return (externalObligation, internalObligation);
     }
 
+    // --- Helpers --- //
+
+    /// @notice Validates a `BoundedMatchResult` along with the input amount supplied by the external party
+    /// @param boundedMatchResult The `BoundedMatchResult` to validate
+    /// @param externalPartyAmountIn The amount of the input token to trade for the external party
+    function validateBoundedMatchResult(
+        BoundedMatchResult calldata boundedMatchResult,
+        uint256 externalPartyAmountIn
+    )
+        internal
+        view
+    {
+        // 1. Validate input amount
+        validateAmountIn(boundedMatchResult, externalPartyAmountIn);
+
+        // 2. Validate bounds of bounded match result
+        validateBounds(boundedMatchResult);
+
+        // 3. Validate block deadline
+        validateDeadline(boundedMatchResult);
+
+        // 4. Validate price
+        // We validate the price in Intent Libraries to avoid unnecessary denormalization of the intent.
+        // TODO: validate price in Intent Libraries
+    }
+
+    /// @notice Validates an amount within the bounds of a `BoundedMatchResult`
+    /// @param boundedMatchResult The `BoundedMatchResult` to validate the amount within
+    /// @param externalPartyAmountIn The amount in of the external party
+    function validateAmountIn(
+        BoundedMatchResult calldata boundedMatchResult,
+        uint256 externalPartyAmountIn
+    )
+        internal
+        pure
+    {
+        // The external party input amount must be a valid amount
+        DarkpoolConstants.validateAmount(externalPartyAmountIn);
+
+        if (externalPartyAmountIn == 0) {
+            revert ZeroAmount();
+        }
+
+        // Bounded match result is from the internal party's perspective, so we need to convert the external party input
+        // amount to an internal party input amount.
+        uint256 internalPartyAmountIn = computeInternalPartyAmountIn(boundedMatchResult, externalPartyAmountIn);
+
+        bool amountTooLow = internalPartyAmountIn < boundedMatchResult.minInternalPartyAmountIn;
+        bool amountTooHigh = internalPartyAmountIn > boundedMatchResult.maxInternalPartyAmountIn;
+        if (amountTooLow || amountTooHigh) {
+            revert AmountOutOfBounds(
+                internalPartyAmountIn,
+                boundedMatchResult.minInternalPartyAmountIn,
+                boundedMatchResult.maxInternalPartyAmountIn
+            );
+        }
+    }
+
+    /// @notice Validates the bounds of a `BoundedMatchResult`
+    /// @param boundedMatchResult The `BoundedMatchResult` to validate the bounds of
+    function validateBounds(BoundedMatchResult calldata boundedMatchResult) internal pure {
+        // The min/max amounts must be valid amounts
+        DarkpoolConstants.validateAmount(boundedMatchResult.minInternalPartyAmountIn);
+        DarkpoolConstants.validateAmount(boundedMatchResult.maxInternalPartyAmountIn);
+
+        // The min amount must be less than the max amount
+        bool boundsInvalid = boundedMatchResult.minInternalPartyAmountIn > boundedMatchResult.maxInternalPartyAmountIn;
+        if (boundsInvalid) {
+            revert InvalidBounds();
+        }
+    }
+
+    /// @notice Validates that match result has not expired
+    /// @param boundedMatchResult The `BoundedMatchResult` to validate the deadline of
+    function validateDeadline(BoundedMatchResult calldata boundedMatchResult) internal view {
+        bool deadlinePassed = block.number > boundedMatchResult.blockDeadline;
+        if (deadlinePassed) revert MatchExpired();
+    }
+
     /// @notice Builds a `SettlementObligation` for the external party from a `SettlementObligation` for the internal
-    /// party. @param internalObligation The `SettlementObligation` for the internal party
-    /// @return externalObligation The `SettlementObligation` for the external party
+    /// party.
+    /// @param internalObligation The `SettlementObligation` for the internal party from which we derive the external
+    /// party's obligation.
+    /// @return externalObligation The matching `SettlementObligation` for the external party
     function buildMatchingExternalObligation(SettlementObligation memory internalObligation)
         internal
         pure
@@ -75,17 +165,22 @@ library BoundedMatchResultLib {
         });
     }
 
-    /// @notice Validates a `BoundedMatchResult`
-    /// @param matchResult The `BoundedMatchResult` to validate
-    function validate(BoundedMatchResult calldata matchResult, uint256 inputAmount) public pure {
-        // Validate bounds (order, inputAmount within bounds)
+    /// @notice Converts an external party amount in to an internal party amount in
+    /// @param boundedMatchResult The `BoundedMatchResult` to convert the amount for
+    /// @param externalPartyAmountIn The amount to convert
+    /// @return internalPartyAmountIn The internal party amount in
+    function computeInternalPartyAmountIn(
+        BoundedMatchResult calldata boundedMatchResult,
+        uint256 externalPartyAmountIn
+    )
+        internal
+        pure
+        returns (uint256 internalPartyAmountIn)
+    {
+        // From the internal party's perspective, `externalPartyAmountIn` is the output amount of the match.
+        uint256 internalPartyAmountOut = externalPartyAmountIn;
 
-        // Validate block deadline
-
-        // Validate price
-
-        // Validate input and output amounts
-        // DarkpoolConstants.validateAmount(obligation0.amountIn);
-        // DarkpoolConstants.validateAmount(obligation0.amountOut);
+        // We divide by the price (outToken/inToken) to get the input amount for the internal party.
+        internalPartyAmountIn = FixedPointLib.divIntegerByFixedPoint(internalPartyAmountOut, boundedMatchResult.price);
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds validation of the `BoundedMatchResult` and the input amount supplied by the external party.

### Todo
- [ ] Verify signature over bounded match result using executor key for public intent case to authenticate (since no proofs)