### PR TITLE
darkpoolv2: native-settled-private-intent: Compute and transfer fees

### DIFF
--- a/src/darkpool/v2/libraries/Commitments.sol
+++ b/src/darkpool/v2/libraries/Commitments.sol
@@ -51,11 +51,7 @@ library CommitmentLib {
         returns (BN254.ScalarField)
     {
         // Compute a commitment to the public shares
-        uint256[] memory publicCommitmentInputs = new uint256[](publicShares.length);
-        for (uint256 i = 0; i < publicShares.length; ++i) {
-            publicCommitmentInputs[i] = publicShares[i];
-        }
-        uint256 publicCommitment = hasher.computeResumableCommitment(publicCommitmentInputs);
+        uint256 publicCommitment = hasher.computeResumableCommitment(publicShares);
 
         // Compute the full commitment: H(privateCommitment || publicCommitment)
         return computeCommitment(privateCommitment, BN254.ScalarField.wrap(publicCommitment), hasher);

--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -285,7 +285,7 @@ library PublicInputsLib {
         pure
         returns (BN254.ScalarField[] memory publicInputs)
     {
-        uint256 nPublicInputs = 5;
+        uint256 nPublicInputs = 6;
         publicInputs = new BN254.ScalarField[](nPublicInputs);
 
         // Add the settlement obligation
@@ -294,6 +294,7 @@ library PublicInputsLib {
         publicInputs[2] = BN254.ScalarField.wrap(statement.obligation.amountIn);
         publicInputs[3] = BN254.ScalarField.wrap(statement.obligation.amountOut);
         publicInputs[4] = BN254.ScalarField.wrap(statement.relayerFee.repr);
+        publicInputs[5] = BN254.ScalarField.wrap(uint256(uint160(statement.relayerFeeRecipient)));
     }
 
     /// @notice Serialize the public inputs for a proof of intent and balance public settlement

--- a/src/darkpool/v2/libraries/public_inputs/Settlement.sol
+++ b/src/darkpool/v2/libraries/public_inputs/Settlement.sol
@@ -21,6 +21,8 @@ struct IntentOnlyPublicSettlementStatement {
     SettlementObligation obligation;
     /// @dev The relayer fee charged for the match
     FixedPoint relayerFee;
+    /// @dev The recipient of the relayer fee
+    address relayerFeeRecipient;
 }
 
 /// @notice A statement for a proof of intent and balance public settlement

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -28,8 +28,9 @@ import { IntentOnlyPublicSettlementStatement } from "darkpoolv2-lib/public_input
 import { IntentPublicShare, IntentPublicShareLib } from "darkpoolv2-types/Intent.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { SettlementTestUtils } from "../SettlementTestUtils.sol";
 
-contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
+contract PrivateIntentSettlementTestUtils is SettlementTestUtils {
     using ObligationLib for ObligationBundle;
     using FixedPointLib for FixedPoint;
     using IntentPublicShareLib for IntentPublicShare;
@@ -104,7 +105,11 @@ contract PrivateIntentSettlementTestUtils is DarkpoolV2TestUtils {
         internal
         returns (IntentOnlyPublicSettlementStatement memory)
     {
-        return IntentOnlyPublicSettlementStatement({ obligation: obligation, relayerFee: randomFee() });
+        return IntentOnlyPublicSettlementStatement({
+            obligation: obligation,
+            relayerFee: relayerFeeRateFixedPoint,
+            relayerFeeRecipient: relayerFeeAddr
+        });
     }
 
     /// @dev Helper to create a sample settlement bundle


### PR DESCRIPTION
### Purpose
This PR computes and transfers fees for the native settled private intent handlers. This looks mostly the same as the natively settled public intent case, except that relayer fee information is pulled from the settlement statement.

### Testing
- [x] All tests pass except mixed bundle type test cases.