### PR TITLE
darkpoolv2: external-match: allocate external party transfers

### DIFF
--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -135,12 +135,14 @@ interface IDarkpoolV2 {
         external;
 
     /// @notice Settle a trade with an external party who decides the trade size
-    /// @param inputAmount The input amount for the trade
-    /// @param matchResult The result of the trade with bounds on the input amount
+    /// @param externalPartyAmountIn The input amount for the trade
+    /// @param recipient The recipient of
+    /// @param matchResult The result of the trade with bounds on the external party's input amount
     /// @param internalPartySettlementBundle The settlement bundle for the internal party. This type validates the
     /// internal user's state elements which are input to the trade.
     function settleExternalMatch(
-        uint256 inputAmount,
+        uint256 externalPartyAmountIn,
+        address recipient,
         BoundedMatchResult calldata matchResult,
         SettlementBundle calldata internalPartySettlementBundle
     )

--- a/src/darkpool/v2/types/Obligation.sol
+++ b/src/darkpool/v2/types/Obligation.sol
@@ -28,7 +28,7 @@ library SettlementObligationLib {
         return EfficientHashLib.hash(obligationBytes);
     }
 
-    /// @notice Get the deposit transfer for a settlement obligation
+    /// @notice Get the deposit transfer for a settlement obligation using a permit2 allowance transfer
     /// @param obligation The settlement obligation to get the deposit transfer for
     /// @param owner The owner of the settlement obligation
     /// @return The deposit transfer
@@ -45,6 +45,26 @@ library SettlementObligationLib {
             mint: obligation.inputToken,
             amount: obligation.amountIn,
             transferType: SimpleTransferType.Permit2AllowanceDeposit
+        });
+    }
+
+    /// @notice Get the deposit transfer for a settlement obligation using an ERC20 approval transfer
+    /// @param obligation The settlement obligation to get the ERC20 approval deposit transfer for
+    /// @param owner The owner of the settlement obligation
+    /// @return The ERC20 approval deposit transfer
+    function buildERC20ApprovalDeposit(
+        SettlementObligation memory obligation,
+        address owner
+    )
+        internal
+        pure
+        returns (SimpleTransfer memory)
+    {
+        return SimpleTransfer({
+            account: owner,
+            mint: obligation.inputToken,
+            amount: obligation.amountIn,
+            transferType: SimpleTransferType.ERC20ApprovalDeposit
         });
     }
 


### PR DESCRIPTION
### Purpose
This PR pushes the transfers needed to settle the external party's obligations. We also add a `recipient` parameter to the settle external match entrypoint.