### PR TITLE
darkpoolv2: DarkpoolState: Move fee information to darkpool state

### DIFF
--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -81,10 +81,11 @@ interface IDarkpoolV2 {
     /// @return True if the root is in the history, false otherwise
     function rootInHistory(BN254.ScalarField root) external view returns (bool);
 
-    /// @notice Get the protocol fee rate for an asset
-    /// @param asset The asset address to get the fee rate for
-    /// @return The protocol fee rate for the asset
-    function getProtocolFeeRate(address asset) external view returns (FixedPoint memory);
+    /// @notice Get the protocol fee for an asset pair
+    /// @param asset0 The first asset in the trading pair
+    /// @param asset1 The second asset in the trading pair
+    /// @return The protocol fee rate for the asset pair
+    function getProtocolFee(address asset0, address asset1) external view returns (FixedPoint memory);
 
     /// @notice Get the amount remaining for an open public intent
     /// @param intentHash The hash of the intent

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -18,6 +18,7 @@ import { Intent } from "darkpoolv2-types/Intent.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { FeeRate } from "darkpoolv2-types/Fee.sol";
 
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { SignatureWithNonceLib, SignatureWithNonce } from "darkpoolv2-types/settlement/IntentBundle.sol";
@@ -80,7 +81,9 @@ library NativeSettledPublicIntentLib {
         validateObligationIntentConstraints(amountRemaining, intent, obligation);
 
         // 3. Execute the state updates necessary to settle the bundle
-        executeStateUpdates(intentHash, intent, obligation, settlementContext, state);
+        FeeRate memory relayerFeeRate = bundleData.relayerFeeRate;
+        FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
+        executeStateUpdates(intentHash, intent, obligation, relayerFeeRate, protocolFeeRate, settlementContext, state);
     }
 
     // ------------------------
@@ -176,6 +179,8 @@ library NativeSettledPublicIntentLib {
         bytes32 intentHash,
         Intent memory intent,
         SettlementObligation memory obligation,
+        FeeRate memory relayerFeeRate,
+        FeeRate memory protocolFeeRate,
         SettlementContext memory settlementContext,
         DarkpoolState storage state
     )

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -23,6 +23,7 @@ import {
 import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { FeeRate } from "darkpoolv2-types/Fee.sol";
 import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
 import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol";
 import { RenegadeSettledPrivateIntentLib } from "./RenegadeSettledPrivateIntent.sol";

--- a/src/darkpool/v2/types/Fee.sol
+++ b/src/darkpool/v2/types/Fee.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.24;
 import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 
 /// @notice A relayer's fee rate for a match
-struct RelayerFeeRate {
+struct FeeRate {
     /// @dev The fee rate
-    FixedPoint relayerFeeRate;
+    FixedPoint rate;
     /// @dev The address to which the fee is paid
     address recipient;
 }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -31,7 +31,7 @@ import {
 import { PartialCommitment } from "darkpoolv2-types/PartialCommitment.sol";
 import { CommitmentLib } from "darkpoolv2-lib/Commitments.sol";
 import { PostMatchBalanceShare, PostMatchBalanceShareLib } from "darkpoolv2-types/Balance.sol";
-import { RelayerFeeRate } from "darkpoolv2-types/Fee.sol";
+import { FeeRate } from "darkpoolv2-types/Fee.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 
@@ -86,7 +86,7 @@ struct PublicIntentPublicBalanceBundle {
     /// @dev The public intent authorization payload with signature attached
     PublicIntentAuthBundle auth;
     /// @dev The relayer's fee take for the match
-    RelayerFeeRate relayerFeeRate;
+    FeeRate relayerFeeRate;
 }
 
 /// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bundle on the first fill

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -17,7 +17,7 @@ import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { RelayerFeeRate } from "darkpoolv2-types/Fee.sol";
+import { FeeRate } from "darkpoolv2-types/Fee.sol";
 
 contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
     using FixedPointLib for FixedPoint;
@@ -114,8 +114,8 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
     }
 
     /// @notice Generate a random relayer fee rate
-    function randomRelayerFeeRate() internal returns (RelayerFeeRate memory relayerFeeRate) {
-        relayerFeeRate = RelayerFeeRate({ relayerFeeRate: randomFee(), recipient: relayerFeeAddr });
+    function randomFeeRate() internal returns (FeeRate memory feeRate) {
+        feeRate = FeeRate({ rate: randomFee(), recipient: relayerFeeAddr });
     }
 
     /// @dev Generate a random set of intent shares

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -21,7 +21,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { NativeSettledPublicIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPublicIntent.sol";
 import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { RelayerFeeRate } from "darkpoolv2-types/Fee.sol";
+import { FeeRate } from "darkpoolv2-types/Fee.sol";
 import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 
 contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
@@ -151,13 +151,13 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         obligation0.amountIn = randomUint(1, amountRemaining);
         uint256 minAmountOut = authBundle2.permit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
         obligation0.amountOut = minAmountOut + 1;
-        RelayerFeeRate memory relayerFeeRate2 = randomRelayerFeeRate();
-        authBundle2.executorSignature = createExecutorSignature(relayerFeeRate2, obligation0, executor.privateKey);
+        FeeRate memory feeRate2 = randomFeeRate();
+        authBundle2.executorSignature = createExecutorSignature(feeRate2, obligation0, executor.privateKey);
         ObligationBundle memory obligationBundle2 = buildObligationBundle(obligation0, obligation1);
 
         // Create the second bundle
         PublicIntentPublicBalanceBundle memory bundleData2 =
-            PublicIntentPublicBalanceBundle({ auth: authBundle2, relayerFeeRate: relayerFeeRate2 });
+            PublicIntentPublicBalanceBundle({ auth: authBundle2, relayerFeeRate: feeRate2 });
         SettlementBundle memory bundle2 = SettlementBundle({
             isFirstFill: false,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,


### PR DESCRIPTION
### Purpose
This PR moves the darkpool's fee state into the `DarkpoolState` wrapper so that it may be accessed by settlement helpers.

### Todo
- Apply fees to native settled public intents

### Testing
- [x] Unit tests pass