### PR TITLE
darkpoolv2: Add `cancelOrder` entrypoint and handler

### DIFF
--- a/src/darkpool/v2/contracts/Verifier.sol
+++ b/src/darkpool/v2/contracts/Verifier.sol
@@ -11,6 +11,7 @@ import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
 import {
     DepositProofBundle,
     NewBalanceDepositProofBundle,
+    OrderCancellationProofBundle,
     WithdrawalProofBundle,
     PublicProtocolFeePaymentProofBundle,
     PublicRelayerFeePaymentProofBundle,
@@ -28,6 +29,7 @@ import {
     ValidPrivateProtocolFeePaymentStatement,
     ValidPrivateRelayerFeePaymentStatement
 } from "darkpoolv2-lib/public_inputs/Fees.sol";
+import { ValidOrderCancellationStatement } from "darkpoolv2-lib/public_inputs/OrderCancellation.sol";
 import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
 
 /// @title Verifier
@@ -37,6 +39,7 @@ contract Verifier is IVerifier {
     using PublicInputsLib for ValidDepositStatement;
     using PublicInputsLib for ValidBalanceCreateStatement;
     using PublicInputsLib for ValidWithdrawalStatement;
+    using PublicInputsLib for ValidOrderCancellationStatement;
     using PublicInputsLib for ValidPublicProtocolFeePaymentStatement;
     using PublicInputsLib for ValidPublicRelayerFeePaymentStatement;
     using PublicInputsLib for ValidPrivateProtocolFeePaymentStatement;
@@ -82,6 +85,17 @@ contract Verifier is IVerifier {
         VerificationKey memory vk = VKEYS.withdrawalKeys();
         BN254.ScalarField[] memory publicInputs = withdrawalProofBundle.statement.statementSerialize();
         return VerifierCore.verify(withdrawalProofBundle.proof, publicInputs, vk);
+    }
+
+    /// @inheritdoc IVerifier
+    function verifyOrderCancellationValidity(OrderCancellationProofBundle calldata orderCancellationProofBundle)
+        external
+        view
+        returns (bool)
+    {
+        VerificationKey memory vk = PublicInputsLib.dummyVkey();
+        BN254.ScalarField[] memory publicInputs = orderCancellationProofBundle.statement.statementSerialize();
+        return VerifierCore.verify(orderCancellationProofBundle.proof, publicInputs, vk);
     }
 
     /// @inheritdoc IVerifier

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -7,6 +7,7 @@ import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.s
 import {
     DepositProofBundle,
     NewBalanceDepositProofBundle,
+    OrderCancellationProofBundle,
     WithdrawalProofBundle,
     PublicProtocolFeePaymentProofBundle,
     PublicRelayerFeePaymentProofBundle,
@@ -15,6 +16,7 @@ import {
 } from "darkpoolv2-types/ProofBundles.sol";
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
+import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
 import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
@@ -110,6 +112,15 @@ interface IDarkpoolV2 {
     /// @param auth The authorization for the withdrawal
     /// @param withdrawalProofBundle The proof bundle for the withdrawal
     function withdraw(WithdrawalAuth memory auth, WithdrawalProofBundle calldata withdrawalProofBundle) external;
+
+    /// @notice Cancel an order in the darkpool
+    /// @param auth The authorization for the order cancellation
+    /// @param orderCancellationProofBundle The proof bundle for the order cancellation
+    function cancelOrder(
+        OrderCancellationAuth memory auth,
+        OrderCancellationProofBundle calldata orderCancellationProofBundle
+    )
+        external;
 
     /// @notice Pay protocol fees publicly on a balance
     /// @param proofBundle The proof bundle for the public protocol fee payment

--- a/src/darkpool/v2/interfaces/IVerifier.sol
+++ b/src/darkpool/v2/interfaces/IVerifier.sol
@@ -7,6 +7,7 @@ import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verif
 import {
     DepositProofBundle,
     NewBalanceDepositProofBundle,
+    OrderCancellationProofBundle,
     WithdrawalProofBundle,
     PublicProtocolFeePaymentProofBundle,
     PublicRelayerFeePaymentProofBundle,
@@ -38,6 +39,14 @@ interface IVerifier {
     /// @param withdrawalProofBundle The proof bundle for the withdrawal
     /// @return True if the proof is valid, false otherwise
     function verifyWithdrawalValidity(WithdrawalProofBundle calldata withdrawalProofBundle)
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify a proof of `VALID ORDER CANCELLATION`
+    /// @param orderCancellationProofBundle The proof bundle for the order cancellation
+    /// @return True if the proof is valid, false otherwise
+    function verifyOrderCancellationValidity(OrderCancellationProofBundle calldata orderCancellationProofBundle)
         external
         view
         returns (bool);

--- a/src/darkpool/v2/libraries/public_inputs/OrderCancellation.sol
+++ b/src/darkpool/v2/libraries/public_inputs/OrderCancellation.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+/// @title Order Cancellation Public Inputs Library
+/// @author Renegade Eng
+/// @notice Library for operating on proof public inputs for order cancellation
+struct ValidOrderCancellationStatement {
+    /// @dev The Merkle root to which the old intent opens
+    BN254.ScalarField merkleRoot;
+    /// @dev The nullifier of the old intent
+    BN254.ScalarField oldIntentNullifier;
+    /// @dev The owner of the intent, leaked in the statement to allow the contracts to verify
+    /// that cancellation is authorized by the owner.
+    address owner;
+}

--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -12,6 +12,7 @@ import {
     ValidPrivateRelayerFeePaymentStatement,
     FeePaymentValidityStatement
 } from "./Fees.sol";
+import { ValidOrderCancellationStatement } from "./OrderCancellation.sol";
 import {
     IntentOnlyValidityStatementFirstFill,
     IntentOnlyValidityStatement,
@@ -101,6 +102,21 @@ library PublicInputsLib {
         publicInputs[5] = statement.newBalanceCommitment;
         publicInputs[6] = statement.recoveryId;
         publicInputs[7] = statement.newAmountShare;
+    }
+
+    /// @notice Serialize the public inputs for a proof of order cancellation validity
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(ValidOrderCancellationStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 3;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = statement.merkleRoot;
+        publicInputs[1] = statement.oldIntentNullifier;
+        publicInputs[2] = BN254.ScalarField.wrap(uint256(uint160(statement.owner)));
     }
 
     /// @notice Serialize the public inputs for a proof of public protocol fee payment validity

--- a/src/darkpool/v2/types/OrderCancellation.sol
+++ b/src/darkpool/v2/types/OrderCancellation.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+/// @notice The authorization for an order cancellation
+/// @dev This authorizes the cancellation of an intent, containing a signature over the intent's nullifier by the owner.
+struct OrderCancellationAuth {
+    /// @dev The signature of the intent nullifier
+    bytes signature;
+}

--- a/src/darkpool/v2/types/ProofBundles.sol
+++ b/src/darkpool/v2/types/ProofBundles.sol
@@ -12,11 +12,23 @@ import {
     ValidPrivateProtocolFeePaymentStatement,
     ValidPrivateRelayerFeePaymentStatement
 } from "darkpoolv2-lib/public_inputs/Fees.sol";
+import { ValidOrderCancellationStatement } from "darkpoolv2-lib/public_inputs/OrderCancellation.sol";
 
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 
 /// This file stores bundles which package a proof together with its statement (public inputs) and any
 /// proof-linking arguments necessary for connecting proofs.
+
+// --- Order Cancellation --- //
+
+struct OrderCancellationProofBundle {
+    /// @dev The Merkle depth of the order
+    uint256 merkleDepth;
+    /// @dev The statement of the order cancellation validity
+    ValidOrderCancellationStatement statement;
+    /// @dev The proof of the order cancellation validity
+    PlonkProof proof;
+}
 
 // --- Transfers --- //
 

--- a/test/test-contracts/TestVerifierV2.sol
+++ b/test/test-contracts/TestVerifierV2.sol
@@ -8,6 +8,7 @@ import { PlonkProof, VerificationKey, OpeningElements } from "renegade-lib/verif
 import {
     DepositProofBundle,
     NewBalanceDepositProofBundle,
+    OrderCancellationProofBundle,
     WithdrawalProofBundle,
     PublicProtocolFeePaymentProofBundle,
     PublicRelayerFeePaymentProofBundle,
@@ -32,6 +33,11 @@ contract TestVerifierV2 is IVerifier {
 
     /// @inheritdoc IVerifier
     function verifyWithdrawalValidity(WithdrawalProofBundle calldata) external pure returns (bool) {
+        return true;
+    }
+
+    /// @inheritdoc IVerifier
+    function verifyOrderCancellationValidity(OrderCancellationProofBundle calldata) external pure returns (bool) {
         return true;
     }
 


### PR DESCRIPTION
### Purpose
This PR adds an entrypoint for cancelling an order. This method checks:
1. A proof of `VALID ORDER CANCELLATION`.
2. A signature over the intent's nullifier authorizing the cancellation.

Then spends the nullifier of the intent to prevent its further use.

### Todo
- Add tests for order cancellation

### Testing
- [x] Existing tests pass