### PR TITLE
darkpoolv2: renegade-settled-private-intent: Compute and transfer fees

### DIFF
--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -305,7 +305,7 @@ library PublicInputsLib {
         pure
         returns (BN254.ScalarField[] memory publicInputs)
     {
-        uint256 nPublicInputs = 12;
+        uint256 nPublicInputs = 13;
         publicInputs = new BN254.ScalarField[](nPublicInputs);
 
         // Add the leaked pre-update amount public share of the intent
@@ -327,8 +327,9 @@ library PublicInputsLib {
         publicInputs[9] = BN254.ScalarField.wrap(statement.settlementObligation.amountIn);
         publicInputs[10] = BN254.ScalarField.wrap(statement.settlementObligation.amountOut);
 
-        // Add the relayer fee
+        // Add the relayer fee and recipient
         publicInputs[11] = BN254.ScalarField.wrap(statement.relayerFee.repr);
+        publicInputs[12] = BN254.ScalarField.wrap(uint256(uint160(statement.relayerFeeRecipient)));
     }
 
     /// @notice Serialize the public inputs for a proof of intent and balance validity

--- a/src/darkpool/v2/libraries/public_inputs/Settlement.sol
+++ b/src/darkpool/v2/libraries/public_inputs/Settlement.sol
@@ -54,6 +54,8 @@ struct IntentAndBalancePublicSettlementStatement {
     /// calldata. This allows the relayer to set the fee and be sure it cannot
     /// be modified by mempool observers.
     FixedPoint relayerFee;
+    /// @dev The recipient of the relayer fee
+    address relayerFeeRecipient;
 }
 
 /// @notice A statement for a proof of intent and balance private settlement

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -183,6 +183,11 @@ library SettlementBundleLib {
     function getNumWithdrawals(SettlementBundle calldata bundle) internal pure returns (uint256) {
         if (isNativelySettled(bundle)) {
             return 3; // One withdrawal for the trader and two for the fees
+        } else if (bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT) {
+            // A renegade settled intent with a public fill
+            // We pay fees immediately after the match is settled to the fee collection EOAs, this results in two
+            // withdrawals
+            return 2;
         }
 
         // All balance updates are Merklized

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
@@ -24,6 +24,14 @@ import { RenegadeSettledPrivateIntentTestUtils } from "./Utils.sol";
 contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivateIntentTestUtils {
     using SettlementBundleLib for RenegadeSettledIntentFirstFillBundle;
 
+    function setUp() public virtual override {
+        super.setUp();
+        // Mint max amounts of the base and quote tokens to the darkpool to capitalize fee payments
+        uint256 maxAmt = 2 ** DarkpoolConstants.AMOUNT_BITS - 1;
+        baseToken.mint(address(darkpool), maxAmt);
+        quoteToken.mint(address(darkpool), maxAmt);
+    }
+
     // -----------
     // | Helpers |
     // -----------

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -28,8 +28,9 @@ import { IntentPreMatchShare } from "darkpoolv2-types/Intent.sol";
 import { IntentAndBalancePublicSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
 import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { SettlementTestUtils } from "../SettlementTestUtils.sol";
 
-contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
+contract RenegadeSettledPrivateIntentTestUtils is SettlementTestUtils {
     using ObligationLib for ObligationBundle;
     using FixedPointLib for FixedPoint;
 
@@ -66,7 +67,7 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
     /// @dev Create a dummy `SettlementContext` for the test
     function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
         context =
-            SettlementContextLib.newContext(0, /* numDeposits */ 0, /* numWithdrawals */ 2 /* verificationCapacity */ );
+            SettlementContextLib.newContext(0, /* numDeposits */ 2, /* numWithdrawals */ 2 /* verificationCapacity */ );
     }
 
     /// @dev Create a dummy intent and balance validity statement (first fill)
@@ -128,8 +129,9 @@ contract RenegadeSettledPrivateIntentTestUtils is DarkpoolV2TestUtils {
             amountPublicShare: randomScalar(),
             inBalancePublicShares: inBalancePublicShares,
             outBalancePublicShares: outBalancePublicShares,
-            relayerFee: FixedPointLib.integerToFixedPoint(100) // Dummy relayer fee
-         });
+            relayerFee: relayerFeeRateFixedPoint,
+            relayerFeeRecipient: relayerFeeAddr
+        });
     }
 
     /// @dev Helper to create a sample settlement bundle


### PR DESCRIPTION
### Purpose
This PR adds fee handling logic to the renegade settled private intent path. Though the balances are private the fees are paid in public because the fill in this case is already public. This is simpler for a number of reasons:
- Users don't accumulate fee balances on their state elements which they later have to settle.
- Share indexing is simpler because no updates happen to the fee shares.

### Testing
- [x] All unit tests pass except the mixed bundle test cases