### PR TITLE
abi: relayer-types: Add relayer types for ring 1 settlement

### DIFF
--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -28,6 +28,7 @@ v2-relayer-types = [
     "dep:renegade-constants-v2",
     "dep:renegade-crypto-v2",
 ]
+v2-auth-helpers = ["alloy/rand"]
 
 [dependencies]
 alloy = { version = "1.0.1", features = ["essentials"] }

--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -1807,6 +1807,71 @@
     "anonymous": false
   },
   {
+    "type": "error",
+    "name": "DepositVerificationFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FeePaymentVerificationFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "IncompatibleAmounts",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "IncompatibleObligationTypes",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "IncompatiblePairs",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidIntentCommitmentSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidOrderCancellationSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPublicInputLength",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSettlementBundleType",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OrderCancellationVerificationFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ProofVerificationFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SettlementVerificationFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WithdrawalVerificationFailed",
+    "inputs": []
+  },
+  {
     "type": "function",
     "name": "batchVerify",
     "inputs": [

--- a/abi/src/v2/auth_helpers.rs
+++ b/abi/src/v2/auth_helpers.rs
@@ -1,0 +1,27 @@
+//! Authorization helpers for the V2 ABI
+
+use alloy::{
+    primitives::{keccak256, U256},
+    signers::{local::PrivateKeySigner, Error as SignerError, SignerSync},
+};
+
+use crate::v2::IDarkpoolV2::SignatureWithNonce;
+
+/// Generate a signature with a nonce for a given message
+pub fn sign_with_nonce(
+    payload: &[u8],
+    signer: &PrivateKeySigner,
+) -> Result<SignatureWithNonce, SignerError> {
+    // Hash the payload with the nonce
+    let nonce = U256::random();
+    let nonce_bytes = nonce.to_be_bytes::<{ U256::BYTES }>();
+    let full_payload = [payload, nonce_bytes.as_slice()].concat();
+
+    let digest = keccak256(&full_payload);
+    let signature = signer.sign_hash_sync(&digest)?;
+    let sig_bytes = signature.as_bytes().to_vec();
+    Ok(SignatureWithNonce {
+        nonce,
+        signature: sig_bytes.into(),
+    })
+}

--- a/abi/src/v2/calldata_bundles.rs
+++ b/abi/src/v2/calldata_bundles.rs
@@ -1,0 +1,48 @@
+//! Calldata bundle implementations for the V2 ABI
+use alloy::sol_types::SolValue;
+
+use super::IDarkpoolV2::*;
+use super::*;
+
+/// The public obligation bundle type
+pub const PUBLIC_OBLIGATION_BUNDLE_TYPE: u8 = 0;
+/// The private obligation bundle type
+pub const PRIVATE_OBLIGATION_BUNDLE_TYPE: u8 = 1;
+
+/// The type of the bundle for a natively-settled private intent
+pub const NATIVE_SETTLED_PRIVATE_INTENT_BUNDLE_TYPE: u8 = 1;
+
+impl ObligationBundle {
+    /// Create a new public obligation bundle
+    pub fn new_public(
+        obligation0: SettlementObligation,
+        obligation1: SettlementObligation,
+    ) -> Self {
+        let data = (obligation0, obligation1).abi_encode();
+        Self {
+            obligationType: PUBLIC_OBLIGATION_BUNDLE_TYPE,
+            data: data.into(),
+        }
+    }
+}
+
+impl SettlementBundle {
+    pub fn private_intent_public_balance_first_fill(
+        auth: PrivateIntentAuthBundleFirstFill,
+        settlement_statement: IntentOnlyPublicSettlementStatement,
+        settlement_proof: PlonkProof,
+    ) -> Self {
+        let inner = PrivateIntentPublicBalanceFirstFillBundle {
+            auth,
+            settlementStatement: settlement_statement,
+            settlementProof: settlement_proof,
+        };
+        let data = inner.abi_encode();
+
+        Self {
+            isFirstFill: true,
+            bundleType: NATIVE_SETTLED_PRIVATE_INTENT_BUNDLE_TYPE,
+            data: data.into(),
+        }
+    }
+}

--- a/abi/src/v2/mod.rs
+++ b/abi/src/v2/mod.rs
@@ -6,6 +6,7 @@ pub mod transfer_auth;
 // We use a combined ABI between the darkpool v2, verifier, and vkeys interfaces as the sol macro currently requires all
 // types to be present in the same macro invocation.
 sol! {
+    #![sol(all_derives)]
     #[allow(missing_docs, clippy::too_many_arguments)]
     #[sol(rpc)]
     IDarkpoolV2,
@@ -14,3 +15,8 @@ sol! {
 
 #[cfg(feature = "v2-relayer-types")]
 pub mod relayer_types;
+
+#[cfg(feature = "v2-auth-helpers")]
+pub mod auth_helpers;
+
+pub mod calldata_bundles;

--- a/abi/src/v2/relayer_types/intent.rs
+++ b/abi/src/v2/relayer_types/intent.rs
@@ -1,0 +1,62 @@
+//! Conversion for intent types
+
+use super::u256_to_scalar;
+use crate::v2::{
+    relayer_types::{u128_to_u256, u256_to_u128},
+    IDarkpoolV2,
+};
+use renegade_circuit_types_v2::{
+    fixed_point::FixedPointShare,
+    intent::{Intent as CircuitIntent, IntentShare},
+};
+use renegade_crypto_v2::fields::scalar_to_u256;
+
+impl From<IDarkpoolV2::Intent> for CircuitIntent {
+    fn from(intent: IDarkpoolV2::Intent) -> Self {
+        Self {
+            in_token: intent.inToken,
+            out_token: intent.outToken,
+            owner: intent.owner,
+            min_price: intent.minPrice.into(),
+            amount_in: u256_to_u128(intent.amountIn),
+        }
+    }
+}
+
+impl From<CircuitIntent> for IDarkpoolV2::Intent {
+    fn from(intent: CircuitIntent) -> Self {
+        Self {
+            inToken: intent.in_token,
+            outToken: intent.out_token,
+            owner: intent.owner,
+            minPrice: intent.min_price.into(),
+            amountIn: u128_to_u256(intent.amount_in),
+        }
+    }
+}
+
+impl From<IntentShare> for IDarkpoolV2::IntentPublicShare {
+    fn from(share: IntentShare) -> Self {
+        Self {
+            inToken: scalar_to_u256(&share.in_token),
+            outToken: scalar_to_u256(&share.out_token),
+            owner: scalar_to_u256(&share.owner),
+            minPrice: scalar_to_u256(&share.min_price.repr),
+            amountIn: scalar_to_u256(&share.amount_in),
+        }
+    }
+}
+
+impl From<IDarkpoolV2::IntentPublicShare> for IntentShare {
+    fn from(share: IDarkpoolV2::IntentPublicShare) -> Self {
+        Self {
+            in_token: u256_to_scalar(share.inToken),
+            out_token: u256_to_scalar(share.outToken),
+            owner: u256_to_scalar(share.owner),
+            min_price: FixedPointShare {
+                repr: u256_to_scalar(share.minPrice),
+            },
+            amount_in: u256_to_scalar(share.amountIn),
+        }
+    }
+}

--- a/abi/src/v2/relayer_types/mod.rs
+++ b/abi/src/v2/relayer_types/mod.rs
@@ -1,12 +1,16 @@
 //! Relayer type interactions and conversions for the V2 ABI
 
 use alloy::primitives::U256;
+use renegade_circuit_types_v2::fixed_point::FixedPoint;
 use renegade_constants_v2::Scalar;
 use renegade_crypto_v2::fields::scalar_to_u256;
 
+use crate::v2::IDarkpoolV2;
 use crate::v2::BN254;
 
 pub mod deposit;
+pub mod intent;
+pub mod obligation;
 pub mod proof_bundles;
 pub mod withdrawal;
 
@@ -31,4 +35,28 @@ pub fn u128_to_u256(x: u128) -> U256 {
 pub fn scalar_to_contract_scalar(scalar: Scalar) -> BN254::ScalarField {
     let u256 = scalar_to_u256(&scalar);
     BN254::ScalarField::from_underlying(u256)
+}
+
+/// Convert a `U256` to a `Scalar`
+pub fn u256_to_scalar(u256: U256) -> Scalar {
+    let bytes: [u8; 32] = u256.to_be_bytes();
+    Scalar::from_be_bytes_mod_order(&bytes)
+}
+
+/// Convert a `FixedPoint` to a contract `FixedPoint`
+impl From<FixedPoint> for IDarkpoolV2::FixedPoint {
+    fn from(fixed_point: FixedPoint) -> Self {
+        Self {
+            repr: scalar_to_u256(&fixed_point.repr),
+        }
+    }
+}
+
+/// Convert a contract `FixedPoint` to a `FixedPoint`
+impl From<IDarkpoolV2::FixedPoint> for FixedPoint {
+    fn from(fixed_point: IDarkpoolV2::FixedPoint) -> Self {
+        Self {
+            repr: u256_to_scalar(fixed_point.repr),
+        }
+    }
 }

--- a/abi/src/v2/relayer_types/obligation.rs
+++ b/abi/src/v2/relayer_types/obligation.rs
@@ -1,0 +1,30 @@
+//! Conversion for obligation types
+
+use crate::v2::{
+    relayer_types::{u128_to_u256, u256_to_u128},
+    IDarkpoolV2,
+};
+
+use renegade_circuit_types_v2::settlement_obligation::SettlementObligation as CircuitObligation;
+
+impl From<IDarkpoolV2::SettlementObligation> for CircuitObligation {
+    fn from(obligation: IDarkpoolV2::SettlementObligation) -> Self {
+        Self {
+            input_token: obligation.inputToken,
+            output_token: obligation.outputToken,
+            amount_in: u256_to_u128(obligation.amountIn),
+            amount_out: u256_to_u128(obligation.amountOut),
+        }
+    }
+}
+
+impl From<CircuitObligation> for IDarkpoolV2::SettlementObligation {
+    fn from(obligation: CircuitObligation) -> Self {
+        Self {
+            inputToken: obligation.input_token,
+            outputToken: obligation.output_token,
+            amountIn: u128_to_u256(obligation.amount_in),
+            amountOut: u128_to_u256(obligation.amount_out),
+        }
+    }
+}

--- a/abi/src/v2/relayer_types/proof_bundles.rs
+++ b/abi/src/v2/relayer_types/proof_bundles.rs
@@ -5,8 +5,10 @@ use crate::v2::IDarkpoolV2;
 use crate::v2::BN254::G1Point;
 use renegade_circuit_types_v2::{traits::BaseType, PlonkProof};
 use renegade_circuits_v2::zk_circuits::{
+    settlement::intent_only_public_settlement::IntentOnlyPublicSettlementStatement,
     valid_balance_create::ValidBalanceCreateStatement, valid_deposit::ValidDepositStatement,
     valid_withdrawal::ValidWithdrawalStatement,
+    validity_proofs::intent_only_first_fill::IntentOnlyFirstFillValidityStatement,
 };
 use renegade_crypto_v2::fields::scalar_to_u256;
 
@@ -102,6 +104,31 @@ impl From<ValidWithdrawalStatement> for IDarkpoolV2::ValidWithdrawalStatement {
             newBalanceCommitment: scalar_to_u256(&statement.new_balance_commitment),
             recoveryId: scalar_to_u256(&statement.recovery_id),
             newAmountShare: scalar_to_u256(&statement.new_amount_share),
+        }
+    }
+}
+
+impl From<IntentOnlyFirstFillValidityStatement>
+    for IDarkpoolV2::IntentOnlyValidityStatementFirstFill
+{
+    fn from(statement: IntentOnlyFirstFillValidityStatement) -> Self {
+        Self {
+            intentOwner: statement.owner,
+            intentPrivateCommitment: scalar_to_u256(&statement.intent_private_commitment),
+            recoveryId: scalar_to_u256(&statement.recovery_id),
+            intentPublicShare: statement.intent_public_share.into(),
+        }
+    }
+}
+
+impl From<IntentOnlyPublicSettlementStatement>
+    for IDarkpoolV2::IntentOnlyPublicSettlementStatement
+{
+    fn from(statement: IntentOnlyPublicSettlementStatement) -> Self {
+        Self {
+            obligation: statement.settlement_obligation.into(),
+            relayerFee: statement.relayer_fee.into(),
+            relayerFeeRecipient: statement.relayer_fee_recipient,
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR updates the `abi` crate to include helpers for creating ring-1 settlement calldata.

### Testing
- [x] Used in integration tests