### PR TITLE
darkpoolv2: native-settled-public-intent: Add fee fields & validation

### DIFF
--- a/script/v2/DeployV2Utils.sol
+++ b/script/v2/DeployV2Utils.sol
@@ -16,6 +16,7 @@ import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
 import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { TransferExecutor } from "darkpoolv1-contracts/TransferExecutor.sol";
 import { GasSponsor } from "darkpoolv1-contracts/GasSponsor.sol";
 import { GasSponsorProxy } from "darkpoolv1-proxies/GasSponsorProxy.sol";
@@ -106,7 +107,7 @@ contract DeployV2Utils {
 
     /// @notice Deploy core contracts
     /// @param owner The owner address for the darkpool
-    /// @param protocolFeeRate The protocol fee rate
+    /// @param protocolFeeRateRepr The protocol fee rate representation
     /// @param protocolFeeAddr The address to receive protocol fees
     /// @param protocolFeeKey The encryption key for protocol fees
     /// @param permit2 The Permit2 contract instance
@@ -115,7 +116,7 @@ contract DeployV2Utils {
     /// @return darkpoolAddr The deployed darkpool proxy address
     function deployCore(
         address owner,
-        uint256 protocolFeeRate,
+        uint256 protocolFeeRateRepr,
         address protocolFeeAddr,
         EncryptionKey memory protocolFeeKey,
         IPermit2 permit2,
@@ -135,7 +136,7 @@ contract DeployV2Utils {
         DarkpoolV2Proxy darkpoolProxy = new DarkpoolV2Proxy(
             address(darkpool),
             owner,
-            protocolFeeRate,
+            protocolFeeRateRepr,
             protocolFeeAddr,
             protocolFeeKey,
             weth,

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -16,6 +16,7 @@ import {
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
+import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
 import { IPermit2 } from "permit2-lib/interfaces/IPermit2.sol";
@@ -47,7 +48,9 @@ interface IDarkpoolV2 {
 
     /// @notice Initialize the darkpool contract
     /// @param initialOwner The initial owner of the contract
-    /// @param protocolFeeRate_ The protocol fee rate
+    /// @param defaultProtocolFeeRateRepr The default protocol fee rate for the darkpool (as uint256 repr)
+    /// We take the repr rather than the `FixedPoint` because the Solidity compiler fails with Yul stack too deep
+    /// errors otherwise.
     /// @param protocolFeeRecipient_ The address to receive protocol fees
     /// @param protocolFeeKey_ The encryption key for protocol fees
     /// @param weth_ The WETH9 contract instance
@@ -57,7 +60,7 @@ interface IDarkpoolV2 {
     /// @param transferExecutor_ The TransferExecutor contract address
     function initialize(
         address initialOwner,
-        uint256 protocolFeeRate_,
+        uint256 defaultProtocolFeeRateRepr,
         address protocolFeeRecipient_,
         EncryptionKey memory protocolFeeKey_,
         IWETH9 weth_,
@@ -77,6 +80,11 @@ interface IDarkpoolV2 {
     /// @param root The root to check
     /// @return True if the root is in the history, false otherwise
     function rootInHistory(BN254.ScalarField root) external view returns (bool);
+
+    /// @notice Get the protocol fee rate for an asset
+    /// @param asset The asset address to get the fee rate for
+    /// @return The protocol fee rate for the asset
+    function getProtocolFeeRate(address asset) external view returns (FixedPoint memory);
 
     /// @notice Get the amount remaining for an open public intent
     /// @param intentHash The hash of the intent

--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { FixedPoint } from "renegade-lib/FixedPoint.sol";
+
 /// @title DarkpoolConstants
 /// @author Renegade Eng
 /// @notice This library contains constants for the darkpool
@@ -15,6 +17,16 @@ library DarkpoolConstants {
     uint256 internal constant DEFAULT_MERKLE_DEPTH = 10;
     /// @notice The maximum bitlength of an amount in the darkpool
     uint256 internal constant AMOUNT_BITS = 100;
+    /// @notice The maximum relayer fee allowed by the darkpool (1%)
+    /// @dev This is the representation of a fixed point value 0.01; i.e. `0.01 * FIXED_POINT_PRECISION`.
+    uint256 internal constant MAX_RELAYER_FEE = 92_233_720_368_547_758;
+
+    /// @notice Get the maximum relayer fee as a FixedPoint struct
+    /// @dev Returns the maximum relayer fee (1%) as a FixedPoint
+    /// @return The maximum relayer fee as a FixedPoint struct
+    function maxRelayerFee() public pure returns (FixedPoint memory) {
+        return FixedPoint({ repr: MAX_RELAYER_FEE });
+    }
 
     /// @notice Check whether an address is the native token address
     /// @param addr The address to check

--- a/src/darkpool/v2/proxies/DarkpoolV2Proxy.sol
+++ b/src/darkpool/v2/proxies/DarkpoolV2Proxy.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import { TransparentUpgradeableProxy } from "oz-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
+import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
@@ -18,7 +19,9 @@ contract DarkpoolV2Proxy is TransparentUpgradeableProxy {
     /// @notice Initializes a TransparentUpgradeableProxy for a DarkpoolV2 implementation.
     /// @param implementation The DarkpoolV2 implementation address
     /// @param admin The admin address - serves as both ProxyAdmin owner and DarkpoolV2 owner
-    /// @param protocolFeeRate The protocol fee rate for the darkpool
+    /// @param defaultProtocolFeeRateRepr The default protocol fee rate for the darkpool
+    /// We take the repr rather than the `FixedPoint` because the Solidity compiler fails with Yul stack too deep
+    /// errors otherwise.
     /// @param protocolFeeRecipient The address to receive protocol fees
     /// @param protocolFeeKey The encryption key for protocol fees
     /// @param weth The WETH9 contract instance
@@ -30,7 +33,7 @@ contract DarkpoolV2Proxy is TransparentUpgradeableProxy {
         address implementation,
         address admin,
         // DarkpoolV2-specific initialization parameters
-        uint256 protocolFeeRate,
+        uint256 defaultProtocolFeeRateRepr,
         address protocolFeeRecipient,
         EncryptionKey memory protocolFeeKey,
         IWETH9 weth,
@@ -46,7 +49,7 @@ contract DarkpoolV2Proxy is TransparentUpgradeableProxy {
             abi.encodeWithSelector(
                 IDarkpoolV2.initialize.selector,
                 admin, // Use the same admin address for DarkpoolV2 owner
-                protocolFeeRate,
+                defaultProtocolFeeRateRepr,
                 protocolFeeRecipient,
                 protocolFeeKey,
                 weth,

--- a/src/darkpool/v2/types/Fee.sol
+++ b/src/darkpool/v2/types/Fee.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { FixedPoint } from "renegade-lib/FixedPoint.sol";
+
+/// @notice A relayer's fee rate for a match
+struct RelayerFeeRate {
+    /// @dev The fee rate
+    FixedPoint relayerFeeRate;
+    /// @dev The address to which the fee is paid
+    address recipient;
+}

--- a/test/darkpool/v2/DarkpoolV2TestBase.sol
+++ b/test/darkpool/v2/DarkpoolV2TestBase.sol
@@ -51,6 +51,7 @@ contract DarkpoolV2TestBase is TestUtils {
     IGasSponsor public gasSponsor;
 
     address public protocolFeeAddr;
+    address public relayerFeeAddr;
     address public darkpoolOwner;
     address public gasSponsorOwner;
     address public gasSponsorAuthAddress;
@@ -102,6 +103,7 @@ contract DarkpoolV2TestBase is TestUtils {
         // Set admin and protocol fee addresses
         darkpoolOwner = vm.randomAddress();
         protocolFeeAddr = vm.randomAddress();
+        relayerFeeAddr = vm.randomAddress();
 
         // Deploy implementation contracts
         darkpoolImpl = new DarkpoolV2();

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -17,6 +17,7 @@ import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { RelayerFeeRate } from "darkpoolv2-types/Fee.sol";
 
 contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
     using FixedPointLib for FixedPoint;
@@ -110,6 +111,11 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
         FixedPoint memory min = FixedPointLib.wrap(minRepr);
         FixedPoint memory max = FixedPointLib.wrap(maxRepr);
         fee = randomFixedPoint(min, max);
+    }
+
+    /// @notice Generate a random relayer fee rate
+    function randomRelayerFeeRate() internal returns (RelayerFeeRate memory relayerFeeRate) {
+        relayerFeeRate = RelayerFeeRate({ relayerFeeRate: randomFee(), recipient: relayerFeeAddr });
     }
 
     /// @dev Generate a random set of intent shares

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -21,6 +21,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { RelayerFeeRate } from "darkpoolv2-types/Fee.sol";
 import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 
 contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
@@ -114,8 +115,9 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         SettlementObligation memory obligation0 = obligationBundle.decodePublicObligationMemory(PartyId.PARTY_0);
 
-        // Corrupt the executor signature
-        SignatureWithNonce memory sig = signObligation(obligation0, wrongSigner.privateKey);
+        // Corrupt the executor signature by signing with wrong signer
+        SignatureWithNonce memory sig =
+            createExecutorSignature(bundleData.relayerFeeRate, obligation0, wrongSigner.privateKey);
         bundleData.auth.executorSignature = sig;
         bundle.data = abi.encode(bundleData);
 
@@ -149,11 +151,13 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         obligation0.amountIn = randomUint(1, amountRemaining);
         uint256 minAmountOut = authBundle2.permit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
         obligation0.amountOut = minAmountOut + 1;
-        authBundle2.executorSignature = signObligation(obligation0, executor.privateKey);
+        RelayerFeeRate memory relayerFeeRate2 = randomRelayerFeeRate();
+        authBundle2.executorSignature = createExecutorSignature(relayerFeeRate2, obligation0, executor.privateKey);
         ObligationBundle memory obligationBundle2 = buildObligationBundle(obligation0, obligation1);
 
         // Create the second bundle
-        PublicIntentPublicBalanceBundle memory bundleData2 = PublicIntentPublicBalanceBundle({ auth: authBundle2 });
+        PublicIntentPublicBalanceBundle memory bundleData2 =
+            PublicIntentPublicBalanceBundle({ auth: authBundle2, relayerFeeRate: relayerFeeRate2 });
         SettlementBundle memory bundle2 = SettlementBundle({
             isFirstFill: false,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,


### PR DESCRIPTION
### Purpose
This PR adds a `RelayerFeeRate` field to the auth bundle for natively settled public intents and includes it in the executor's signature. So the executor now authorizes both the `SettlementObligation` and the `RelayerFeeRate`.

### Todo
- Apply the fee rate to the transfers

### Testing
- [x] All tests pass