### PR TITLE
darkpoolv2: settlement: renegade-settled-private-intent: Use full commitment

### DIFF
--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -256,6 +256,7 @@ library RenegadeSettledPrivateIntentLib {
         state.spendNullifier(intentNullifier);
 
         // 2. Insert commitments to the updated intent and balance into the Merkle tree
+        // TODO: Add output balances
         uint256 merkleDepth = bundleData.auth.merkleDepth;
         BN254.ScalarField newIntentCommitment = bundleData.computeFullIntentCommitment(hasher);
         BN254.ScalarField newBalanceCommitment = bundleData.computeFullBalanceCommitment(hasher);


### PR DESCRIPTION
### Purpose
This PR changes the implementation of the Renegade settled private intent handler for subsequent fills to compute the full commitment to the new shares.

### Testing
- [x] All tests pass 