### PR TITLE
darkpoolv2: native-settled-public-intent: Compute and transfer fees

### DIFF
--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -315,7 +315,9 @@ library NativeSettledPrivateIntentLib {
         settlementContext.pushDeposit(deposit);
 
         // Withdraw the output token from the darkpool
-        SimpleTransfer memory withdrawal = obligation.buildWithdrawalTransfer(owner);
+        // TODO: Add in fees
+        uint256 totalFee = 0;
+        SimpleTransfer memory withdrawal = obligation.buildWithdrawalTransfer(owner, totalFee);
         settlementContext.pushWithdrawal(withdrawal);
     }
 }

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -75,12 +75,14 @@ library SettlementLib {
         pure
         returns (SettlementContext memory)
     {
-        uint256 transferCapacity = SettlementBundleLib.getNumTransfers(party0SettlementBundle)
-            + SettlementBundleLib.getNumTransfers(party1SettlementBundle);
+        uint256 numDeposits = SettlementBundleLib.getNumDeposits(party0SettlementBundle)
+            + SettlementBundleLib.getNumDeposits(party1SettlementBundle);
+        uint256 numWithdrawals = SettlementBundleLib.getNumWithdrawals(party0SettlementBundle)
+            + SettlementBundleLib.getNumWithdrawals(party1SettlementBundle);
         uint256 proofCapacity = SettlementBundleLib.getNumProofs(party0SettlementBundle)
             + SettlementBundleLib.getNumProofs(party1SettlementBundle);
 
-        return SettlementContextLib.newContext(transferCapacity, proofCapacity);
+        return SettlementContextLib.newContext(numDeposits, numWithdrawals, proofCapacity);
     }
 
     // --- Obligation Compatibility --- //

--- a/src/darkpool/v2/types/Fee.sol
+++ b/src/darkpool/v2/types/Fee.sol
@@ -1,12 +1,81 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { FixedPoint } from "renegade-lib/FixedPoint.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { SimpleTransfer, SimpleTransferType } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 
-/// @notice A relayer's fee rate for a match
+/// @notice A fee rate for a match
 struct FeeRate {
     /// @dev The fee rate
     FixedPoint rate;
     /// @dev The address to which the fee is paid
     address recipient;
+}
+
+/// @title FeeRateLib
+/// @author Renegade Eng
+/// @notice Library for fee rates
+library FeeRateLib {
+    using FixedPointLib for FixedPoint;
+
+    /// @notice Error thrown when a fee rate is invalid
+    error InvalidFeeRate();
+
+    /// @notice Verify that a given fee rate is within allowable bounds
+    /// @param feeRate The fee rate to verify
+    /// @dev Reverts with InvalidFeeRate if the fee rate is out of bounds
+    function verify(FeeRate memory feeRate) public pure {
+        if (feeRate.rate.repr > DarkpoolConstants.MAX_RELAYER_FEE) {
+            revert InvalidFeeRate();
+        }
+    }
+
+    /// @notice Compute a fee take from a fee rate and receive amount
+    /// @param feeRate The fee rate to compute the fee take from
+    /// @param receiveAmount The amount to compute the fee take for
+    /// @return The fee take
+    /// SAFETY: The fee rate is verified to be within bounds and the receive amount must be separately constrained to be
+    /// with amount bounds. See `DarkpoolConstants.AMOUNT_BITS`.
+    function computeFeeTake(
+        FeeRate memory feeRate,
+        address mint,
+        uint256 receiveAmount
+    )
+        public
+        pure
+        returns (FeeTake memory)
+    {
+        verify(feeRate);
+        uint256 fee = feeRate.rate.unsafeFixedPointMul(receiveAmount);
+        return FeeTake({ mint: mint, fee: fee, recipient: feeRate.recipient });
+    }
+}
+
+/// @notice A fee take for a match
+/// @dev A fee take represents the fees due to a party in a match rather than the rate
+struct FeeTake {
+    /// @dev The mint of the token to withdraw
+    address mint;
+    /// @dev The fee due to the recipient
+    uint256 fee;
+    /// @dev The recipient of the fee
+    address recipient;
+}
+
+/// @title FeeTakeLib
+/// @author Renegade Eng
+/// @notice Library for fee takes
+library FeeTakeLib {
+    /// @notice Build a withdrawal transfer for a fee take
+    /// @param feeTake The fee take to build the withdrawal transfer for
+    /// @return The withdrawal transfer
+    function buildWithdrawalTransfer(FeeTake memory feeTake) public pure returns (SimpleTransfer memory) {
+        return SimpleTransfer({
+            account: feeTake.recipient,
+            mint: feeTake.mint,
+            amount: feeTake.fee,
+            transferType: SimpleTransferType.Withdrawal
+        });
+    }
 }

--- a/src/darkpool/v2/types/Obligation.sol
+++ b/src/darkpool/v2/types/Obligation.sol
@@ -51,10 +51,12 @@ library SettlementObligationLib {
     /// @notice Get the withdrawal transfer for a settlement obligation
     /// @param obligation The settlement obligation to get the withdrawal transfer for
     /// @param owner The owner of the settlement obligation
+    /// @param totalFee The total fee to deduct from the raw obligation amount out
     /// @return The withdrawal transfer
     function buildWithdrawalTransfer(
         SettlementObligation memory obligation,
-        address owner
+        address owner,
+        uint256 totalFee
     )
         internal
         pure
@@ -63,7 +65,7 @@ library SettlementObligationLib {
         return SimpleTransfer({
             account: owner,
             mint: obligation.outputToken,
-            amount: obligation.amountOut,
+            amount: obligation.amountOut - totalFee,
             transferType: SimpleTransferType.Withdrawal
         });
     }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -161,15 +161,28 @@ library SettlementBundleLib {
 
     // --- Context Allocation --- //
 
-    /// @notice Get the number of transfers a settlement bundle will require in order to settle
-    /// @notice A transfer is both a deposit and a subsequent withdrawal from the darkpool.
-    /// @param bundle The settlement bundle to get the number of transfers for
-    /// @dev If the bundle is natively settled, it will require 1 transfer.
-    /// If the bundle is Renegade settled, no transfers are required.
-    /// @return The number of transfers required to settle the bundle
-    function getNumTransfers(SettlementBundle calldata bundle) internal pure returns (uint256) {
+    /// @notice Get the number of deposits a settlement bundle will require in order to settle
+    /// @param bundle The settlement bundle to get the number of deposits for
+    /// @dev If the bundle is natively settled, it will require 1 deposit.
+    /// If the bundle is Renegade settled, no deposits are required.
+    /// @return The number of deposits required to settle the bundle
+    function getNumDeposits(SettlementBundle calldata bundle) internal pure returns (uint256) {
         if (isNativelySettled(bundle)) {
-            return 1; // One transfer: a deposit and a subsequent withdrawal
+            return 1; // One deposit
+        }
+
+        // All balance updates are Merklized
+        return 0;
+    }
+
+    /// @notice Get the number of withdrawals a settlement bundle will require in order to settle
+    /// @param bundle The settlement bundle to get the number of withdrawals for
+    /// @dev If the bundle is natively settled, it will require 3 withdrawals; one for the trader and two for the fees.
+    /// If the bundle is Renegade settled, no withdrawals are required.
+    /// @return The number of withdrawals required to settle the bundle
+    function getNumWithdrawals(SettlementBundle calldata bundle) internal pure returns (uint256) {
+        if (isNativelySettled(bundle)) {
+            return 3; // One withdrawal for the trader and two for the fees
         }
 
         // All balance updates are Merklized

--- a/src/darkpool/v2/types/settlement/SettlementContext.sol
+++ b/src/darkpool/v2/types/settlement/SettlementContext.sol
@@ -25,11 +25,13 @@ library SettlementContextLib {
     using VerificationListLib for VerificationList;
 
     /// @notice Create a new settlement context
-    /// @param transferCapacity The capacity of the transfers list
+    /// @param numDeposits The initial number of deposits
+    /// @param numWithdrawals The initial number of withdrawals
     /// @param verificationCapacity The capacity of the verifications list
     /// @return The new settlement context
     function newContext(
-        uint256 transferCapacity,
+        uint256 numDeposits,
+        uint256 numWithdrawals,
         uint256 verificationCapacity
     )
         internal
@@ -37,7 +39,7 @@ library SettlementContextLib {
         returns (SettlementContext memory)
     {
         return SettlementContext({
-            transfers: SettlementTransfersLib.newList(transferCapacity),
+            transfers: SettlementTransfersLib.newList(numDeposits, numWithdrawals),
             verifications: VerificationListLib.newList(verificationCapacity)
         });
     }

--- a/src/darkpool/v2/types/transfers/TransfersList.sol
+++ b/src/darkpool/v2/types/transfers/TransfersList.sol
@@ -71,12 +71,13 @@ library SettlementTransfersLib {
     using SettlementTransfersListLib for SettlementTransfersList;
 
     /// @notice Create a new settlement transfers list
-    /// @param capacity The initial capacity of the list
+    /// @param numDeposits The initial number of deposits
+    /// @param numWithdrawals The initial number of withdrawals
     /// @return The new settlement transfers list
-    function newList(uint256 capacity) internal pure returns (SettlementTransfers memory) {
+    function newList(uint256 numDeposits, uint256 numWithdrawals) internal pure returns (SettlementTransfers memory) {
         return SettlementTransfers({
-            deposits: SettlementTransfersListLib.newList(capacity),
-            withdrawals: SettlementTransfersListLib.newList(capacity)
+            deposits: SettlementTransfersListLib.newList(numDeposits),
+            withdrawals: SettlementTransfersListLib.newList(numWithdrawals)
         });
     }
 

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -86,36 +86,9 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
         price = randomFixedPoint(minPrice, maxPrice);
     }
 
-    /// @notice Generate a random fixed point between two fixed point values
-    /// @dev This is inclusive of the bounds, so [min, max]
-    /// @param min The minimum fixed point value
-    /// @param max The maximum fixed point value
-    /// @return result The random fixed point value
-    function randomFixedPoint(
-        FixedPoint memory min,
-        FixedPoint memory max
-    )
-        internal
-        returns (FixedPoint memory result)
-    {
-        uint256 minRepr = min.repr;
-        uint256 maxRepr = max.repr;
-        uint256 randomRepr = vm.randomUint(minRepr, maxRepr);
-        result = FixedPointLib.wrap(randomRepr);
-    }
-
-    /// @notice Generate a random fee
-    function randomFee() internal returns (FixedPoint memory fee) {
-        uint256 minRepr = 0;
-        uint256 maxRepr = 2 ** FixedPointLib.FIXED_POINT_PRECISION_BITS / 100; // 1%
-        FixedPoint memory min = FixedPointLib.wrap(minRepr);
-        FixedPoint memory max = FixedPointLib.wrap(maxRepr);
-        fee = randomFixedPoint(min, max);
-    }
-
     /// @notice Generate a random relayer fee rate
-    function randomFeeRate() internal returns (FeeRate memory feeRate) {
-        feeRate = FeeRate({ rate: randomFee(), recipient: relayerFeeAddr });
+    function relayerFeeRate() internal view returns (FeeRate memory feeRate) {
+        feeRate = FeeRate({ rate: relayerFeeRateFixedPoint, recipient: relayerFeeAddr });
     }
 
     /// @dev Generate a random set of intent shares

--- a/test/darkpool/v2/settlement/SettlementTestUtils.sol
+++ b/test/darkpool/v2/settlement/SettlementTestUtils.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { FeeRate, FeeRateLib, FeeTake } from "darkpoolv2-types/Fee.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { FixedPoint } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolV2TestUtils } from "../DarkpoolV2TestUtils.sol";
+
+/// @notice The expected differences in balances before and after settlement
+struct ExpectedDifferences {
+    /// @dev The expected difference in the party0 base balance
+    int256 party0BaseChange;
+    /// @dev The expected difference in the party0 quote balance
+    int256 party0QuoteChange;
+    /// @dev The expected difference in the party1 base balance
+    int256 party1BaseChange;
+    /// @dev The expected difference in the party1 quote balance
+    int256 party1QuoteChange;
+    /// @dev The expected difference in the darkpool base balance
+    int256 darkpoolBaseChange;
+    /// @dev The expected difference in the darkpool quote balance
+    int256 darkpoolQuoteChange;
+    /// @dev The expected difference in the relayer fee base balance
+    int256 relayerFeeBaseChange;
+    /// @dev The expected difference in the relayer fee quote balance
+    int256 relayerFeeQuoteChange;
+    /// @dev The expected difference in the protocol fee base balance
+    int256 protocolFeeBaseChange;
+    /// @dev The expected difference in the protocol fee quote balance
+    int256 protocolFeeQuoteChange;
+}
+
+/// @notice Balance snapshot for an address
+struct BalanceSnapshot {
+    int256 base;
+    int256 quote;
+}
+
+/// @notice All balance snapshots at a point in time
+struct BalanceSnapshots {
+    BalanceSnapshot party0;
+    BalanceSnapshot party1;
+    BalanceSnapshot darkpool;
+    BalanceSnapshot relayerFee;
+    BalanceSnapshot protocolFee;
+}
+
+/// @title Settlement Test Utils
+/// @author Renegade Eng
+/// @notice Utility functions for testing settlement
+contract SettlementTestUtils is DarkpoolV2TestUtils {
+    using FeeRateLib for FeeRate;
+
+    /// @notice Create an empty expected differences struct
+    function createEmptyExpectedDifferences() public pure returns (ExpectedDifferences memory expectedDifferences) {
+        expectedDifferences = ExpectedDifferences({
+            party0BaseChange: 0,
+            party0QuoteChange: 0,
+            party1BaseChange: 0,
+            party1QuoteChange: 0,
+            darkpoolBaseChange: 0,
+            darkpoolQuoteChange: 0,
+            relayerFeeBaseChange: 0,
+            relayerFeeQuoteChange: 0,
+            protocolFeeBaseChange: 0,
+            protocolFeeQuoteChange: 0
+        });
+    }
+
+    /// @notice Compute the fees due by a party in a match
+    function computeMatchFees(SettlementObligation memory obligation)
+        public
+        view
+        returns (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake)
+    {
+        uint256 receiveAmount = obligation.amountOut;
+        FeeRate memory relayerFeeRate = relayerFeeRate();
+        relayerFeeTake = relayerFeeRate.computeFeeTake(obligation.outputToken, receiveAmount);
+
+        // Build a protocol fee rate
+        FixedPoint memory rate = darkpool.getProtocolFee(obligation.inputToken, obligation.outputToken);
+        FeeRate memory protocolFeeRate = FeeRate({ rate: rate, recipient: protocolFeeAddr });
+        protocolFeeTake = protocolFeeRate.computeFeeTake(obligation.outputToken, receiveAmount);
+    }
+
+    /// @notice Check the balances before and after settlement
+    /// @param obligationBundle The obligation bundle
+    /// @param party0SettlementBundle The settlement bundle for the first party
+    /// @param party1SettlementBundle The settlement bundle for the second party
+    /// @param expectedDifferences The expected differences in balances
+    function checkBalancesBeforeAndAfterSettlement(
+        ObligationBundle memory obligationBundle,
+        SettlementBundle memory party0SettlementBundle,
+        SettlementBundle memory party1SettlementBundle,
+        ExpectedDifferences memory expectedDifferences
+    )
+        public
+    {
+        // Settle the match and record balances before and after
+        // We have to break up these methods to avoid Yul stack overflows
+        BalanceSnapshots memory preMatch = _captureBalances();
+        darkpool.settleMatch(obligationBundle, party0SettlementBundle, party1SettlementBundle);
+        BalanceSnapshots memory postMatch = _captureBalances();
+
+        // Verify the balance changes
+        _verifyBalanceChanges(preMatch, postMatch, expectedDifferences);
+    }
+
+    /// @notice Capture all balance snapshots
+    function _captureBalances() internal view returns (BalanceSnapshots memory snapshots) {
+        (snapshots.party0.base, snapshots.party0.quote) = baseQuoteBalancesSigned(party0.addr);
+        (snapshots.party1.base, snapshots.party1.quote) = baseQuoteBalancesSigned(party1.addr);
+        (snapshots.darkpool.base, snapshots.darkpool.quote) = baseQuoteBalancesSigned(address(darkpool));
+        (snapshots.relayerFee.base, snapshots.relayerFee.quote) = baseQuoteBalancesSigned(relayerFeeAddr);
+        (snapshots.protocolFee.base, snapshots.protocolFee.quote) = baseQuoteBalancesSigned(protocolFeeAddr);
+    }
+
+    /// @notice Verify balance changes between two snapshots match expected differences
+    function _verifyBalanceChanges(
+        BalanceSnapshots memory preMatch,
+        BalanceSnapshots memory postMatch,
+        ExpectedDifferences memory expectedDifferences
+    )
+        internal
+        pure
+    {
+        assertEq(
+            postMatch.party0.base - preMatch.party0.base, expectedDifferences.party0BaseChange, "party0 base change"
+        );
+        assertEq(
+            postMatch.party0.quote - preMatch.party0.quote, expectedDifferences.party0QuoteChange, "party0 quote change"
+        );
+        assertEq(
+            postMatch.party1.base - preMatch.party1.base, expectedDifferences.party1BaseChange, "party1 base change"
+        );
+        assertEq(
+            postMatch.party1.quote - preMatch.party1.quote, expectedDifferences.party1QuoteChange, "party1 quote change"
+        );
+        assertEq(
+            postMatch.darkpool.base - preMatch.darkpool.base,
+            expectedDifferences.darkpoolBaseChange,
+            "darkpool base change"
+        );
+        assertEq(
+            postMatch.darkpool.quote - preMatch.darkpool.quote,
+            expectedDifferences.darkpoolQuoteChange,
+            "darkpool quote change"
+        );
+        assertEq(
+            postMatch.relayerFee.base - preMatch.relayerFee.base,
+            expectedDifferences.relayerFeeBaseChange,
+            "relayer fee base change"
+        );
+        assertEq(
+            postMatch.relayerFee.quote - preMatch.relayerFee.quote,
+            expectedDifferences.relayerFeeQuoteChange,
+            "relayer fee quote change"
+        );
+        assertEq(
+            postMatch.protocolFee.base - preMatch.protocolFee.base,
+            expectedDifferences.protocolFeeBaseChange,
+            "protocol fee base change"
+        );
+        assertEq(
+            postMatch.protocolFee.quote - preMatch.protocolFee.quote,
+            expectedDifferences.protocolFeeQuoteChange,
+            "protocol fee quote change"
+        );
+    }
+}

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -83,7 +83,8 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
 
     /// @dev Create a dummy `SettlementContext` for the test
     function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
-        context = SettlementContextLib.newContext(2, /* transferCapacity */ 2 /* verificationCapacity */ );
+        context =
+            SettlementContextLib.newContext(1, /* numDeposits */ 3, /* numWithdrawals */ 2 /* verificationCapacity */ );
     }
 
     /// @dev Create a dummy intent validity statement

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -151,7 +151,7 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         obligation0.amountIn = randomUint(1, amountRemaining);
         uint256 minAmountOut = authBundle2.permit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
         obligation0.amountOut = minAmountOut + 1;
-        FeeRate memory feeRate2 = randomFeeRate();
+        FeeRate memory feeRate2 = relayerFeeRate();
         authBundle2.executorSignature = createExecutorSignature(feeRate2, obligation0, executor.privateKey);
         ObligationBundle memory obligationBundle2 = buildObligationBundle(obligation0, obligation1);
 

--- a/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
@@ -20,8 +20,9 @@ import {
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { FeeRate } from "darkpoolv2-types/Fee.sol";
+import { SettlementTestUtils } from "../SettlementTestUtils.sol";
 
-contract PublicIntentSettlementTestUtils is DarkpoolV2TestUtils {
+contract PublicIntentSettlementTestUtils is SettlementTestUtils {
     using ObligationLib for ObligationBundle;
     using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
@@ -86,7 +87,8 @@ contract PublicIntentSettlementTestUtils is DarkpoolV2TestUtils {
 
     /// @dev Create a dummy `SettlementTransfers` list for the test
     function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
-        context = SettlementContextLib.newContext(1, /* transferCapacity */ 1 /* verificationCapacity */ );
+        context =
+            SettlementContextLib.newContext(1, /* numDeposits */ 3, /* numWithdrawals */ 1 /* verificationCapacity */ );
     }
 
     /// @dev Helper to create a sample settlement bundle
@@ -129,7 +131,7 @@ contract PublicIntentSettlementTestUtils is DarkpoolV2TestUtils {
         SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
 
         // Create relayer fee rate and sign the executor digest with the executor key
-        FeeRate memory feeRate = randomFeeRate();
+        FeeRate memory feeRate = relayerFeeRate();
         SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
 
         // Create auth bundle

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
@@ -69,7 +69,8 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
 
     /// @dev Create a dummy `SettlementContext` for the test
     function _createSettlementContext() internal pure returns (SettlementContext memory context) {
-        context = SettlementContextLib.newContext(2, /* transferCapacity */ 2 /* verificationCapacity */ );
+        context =
+            SettlementContextLib.newContext(0, /* numDeposits */ 0, /* numWithdrawals */ 2 /* verificationCapacity */ );
     }
 
     /// @dev Create a dummy intent and balance validity statement (first fill)

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -65,7 +65,8 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
 
     /// @dev Create a dummy `SettlementContext` for the test
     function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
-        context = SettlementContextLib.newContext(2, /* transferCapacity */ 2 /* verificationCapacity */ );
+        context =
+            SettlementContextLib.newContext(0, /* numDeposits */ 0, /* numWithdrawals */ 2 /* verificationCapacity */ );
     }
 
     /// @dev Create a dummy intent and balance validity statement (first fill)


### PR DESCRIPTION
### Purpose
This PR computes the fees due on a natively settled public intent and transfers them to the protocol and relayer. I also updated tests to expect the fee payment.

### Testing
- [x] Most unit tests pass
    - The cross-bundle type tests will fail while fees are only partially implemented.