### PR TITLE
darkpoolv2: renegade-settled-public-fill: Use full commitments

### DIFF
--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -263,10 +263,10 @@ library PublicInputsLib {
         publicInputs = new BN254.ScalarField[](nPublicInputs);
         publicInputs[0] = statement.merkleRoot;
         publicInputs[1] = statement.intentAndAuthorizingAddressCommitment;
-        publicInputs[2] = statement.intentPublicShare[0];
-        publicInputs[3] = statement.intentPublicShare[1];
-        publicInputs[4] = statement.intentPublicShare[2];
-        publicInputs[5] = statement.intentPublicShare[3];
+        publicInputs[2] = statement.intentPublicShare.inToken;
+        publicInputs[3] = statement.intentPublicShare.outToken;
+        publicInputs[4] = statement.intentPublicShare.owner;
+        publicInputs[5] = statement.intentPublicShare.minPrice;
         publicInputs[6] = statement.intentPrivateShareCommitment;
         publicInputs[7] = statement.intentRecoveryId;
         publicInputs[8] = statement.balancePartialCommitment.privateCommitment;
@@ -311,14 +311,14 @@ library PublicInputsLib {
         publicInputs[0] = statement.amountPublicShare;
 
         // Add the input balance public shares
-        publicInputs[1] = statement.inBalancePublicShares[0];
-        publicInputs[2] = statement.inBalancePublicShares[1];
-        publicInputs[3] = statement.inBalancePublicShares[2];
+        publicInputs[1] = statement.inBalancePublicShares.relayerFeeBalance;
+        publicInputs[2] = statement.inBalancePublicShares.protocolFeeBalance;
+        publicInputs[3] = statement.inBalancePublicShares.amount;
 
         // Add the output balance public shares
-        publicInputs[4] = statement.outBalancePublicShares[0];
-        publicInputs[5] = statement.outBalancePublicShares[1];
-        publicInputs[6] = statement.outBalancePublicShares[2];
+        publicInputs[4] = statement.outBalancePublicShares.relayerFeeBalance;
+        publicInputs[5] = statement.outBalancePublicShares.protocolFeeBalance;
+        publicInputs[6] = statement.outBalancePublicShares.amount;
 
         // Add the settlement obligation
         publicInputs[7] = BN254.ScalarField.wrap(uint256(uint160(statement.settlementObligation.inputToken)));

--- a/src/darkpool/v2/libraries/public_inputs/Settlement.sol
+++ b/src/darkpool/v2/libraries/public_inputs/Settlement.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { FixedPoint } from "renegade-lib/FixedPoint.sol";
+import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
 
 // --- Settlement Statements --- //
 // Settlement proofs verify that:
@@ -39,20 +40,12 @@ struct IntentAndBalancePublicSettlementStatement {
     /// balance.
     /// @dev This value is also leaked from the witness so that the contracts can
     /// update it directly on-chain.
-    /// These correspond to the updated:
-    /// - Relayer fee
-    /// - Protocol fee
-    /// - Amount
-    BN254.ScalarField[3] inBalancePublicShares;
+    PostMatchBalanceShare inBalancePublicShares;
     /// @dev The updated public shares of the post-match balance fields for the
     /// output balance
     /// @dev This value is also leaked from the witness so that the contracts can
     /// update it directly on-chain.
-    /// These correspond to the updated:
-    /// - Relayer fee
-    /// - Protocol fee
-    /// - Amount
-    BN254.ScalarField[3] outBalancePublicShares;
+    PostMatchBalanceShare outBalancePublicShares;
     /// @dev The relayer fee which is charged for the settlement
     /// @dev We place this field in the statement so that it is included in the
     /// Fiat-Shamir transcript and therefore is not malleable transaction

--- a/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
+++ b/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { PartialCommitment } from "darkpoolv2-types/PartialCommitment.sol";
-import { IntentPublicShare } from "darkpoolv2-types/Intent.sol";
+import { IntentPublicShare, IntentPreMatchShare } from "darkpoolv2-types/Intent.sol";
 
 // --- Validity Statements --- //
 // Validity proofs verify that:
@@ -66,7 +66,7 @@ struct IntentAndBalanceValidityStatementFirstFill {
     /// @dev The public shares of the intent minus the `amount_in` field
     /// @dev The public share of the `amount_in` field is leaked after it's been
     /// updated by the settlement circuit.
-    BN254.ScalarField[4] intentPublicShare;
+    IntentPreMatchShare intentPublicShare;
     /// @dev The partial commitment to the original intent
     /// @dev This commitment commits to all fields except the public share of the
     /// `amount_in` field. The smart contracts will resume the commitment by

--- a/src/darkpool/v2/types/Balance.sol
+++ b/src/darkpool/v2/types/Balance.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+/// @title Post-match balance share
+/// @notice A post-match balance share is a share of the balance containing only the fields which change in a match.
+/// @dev That is, the fee and amount fields.
+struct PostMatchBalanceShare {
+    /// @dev The relayer fee balance of the balance
+    BN254.ScalarField relayerFeeBalance;
+    /// @dev The protocol fee balance of the balance
+    BN254.ScalarField protocolFeeBalance;
+    /// @dev The amount of the token in the balance
+    BN254.ScalarField amount;
+}
+
+/// @title Post-match balance share library
+/// @notice Library for post-match balance shares
+library PostMatchBalanceShareLib {
+    /// @notice Serialize a post-match balance share to scalars
+    /// @param share The post-match balance share to serialize
+    /// @return scalars The serialized post-match balance share as an array of scalars
+    function scalarSerialize(PostMatchBalanceShare memory share) internal pure returns (uint256[] memory scalars) {
+        scalars = new uint256[](3);
+        scalars[0] = BN254.ScalarField.unwrap(share.relayerFeeBalance);
+        scalars[1] = BN254.ScalarField.unwrap(share.protocolFeeBalance);
+        scalars[2] = BN254.ScalarField.unwrap(share.amount);
+    }
+}

--- a/src/darkpool/v2/types/Intent.sol
+++ b/src/darkpool/v2/types/Intent.sol
@@ -66,3 +66,41 @@ library IntentPublicShareLib {
         scalars[4] = BN254.ScalarField.unwrap(share.amountIn);
     }
 }
+
+/// @notice A pre-match share of an intent
+/// @dev This is a secret share of all fields in an intent which don't change in a match
+/// @dev That is, all but the `amountIn` field.
+struct IntentPreMatchShare {
+    /// @dev The token to buy
+    BN254.ScalarField inToken;
+    /// @dev The token to sell
+    BN254.ScalarField outToken;
+    /// @dev The owner of the intent
+    BN254.ScalarField owner;
+    /// @dev The minimum price at which a party may settle a partial fill
+    /// @dev This is in units of `outToken/inToken`
+    BN254.ScalarField minPrice;
+}
+
+library IntentPreMatchShareLib {
+    /// @notice Create an intent public share from a pre-match share and an `amountIn` share
+    /// @param preMatchShare The pre-match share to create the intent public share from
+    /// @param amountInShare The `amountIn` share to create the intent public share from
+    /// @return intentPublicShare The intent public share
+    function toFullPublicShare(
+        IntentPreMatchShare memory preMatchShare,
+        BN254.ScalarField amountInShare
+    )
+        internal
+        pure
+        returns (IntentPublicShare memory intentPublicShare)
+    {
+        intentPublicShare = IntentPublicShare({
+            inToken: preMatchShare.inToken,
+            outToken: preMatchShare.outToken,
+            owner: preMatchShare.owner,
+            minPrice: preMatchShare.minPrice,
+            amountIn: amountInShare
+        });
+    }
+}

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -151,8 +151,6 @@ library PrivateIntentPrivateBalanceAuthBundleLib {
     /// @notice Get the digest for the owner signature
     /// @param bundleData The bundle data to get the digest for
     /// @return digest The digest for the owner signature
-    /// @dev The digest is computed as:
-    ///     H(intentCommitment || updatedBalanceOneTimeKeyHash)
     function getOwnerSignatureDigest(RenegadeSettledIntentAuthBundleFirstFill memory bundleData)
         internal
         pure

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
@@ -28,6 +28,7 @@ import {
     IntentAndBalanceValidityStatementFirstFill,
     IntentAndBalanceValidityStatement
 } from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import { IntentPreMatchShare } from "darkpoolv2-types/Intent.sol";
 import { IntentAndBalancePrivateSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 
@@ -72,10 +73,12 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
 
     /// @dev Create a dummy intent and balance validity statement (first fill)
     function createSampleStatementFirstFill() internal returns (IntentAndBalanceValidityStatementFirstFill memory) {
-        BN254.ScalarField[4] memory intentPublicShare;
-        for (uint256 i = 0; i < 4; ++i) {
-            intentPublicShare[i] = randomScalar();
-        }
+        IntentPreMatchShare memory intentPublicShare = IntentPreMatchShare({
+            inToken: randomScalar(),
+            outToken: randomScalar(),
+            owner: randomScalar(),
+            minPrice: randomScalar()
+        });
 
         return IntentAndBalanceValidityStatementFirstFill({
             merkleRoot: randomScalar(),

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -24,7 +24,9 @@ import {
     IntentAndBalanceValidityStatementFirstFill,
     IntentAndBalanceValidityStatement
 } from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import { IntentPreMatchShare } from "darkpoolv2-types/Intent.sol";
 import { IntentAndBalancePublicSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
+import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 
 contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
@@ -68,10 +70,12 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
 
     /// @dev Create a dummy intent and balance validity statement (first fill)
     function createSampleStatementFirstFill() internal returns (IntentAndBalanceValidityStatementFirstFill memory) {
-        BN254.ScalarField[4] memory intentPublicShare;
-        for (uint256 i = 0; i < 4; ++i) {
-            intentPublicShare[i] = randomScalar();
-        }
+        IntentPreMatchShare memory intentPublicShare = IntentPreMatchShare({
+            inToken: randomScalar(),
+            outToken: randomScalar(),
+            owner: randomScalar(),
+            minPrice: randomScalar()
+        });
 
         return IntentAndBalanceValidityStatementFirstFill({
             merkleRoot: randomScalar(),
@@ -106,15 +110,17 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
         internal
         returns (IntentAndBalancePublicSettlementStatement memory)
     {
-        BN254.ScalarField[3] memory inBalancePublicShares;
-        inBalancePublicShares[0] = randomScalar();
-        inBalancePublicShares[1] = randomScalar();
-        inBalancePublicShares[2] = randomScalar();
+        PostMatchBalanceShare memory inBalancePublicShares = PostMatchBalanceShare({
+            relayerFeeBalance: randomScalar(),
+            protocolFeeBalance: randomScalar(),
+            amount: randomScalar()
+        });
 
-        BN254.ScalarField[3] memory outBalancePublicShares;
-        outBalancePublicShares[0] = randomScalar();
-        outBalancePublicShares[1] = randomScalar();
-        outBalancePublicShares[2] = randomScalar();
+        PostMatchBalanceShare memory outBalancePublicShares = PostMatchBalanceShare({
+            relayerFeeBalance: randomScalar(),
+            protocolFeeBalance: randomScalar(),
+            amount: randomScalar()
+        });
 
         return IntentAndBalancePublicSettlementStatement({
             settlementObligation: obligation,


### PR DESCRIPTION
### Purpose
This PR computes the correct full commitments for renegade settled private intents on the first fill.

### Todo
- Subsequent fills
- Other settlement paths

### Testing
- [x] Unit tests pass