### PR TITLE
darkpoolv2: settlement: native-settled-private-intent: Use full commitment

### DIFF
--- a/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
+++ b/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
@@ -47,6 +47,7 @@ struct IntentOnlyValidityStatement {
     /// @dev The new public share of the amount field on the intent
     BN254.ScalarField newAmountShare;
     /// @dev A partial commitment to the intent
+    /// @dev This is a commitment to all shares except the public share of the amount field which changes post-match.
     PartialCommitment newIntentPartialCommitment;
     /// @dev The recovery ID for the intent
     BN254.ScalarField recoveryId;


### PR DESCRIPTION
### Purpose
This PR updates the helper to compute the correct full commitment to the updated shares of the intent in the natively settled private intent (subsequent fill) handler.

This involves hashing the new `amountIn` public share--updated by the contracts--into the partial commitment. This is the only share which changes in the match.

### Todo
- Update all other settlement handlers

### Testing
- [x] Unit tests pass