### PR TITLE
darkpoolv2: external-match: bounded-match-result: add authorization

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -19,7 +19,8 @@ import { NullifierLib } from "renegade-lib/NullifierSet.sol";
 
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
 
-import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/settlement/BoundedMatchResult.sol";
+import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
+import { BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { PartyId, SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
@@ -305,7 +306,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     function settleExternalMatch(
         uint256 externalPartyAmountIn,
         address recipient,
-        BoundedMatchResult calldata matchResult,
+        BoundedMatchResultBundle calldata matchBundle,
         SettlementBundle calldata internalPartySettlementBundle
     )
         public
@@ -316,11 +317,11 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
 
         // Build settlement obligations from the bounded match result and external party amount in
         (SettlementObligation memory externalObligation, SettlementObligation memory internalObligation) =
-            BoundedMatchResultLib.buildObligations(matchResult, externalPartyAmountIn);
+            BoundedMatchResultLib.buildObligations(matchBundle.permit.matchResult, externalPartyAmountIn);
 
         // Validate and authorize the settlement bundles
         SettlementLib.executeExternalSettlementBundle(
-            internalObligation, internalPartySettlementBundle, settlementContext, _state, hasher
+            matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, _state, hasher
         );
 
         // Allocate transfers for external party

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -13,7 +13,7 @@ import {
     PrivateProtocolFeePaymentProofBundle,
     PrivateRelayerFeePaymentProofBundle
 } from "darkpoolv2-types/ProofBundles.sol";
-import { BoundedMatchResult } from "darkpoolv2-types/settlement/BoundedMatchResult.sol";
+import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
@@ -137,13 +137,13 @@ interface IDarkpoolV2 {
     /// @notice Settle a trade with an external party who decides the trade size
     /// @param externalPartyAmountIn The input amount for the trade
     /// @param recipient The recipient of
-    /// @param matchResult The result of the trade with bounds on the external party's input amount
-    /// @param internalPartySettlementBundle The settlement bundle for the internal party. This type validates the
-    /// internal user's state elements which are input to the trade.
+    /// @param matchBundle The bounded match result bundle
+    /// @param internalPartySettlementBundle The settlement bundle for the internal party. This type validates
+    /// the internal user's state elements which are input to the trade.
     function settleExternalMatch(
         uint256 externalPartyAmountIn,
         address recipient,
-        BoundedMatchResult calldata matchResult,
+        BoundedMatchResultBundle calldata matchBundle,
         SettlementBundle calldata internalPartySettlementBundle
     )
         external;

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -2,9 +2,14 @@
 pragma solidity ^0.8.24;
 
 import {
+    BoundedMatchResultBundle,
+    BoundedMatchResultPermit,
+    BoundedMatchResultPermitLib
+} from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
+import {
     PartyId,
-    SettlementBundle,
     PublicIntentPublicBalanceBundle,
+    SettlementBundle,
     SettlementBundleLib
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
@@ -20,21 +25,22 @@ import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { SignatureWithNonceLib, SignatureWithNonce } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
 
 /// @title Native Settled Public Intent Library
 /// @author Renegade Eng
 /// @notice Library for validating a natively settled public intent
 /// @dev A natively settled public intent is a public intent with a public (EOA) balance.
 library NativeSettledPublicIntentLib {
-    using FixedPointLib for FixedPoint;
-    using SignatureWithNonceLib for SignatureWithNonce;
-    using SettlementBundleLib for SettlementBundle;
-    using ObligationLib for ObligationBundle;
-    using SettlementObligationLib for SettlementObligation;
-    using PublicIntentPermitLib for PublicIntentPermit;
-    using SettlementContextLib for SettlementContext;
     using DarkpoolStateLib for DarkpoolState;
+    using FixedPointLib for FixedPoint;
+    using ObligationLib for ObligationBundle;
+    using PublicIntentPermitLib for PublicIntentPermit;
+    using SettlementBundleLib for SettlementBundle;
+    using SettlementContextLib for SettlementContext;
+    using SettlementObligationLib for SettlementObligation;
+    using SignatureWithNonceLib for SignatureWithNonce;
+    using BoundedMatchResultPermitLib for BoundedMatchResultPermit;
 
     /// @notice Error thrown when an intent signature is invalid
     error InvalidIntentSignature();
@@ -68,17 +74,23 @@ library NativeSettledPublicIntentLib {
         internal
     {
         // Decode the settlement bundle data
+        PublicIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePublicBundleData();
         SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
-        execute(obligation, settlementBundle, settlementContext, state);
+        // Verify that the executor has signed the settlement obligation
+        validateObligationAuthorization(bundleData.auth, obligation, state);
+
+        executeInner(bundleData, obligation, settlementContext, state);
     }
 
-    /// @notice Validate and execute a public intent and public balance settlement bundle
+    /// @notice Validate and execute a public intent and public balance settlement bundle for a bounded match
+    /// @param matchBundle The bounded match result authorization bundle to validate
     /// @param obligation The settlement obligation to validate
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
-    function execute(
+    function executeBoundedMatch(
+        BoundedMatchResultBundle calldata matchBundle,
         SettlementObligation memory obligation,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
@@ -89,9 +101,28 @@ library NativeSettledPublicIntentLib {
         // Decode the settlement bundle data
         PublicIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePublicBundleData();
 
+        // Verify that the executor has signed the bounded match result, authorizing the settlement obligation derived
+        // from it
+        validateBoundedMatchResultAuthorization(matchBundle, state);
+
+        executeInner(bundleData, obligation, settlementContext, state);
+    }
+
+    /// @notice Execute a public intent and public balance settlement bundle
+    /// @param bundleData The validated bundle data
+    /// @param obligation The validated settlement obligation
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
+    function executeInner(
+        PublicIntentPublicBalanceBundle memory bundleData,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        private
+    {
         // 1. Validate the intent authorization
-        (uint256 amountRemaining, bytes32 intentHash) =
-            validatePublicIntentAuthorization(bundleData.auth, obligation, state);
+        (uint256 amountRemaining, bytes32 intentHash) = validatePublicIntentAuthorization(bundleData.auth, state);
 
         // 2. Validate the intent and balance constraints on the obligation
         Intent memory intent = bundleData.auth.permit.intent;
@@ -107,28 +138,18 @@ library NativeSettledPublicIntentLib {
 
     /// @notice Validate the authorization of a public intent
     /// @param auth The public intent authorization bundle to validate
-    /// @param obligation The settlement obligation to validate
     /// @param state The darkpool state containing all storage references
-    /// @dev We require two checks to pass for a public intent to be authorized:
-    /// 1. The executor has signed the settlement obligation. This authorizes the individual fill parameters.
-    /// 2. The intent owner has signed a tuple of (executor, intent). This authorizes the intent to be filled by the
-    /// executor.
-    /// @return amountRemaining The amount remaining of the intent
+    /// @dev We require that the intent owner has signed a tuple of (executor, intent). This authorizes the intent to be
+    /// filled by the executor.
+    /// @return amountRemaining The amount remaining on the intent
     /// @return intentHash The hash of the intent
     function validatePublicIntentAuthorization(
         PublicIntentAuthBundle memory auth,
-        SettlementObligation memory obligation,
         DarkpoolState storage state
     )
         internal
         returns (uint256 amountRemaining, bytes32 intentHash)
     {
-        // Verify that the executor has signed the settlement obligation
-        bytes32 obligationHash = obligation.computeObligationHash();
-        bool executorValid = auth.executorSignature.verifyPrehashed(auth.permit.executor, obligationHash);
-        if (!executorValid) revert InvalidExecutorSignature();
-        state.spendNonce(auth.executorSignature.nonce);
-
         // If the intent is already in the mapping, we need not check its owner's signature
         intentHash = auth.permit.computeHash();
         amountRemaining = state.getOpenIntentAmountRemaining(intentHash);
@@ -145,6 +166,51 @@ library NativeSettledPublicIntentLib {
         amountRemaining = auth.permit.intent.amountIn;
         state.setOpenIntentAmountRemaining(intentHash, amountRemaining);
         return (amountRemaining, intentHash);
+    }
+
+    // ----------------------------
+    // | Obligation Authorization |
+    // ----------------------------
+
+    /// @notice Validate the authorization of a settlement obligation
+    /// @param auth The public intent authorization bundle to validate
+    /// @param obligation The settlement obligation to validate
+    /// @param state The darkpool state containing all storage references
+    /// @dev We require that the executor has signed the settlement obligation. This authorizes the individual fill
+    /// parameters.
+    function validateObligationAuthorization(
+        PublicIntentAuthBundle memory auth,
+        SettlementObligation memory obligation,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        bytes32 obligationHash = obligation.computeObligationHash();
+        bool executorValid = auth.executorSignature.verifyPrehashed(auth.permit.executor, obligationHash);
+        if (!executorValid) revert InvalidExecutorSignature();
+        state.spendNonce(auth.executorSignature.nonce);
+    }
+
+    // -------------------------------
+    // | Bounded Match Authorization |
+    // -------------------------------
+
+    /// @notice Validate the authorization of a bounded match result
+    /// @param matchBundle The bounded match result authorization bundle to validate
+    /// @param state The darkpool state containing all storage references
+    /// @dev We require that the executor has a tuple of (executor, match result). This authorizes the match result to
+    /// be filled by the executor.
+    function validateBoundedMatchResultAuthorization(
+        PublicIntentAuthBundle memory auth,
+        BoundedMatchResultBundle calldata matchBundle,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        bytes32 matchResultHash = matchBundle.permit.computeHash();
+        bool executorValid = matchBundle.executorSignature.verifyPrehashed(auth.permit.executor, matchResultHash);
+        if (!executorValid) revert InvalidExecutorSignature();
+        state.spendNonce(matchBundle.executorSignature.nonce);
     }
 
     // --------------------------

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -8,6 +8,7 @@ import { IPermit2 } from "permit2-lib/interfaces/IPermit2.sol";
 import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 
+import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
 import {
     PartyId,
     SettlementBundle,
@@ -231,22 +232,26 @@ library SettlementLib {
     }
 
     /// @notice Execute an external settlement bundle
-    /// @param obligation The settlement obligation to validate
-    /// @param settlementBundle The settlement bundle to validate
+    /// @param matchBundle The bounded match result authorization bundle to validate
+    /// @param internalObligation The settlement obligation to validate
+    /// @param internalPartySettlementBundle The settlement bundle for the internal party
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
     function executeExternalSettlementBundle(
-        SettlementObligation memory obligation,
-        SettlementBundle calldata settlementBundle,
+        BoundedMatchResultBundle calldata matchBundle,
+        SettlementObligation memory internalObligation,
+        SettlementBundle calldata internalPartySettlementBundle,
         SettlementContext memory settlementContext,
         DarkpoolState storage state,
         IHasher _hasher
     )
         internal
     {
-        SettlementBundleType bundleType = settlementBundle.bundleType;
+        SettlementBundleType bundleType = internalPartySettlementBundle.bundleType;
         if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
-            NativeSettledPublicIntentLib.execute(obligation, settlementBundle, settlementContext, state);
+            NativeSettledPublicIntentLib.executeBoundedMatch(
+                matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, state
+            );
         } else {
             // TODO: Add support for other settlement bundle types
             revert InvalidSettlementBundleType();

--- a/src/darkpool/v2/types/BoundedMatchResult.sol
+++ b/src/darkpool/v2/types/BoundedMatchResult.sol
@@ -40,12 +40,12 @@ library BoundedMatchResultLib {
     error ZeroAmount();
 
     /// @notice Build two `SettlementObligation`s from a `BoundedMatchResult` and an input amount.
-    /// @param boundedMatchResult The `BoundedMatchResult` to build the `SettlementObligation`s from
+    /// @param matchResult The `BoundedMatchResult` to build the `SettlementObligation`s from
     /// @param externalPartyAmountIn The amount of the input token to trade for the external party
     /// @return externalObligation The `SettlementObligation` for the external party
     /// @return internalObligation The `SettlementObligation` for the internal party
     function buildObligations(
-        BoundedMatchResult calldata boundedMatchResult,
+        BoundedMatchResult calldata matchResult,
         uint256 externalPartyAmountIn
     )
         internal
@@ -53,13 +53,12 @@ library BoundedMatchResultLib {
         returns (SettlementObligation memory externalObligation, SettlementObligation memory internalObligation)
     {
         // Validate the bounded match result
-        validateBoundedMatchResult(boundedMatchResult, externalPartyAmountIn);
-
-        uint256 internalPartyAmountIn = computeInternalPartyAmountIn(boundedMatchResult, externalPartyAmountIn);
+        validateBoundedMatchResult(matchResult, externalPartyAmountIn);
+        uint256 internalPartyAmountIn = computeInternalPartyAmountIn(matchResult, externalPartyAmountIn);
 
         internalObligation = SettlementObligation({
-            inputToken: boundedMatchResult.internalPartyInputToken,
-            outputToken: boundedMatchResult.internalPartyOutputToken,
+            inputToken: matchResult.internalPartyInputToken,
+            outputToken: matchResult.internalPartyOutputToken,
             amountIn: internalPartyAmountIn,
             amountOut: externalPartyAmountIn
         });

--- a/src/darkpool/v2/types/settlement/BoundedMatchResultBundle.sol
+++ b/src/darkpool/v2/types/settlement/BoundedMatchResultBundle.sol
@@ -1,0 +1,37 @@
+/// SPDX-License-Identifier: Apache
+// solhint-disable one-contract-per-file
+pragma solidity ^0.8.24;
+
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
+
+// --------------------------------------------
+// | Bounded Match Result Authorization Types |
+// --------------------------------------------
+
+/// @notice Bounded match result authorization payload with signature attached
+struct BoundedMatchResultBundle {
+    /// @dev The bounded match result authorization permit
+    BoundedMatchResultPermit permit;
+    /// @dev The signature of the bounded match result by the authorized executor
+    SignatureWithNonce executorSignature;
+}
+
+/// @notice Bounded match result authorization data
+struct BoundedMatchResultPermit {
+    /// @dev The bounded match result
+    BoundedMatchResult matchResult;
+}
+
+/// @title Bounded Match Result Permit Library
+/// @author Renegade Eng
+/// @notice Library for bounded match result permit operations
+library BoundedMatchResultPermitLib {
+    /// @notice Compute the hash of a `BoundedMatchResultPermit`
+    /// @param matchResult The `BoundedMatchResult` to compute the hash of
+    /// @return The hash of the `BoundedMatchResultPermit`
+    function computeHash(BoundedMatchResultPermit memory matchResult) internal pure returns (bytes32) {
+        return EfficientHashLib.hash(abi.encode(matchResult));
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds a `BoundedMatchResultBundle` struct which holds the bounded match result as well as the executor's signature over it. This will be used in the settlement of natively settled public intents to ensure the match bundle, and thus the internal party's obligation derived from it, have been authorized by the executor.

### Todo
- [x] Test external settlement with natively settled public intent flow