### PR TITLE
darkpoolv2: renegade-settled-private-fill: Use full commitment

### DIFF
--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -369,27 +369,27 @@ library PublicInputsLib {
         publicInputs[0] = statement.newAmountPublicShare0;
 
         // First party input balance shares
-        publicInputs[1] = statement.newInBalancePublicShares0[0];
-        publicInputs[2] = statement.newInBalancePublicShares0[1];
-        publicInputs[3] = statement.newInBalancePublicShares0[2];
+        publicInputs[1] = statement.newInBalancePublicShares0.relayerFeeBalance;
+        publicInputs[2] = statement.newInBalancePublicShares0.protocolFeeBalance;
+        publicInputs[3] = statement.newInBalancePublicShares0.amount;
 
         // First party output balance shares
-        publicInputs[4] = statement.newOutBalancePublicShares0[0];
-        publicInputs[5] = statement.newOutBalancePublicShares0[1];
-        publicInputs[6] = statement.newOutBalancePublicShares0[2];
+        publicInputs[4] = statement.newOutBalancePublicShares0.relayerFeeBalance;
+        publicInputs[5] = statement.newOutBalancePublicShares0.protocolFeeBalance;
+        publicInputs[6] = statement.newOutBalancePublicShares0.amount;
 
         // Second party intent amount
         publicInputs[7] = statement.newAmountPublicShare1;
 
         // Second party input balance shares
-        publicInputs[8] = statement.newInBalancePublicShares1[0];
-        publicInputs[9] = statement.newInBalancePublicShares1[1];
-        publicInputs[10] = statement.newInBalancePublicShares1[2];
+        publicInputs[8] = statement.newInBalancePublicShares1.relayerFeeBalance;
+        publicInputs[9] = statement.newInBalancePublicShares1.protocolFeeBalance;
+        publicInputs[10] = statement.newInBalancePublicShares1.amount;
 
         // Second party output balance shares
-        publicInputs[11] = statement.newOutBalancePublicShares1[0];
-        publicInputs[12] = statement.newOutBalancePublicShares1[1];
-        publicInputs[13] = statement.newOutBalancePublicShares1[2];
+        publicInputs[11] = statement.newOutBalancePublicShares1.relayerFeeBalance;
+        publicInputs[12] = statement.newOutBalancePublicShares1.protocolFeeBalance;
+        publicInputs[13] = statement.newOutBalancePublicShares1.amount;
 
         // Fees
         publicInputs[14] = BN254.ScalarField.wrap(statement.relayerFee0.repr);

--- a/src/darkpool/v2/libraries/public_inputs/Settlement.sol
+++ b/src/darkpool/v2/libraries/public_inputs/Settlement.sol
@@ -65,13 +65,13 @@ struct IntentAndBalancePrivateSettlementStatement {
     /// - Relayer fee
     /// - Protocol fee
     /// - Amount
-    BN254.ScalarField[3] newInBalancePublicShares0;
+    PostMatchBalanceShare newInBalancePublicShares0;
     /// @dev The updated public shares of the first party's output balance
     /// These correspond to the updated:
     /// - Relayer fee
     /// - Protocol fee
     /// - Amount
-    BN254.ScalarField[3] newOutBalancePublicShares0;
+    PostMatchBalanceShare newOutBalancePublicShares0;
     // --- Second Party --- //
     /// @dev The updated public share of the second party's intent amount
     BN254.ScalarField newAmountPublicShare1;
@@ -80,13 +80,13 @@ struct IntentAndBalancePrivateSettlementStatement {
     /// - Relayer fee
     /// - Protocol fee
     /// - Amount
-    BN254.ScalarField[3] newInBalancePublicShares1;
+    PostMatchBalanceShare newInBalancePublicShares1;
     /// @dev The updated public shares of the second party's output balance
     /// These correspond to the updated:
     /// - Relayer fee
     /// - Protocol fee
     /// - Amount
-    BN254.ScalarField[3] newOutBalancePublicShares1;
+    PostMatchBalanceShare newOutBalancePublicShares1;
     // --- Fees --- //
     /// @dev The relayer fee applied to the first party's match
     FixedPoint relayerFee0;

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
@@ -21,6 +21,8 @@ import {
     IntentAndBalanceValidityStatement
 } from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
 
+import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
+
 import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
 
 import { RenegadeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/RenegadeSettledPrivateIntent.sol";
@@ -210,7 +212,7 @@ library RenegadeSettledPrivateFillLib {
 
         // 2. Insert commitments to the updated balance and intent into the Merkle tree
         BN254.ScalarField newIntentAmountPublicShare;
-        BN254.ScalarField[3] memory newBalanceShares;
+        PostMatchBalanceShare memory newBalanceShares;
         if (partyId == PartyId.PARTY_0) {
             newIntentAmountPublicShare = obligation.statement.newAmountPublicShare0;
             newBalanceShares = obligation.statement.newOutBalancePublicShares0;
@@ -252,13 +254,13 @@ library RenegadeSettledPrivateFillLib {
 
         // 2. Insert commitments to the updated balance and intent into the Merkle tree
         BN254.ScalarField newIntentAmountPublicShare;
-        BN254.ScalarField[3] memory newBalanceShares;
+        PostMatchBalanceShare memory newBalanceShares;
         if (partyId == PartyId.PARTY_0) {
             newIntentAmountPublicShare = obligation.statement.newAmountPublicShare0;
-            newBalanceShares = obligation.statement.newOutBalancePublicShares0;
+            newBalanceShares = obligation.statement.newInBalancePublicShares0;
         } else if (partyId == PartyId.PARTY_1) {
             newIntentAmountPublicShare = obligation.statement.newAmountPublicShare1;
-            newBalanceShares = obligation.statement.newOutBalancePublicShares1;
+            newBalanceShares = obligation.statement.newInBalancePublicShares1;
         }
 
         // Compute the commitments to the updated balance and intent

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -256,6 +256,7 @@ library RenegadeSettledPrivateIntentLib {
         state.spendNullifier(intentNullifier);
 
         // 2. Insert commitments to the updated intent and balance into the Merkle tree
+        // TODO: Add output balances
         uint256 merkleDepth = bundleData.auth.merkleDepth;
         BN254.ScalarField newIntentCommitment = bundleData.computeFullIntentCommitment(hasher);
         BN254.ScalarField newBalanceCommitment = bundleData.computeFullBalanceCommitment(hasher);

--- a/src/darkpool/v2/types/Intent.sol
+++ b/src/darkpool/v2/types/Intent.sol
@@ -36,6 +36,9 @@ struct IntentPublicShare {
     BN254.ScalarField amountIn;
 }
 
+/// @title IntentPublicShareLib
+/// @author Renegade Eng
+/// @notice Library for operating on intent public shares
 library IntentPublicShareLib {
     /// @notice Serialize an intent public share to scalars for the prefix of a match
     /// @dev The prefix here is the fields which don't change in a match.
@@ -82,6 +85,9 @@ struct IntentPreMatchShare {
     BN254.ScalarField minPrice;
 }
 
+/// @title IntentPreMatchShareLib
+/// @author Renegade Eng
+/// @notice Library for operating on pre-match intent shares
 library IntentPreMatchShareLib {
     /// @notice Create an intent public share from a pre-match share and an `amountIn` share
     /// @param preMatchShare The pre-match share to create the intent public share from

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -11,6 +11,7 @@ import { BN254Helpers } from "renegade-lib/verifier/BN254Helpers.sol";
 import { ObligationBundle, ObligationType } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { Intent, IntentPublicShare } from "darkpoolv2-types/Intent.sol";
+import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
 import { PartialCommitment } from "darkpoolv2-types/PartialCommitment.sol";
 import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
@@ -120,6 +121,15 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
             owner: randomScalar(),
             minPrice: randomScalar(),
             amountIn: randomScalar()
+        });
+    }
+
+    /// @dev Generate a random post match balance share
+    function randomPostMatchBalanceShare() internal returns (PostMatchBalanceShare memory) {
+        return PostMatchBalanceShare({
+            relayerFeeBalance: randomScalar(),
+            protocolFeeBalance: randomScalar(),
+            amount: randomScalar()
         });
     }
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/FullMatchTests.t.sol
@@ -161,9 +161,9 @@ contract FullMatchTests is RenegadeSettledPrivateFillTestUtils {
         BN254.ScalarField intentCommitment1 =
             bundleData1.computeFullIntentCommitment(obligation.statement.newAmountPublicShare1, hasher);
         BN254.ScalarField balanceCommitment0 =
-            bundleData0.computeFullBalanceCommitment(obligation.statement.newOutBalancePublicShares0, hasher);
+            bundleData0.computeFullBalanceCommitment(obligation.statement.newInBalancePublicShares0, hasher);
         BN254.ScalarField balanceCommitment1 =
-            bundleData1.computeFullBalanceCommitment(obligation.statement.newOutBalancePublicShares1, hasher);
+            bundleData1.computeFullBalanceCommitment(obligation.statement.newInBalancePublicShares1, hasher);
 
         // Validate against a single Merkle tree
         MerkleTreeLib.MerkleTreeConfig memory config =

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
@@ -31,6 +31,7 @@ import {
 import { IntentPreMatchShare } from "darkpoolv2-types/Intent.sol";
 import { IntentAndBalancePrivateSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
 
 contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
     using ObligationLib for ObligationBundle;
@@ -110,25 +111,10 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
 
     /// @dev Create a dummy private obligation bundle for a private fill
     function createPrivateObligationBundle() internal returns (PrivateObligationBundle memory) {
-        BN254.ScalarField[3] memory party0InBalanceShares;
-        party0InBalanceShares[0] = randomScalar();
-        party0InBalanceShares[1] = randomScalar();
-        party0InBalanceShares[2] = randomScalar();
-
-        BN254.ScalarField[3] memory party0OutBalanceShares;
-        party0OutBalanceShares[0] = randomScalar();
-        party0OutBalanceShares[1] = randomScalar();
-        party0OutBalanceShares[2] = randomScalar();
-
-        BN254.ScalarField[3] memory party1InBalanceShares;
-        party1InBalanceShares[0] = randomScalar();
-        party1InBalanceShares[1] = randomScalar();
-        party1InBalanceShares[2] = randomScalar();
-
-        BN254.ScalarField[3] memory party1OutBalanceShares;
-        party1OutBalanceShares[0] = randomScalar();
-        party1OutBalanceShares[1] = randomScalar();
-        party1OutBalanceShares[2] = randomScalar();
+        PostMatchBalanceShare memory party0InBalanceShares = randomPostMatchBalanceShare();
+        PostMatchBalanceShare memory party0OutBalanceShares = randomPostMatchBalanceShare();
+        PostMatchBalanceShare memory party1InBalanceShares = randomPostMatchBalanceShare();
+        PostMatchBalanceShare memory party1OutBalanceShares = randomPostMatchBalanceShare();
 
         IntentAndBalancePrivateSettlementStatement memory statement = IntentAndBalancePrivateSettlementStatement({
             newAmountPublicShare0: randomScalar(),


### PR DESCRIPTION
### Purpose
This PR correctly computes the full commitment to the updated shares of the balances and intents in the Renegade-settled private fill handlers.

### Testing
- [x] All tests pass