### PR TITLE
darkpoolv2: Split darkpool contract into libraries for size

### DIFF
--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -28,6 +28,34 @@ import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 /// @author Renegade Eng
 /// @notice Interface for the DarkpoolV2 contract
 interface IDarkpoolV2 {
+    // --- Error Messages --- //
+    /// @notice Thrown when proof verification fails
+    error ProofVerificationFailed();
+    /// @notice Thrown when a deposit verification fails
+    error DepositVerificationFailed();
+    /// @notice Thrown when a withdrawal verification fails
+    error WithdrawalVerificationFailed();
+    /// @notice Thrown when a fee payment verification fails
+    error FeePaymentVerificationFailed();
+    /// @notice Thrown when an order cancellation verification fails
+    error OrderCancellationVerificationFailed();
+    /// @notice Thrown when the order cancellation signature is invalid
+    error InvalidOrderCancellationSignature();
+    /// @notice Thrown when the obligation types are not compatible
+    error IncompatibleObligationTypes();
+    /// @notice Thrown when the obligation tokens are not compatible
+    error IncompatiblePairs();
+    /// @notice Thrown when the obligation amounts are not compatible
+    error IncompatibleAmounts();
+    /// @notice Thrown when the settlement bundle type is invalid
+    error InvalidSettlementBundleType();
+    /// @notice Thrown when verification fails for a settlement
+    error SettlementVerificationFailed();
+    /// @notice Thrown when an intent commitment signature is invalid
+    error InvalidIntentCommitmentSignature();
+    /// @notice Thrown when the public input length is invalid
+    error InvalidPublicInputLength();
+
     // --- Events --- //
 
     /// @notice Emitted when an internal Merkle node is updated

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -29,6 +29,7 @@ import { FeeRate, FeeRateLib, FeeTake, FeeTakeLib } from "darkpoolv2-types/Fee.s
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { SignatureWithNonceLib, SignatureWithNonce } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 
 /// @title Native Settled Private Intent Library
 /// @author Renegade Eng
@@ -48,11 +49,6 @@ library NativeSettledPrivateIntentLib {
     using PublicInputsLib for IntentOnlyPublicSettlementStatement;
     using FeeRateLib for FeeRate;
     using FeeTakeLib for FeeTake;
-
-    // --- Errors --- //
-
-    /// @notice Error thrown when an intent commitment signature is invalid
-    error InvalidIntentCommitmentSignature();
 
     // --- Implementation --- //
 
@@ -237,7 +233,7 @@ library NativeSettledPrivateIntentLib {
 
         bytes32 commitmentHash = EfficientHashLib.hash(bytes32(commitment));
         bool valid = authBundle.intentSignature.verifyPrehashed(intentOwner, commitmentHash);
-        if (!valid) revert InvalidIntentCommitmentSignature();
+        if (!valid) revert IDarkpoolV2.InvalidIntentCommitmentSignature();
         state.spendNonce(authBundle.intentSignature.nonce);
     }
 

--- a/test/darkpool/v2/OrderCancellation.t.sol
+++ b/test/darkpool/v2/OrderCancellation.t.sol
@@ -9,6 +9,7 @@ import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
 import { ValidOrderCancellationStatement } from "darkpoolv2-lib/public_inputs/OrderCancellation.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { DarkpoolV2 } from "darkpoolv2-contracts/DarkpoolV2.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { NullifierLib } from "renegade-lib/NullifierSet.sol";
 
 /// @title OrderCancellationTest
@@ -120,7 +121,7 @@ contract OrderCancellationTest is DarkpoolV2TestUtils {
         OrderCancellationAuth memory auth = createOrderCancellationAuthWrongSigner(intentNullifier);
 
         // Should revert due to invalid signature
-        vm.expectRevert(DarkpoolV2.InvalidOrderCancellationSignature.selector);
+        vm.expectRevert(IDarkpoolV2.InvalidOrderCancellationSignature.selector);
         darkpool.cancelOrder(auth, proofBundle);
     }
 }

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -18,6 +18,7 @@ import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { NativeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPrivateIntent.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { PrivateIntentSettlementTestUtils } from "./Utils.sol";
 
 contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
@@ -99,7 +100,7 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         bundle.data = abi.encode(bundleData);
 
         // Should revert with InvalidIntentCommitmentSignature
-        vm.expectRevert(NativeSettledPrivateIntentLib.InvalidIntentCommitmentSignature.selector);
+        vm.expectRevert(IDarkpoolV2.InvalidIntentCommitmentSignature.selector);
         authorizeIntentHelper(obligationBundle, bundle);
     }
 

--- a/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
@@ -8,6 +8,7 @@ import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.s
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 
 contract ObligationCompatibilityTest is PublicIntentSettlementTestUtils {
@@ -54,7 +55,7 @@ contract ObligationCompatibilityTest is PublicIntentSettlementTestUtils {
 
         // Should revert with IncompatiblePairs
         ObligationBundle memory obligationBundle = buildObligationBundle(party0Obligation, party1Obligation);
-        vm.expectRevert(SettlementLib.IncompatiblePairs.selector);
+        vm.expectRevert(IDarkpoolV2.IncompatiblePairs.selector);
         validateObligationBundleHelper(obligationBundle);
     }
 
@@ -71,7 +72,7 @@ contract ObligationCompatibilityTest is PublicIntentSettlementTestUtils {
 
         // Should revert with IncompatibleAmounts
         ObligationBundle memory obligationBundle = buildObligationBundle(party0Obligation, party1Obligation);
-        vm.expectRevert(SettlementLib.IncompatibleAmounts.selector);
+        vm.expectRevert(IDarkpoolV2.IncompatibleAmounts.selector);
         validateObligationBundleHelper(obligationBundle);
     }
 


### PR DESCRIPTION
### Purpose
This PR makes two changes in light of the integration testing:
1. Splits the `DarkpoolV2` entrypoint implementations out into libraries; currently `SettlementLib.sol` and `StateUpdatesLib.sol`. This brings the darkpool contract below the 24kb max size.
2. Moves all errors onto `IDarkpool`. This allows the client to generate abi types for the errors automatically and deserialize them directly rather than just printing an opaque error selector.

### Testing
- [x] All unit tests pass
- [x] Tested changes with the integration tests