### PR TITLE
integration: v2: Include proof linking in settlement tests

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -636,6 +636,11 @@
         "internalType": "contract IHasher"
       },
       {
+        "name": "vkeys_",
+        "type": "address",
+        "internalType": "contract IVkeys"
+      },
+      {
         "name": "verifier_",
         "type": "address",
         "internalType": "contract IVerifier"
@@ -1834,6 +1839,11 @@
   {
     "type": "error",
     "name": "InvalidIntentCommitmentSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidObligation",
     "inputs": []
   },
   {
@@ -3930,7 +3940,1372 @@
   },
   {
     "type": "function",
+    "name": "intentAndBalanceFirstFillValidityKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentAndBalancePrivateSettlementKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentAndBalancePublicSettlementKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentAndBalanceSettlement0LinkingKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ProofLinkingVK",
+        "components": [
+          {
+            "name": "linkGroupGenerator",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "linkGroupOffset",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "linkGroupSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentAndBalanceSettlement1LinkingKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ProofLinkingVK",
+        "components": [
+          {
+            "name": "linkGroupGenerator",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "linkGroupOffset",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "linkGroupSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentAndBalanceValidityKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentOnlyFirstFillValidityKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentOnlyPublicSettlementKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentOnlySettlementLinkingKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ProofLinkingVK",
+        "components": [
+          {
+            "name": "linkGroupGenerator",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "linkGroupOffset",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "linkGroupSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "intentOnlyValidityKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "noteRedemptionKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "orderCancellationKeys",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct VerificationKey",
+        "components": [
+          {
+            "name": "n",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "l",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "k",
+            "type": "uint256[5]",
+            "internalType": "BN254.ScalarField[5]"
+          },
+          {
+            "name": "qComms",
+            "type": "tuple[13]",
+            "internalType": "struct BN254.G1Point[13]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "sigmaComms",
+            "type": "tuple[5]",
+            "internalType": "struct BN254.G1Point[5]",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "g",
+            "type": "tuple",
+            "internalType": "struct BN254.G1Point",
+            "components": [
+              {
+                "name": "x",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "h",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          },
+          {
+            "name": "xH",
+            "type": "tuple",
+            "internalType": "struct BN254.G2Point",
+            "components": [
+              {
+                "name": "x0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "x1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y0",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              },
+              {
+                "name": "y1",
+                "type": "uint256",
+                "internalType": "BN254.BaseField"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "outputBalanceSettlement0LinkingKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ProofLinkingVK",
+        "components": [
+          {
+            "name": "linkGroupGenerator",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "linkGroupOffset",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "linkGroupSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "outputBalanceSettlement1LinkingKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct ProofLinkingVK",
+        "components": [
+          {
+            "name": "linkGroupGenerator",
+            "type": "uint256",
+            "internalType": "BN254.ScalarField"
+          },
+          {
+            "name": "linkGroupOffset",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "linkGroupSize",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "outputBalanceValidityKeys",
     "inputs": [],
     "outputs": [
       {
@@ -5887,6 +7262,47 @@
                 "internalType": "BN254.ScalarField"
               }
             ]
+          },
+          {
+            "name": "authSettlementLinkingProof",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linkingQuotientPolyComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linkingPolyOpening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }
@@ -6220,6 +7636,47 @@
                 "name": "zBar",
                 "type": "uint256",
                 "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "authSettlementLinkingProof",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linkingQuotientPolyComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linkingPolyOpening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
               }
             ]
           }
@@ -6584,6 +8041,47 @@
                 "internalType": "BN254.ScalarField"
               }
             ]
+          },
+          {
+            "name": "authSettlementLinkingProof",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linkingQuotientPolyComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linkingPolyOpening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }
@@ -6939,6 +8437,47 @@
                 "name": "zBar",
                 "type": "uint256",
                 "internalType": "BN254.ScalarField"
+              }
+            ]
+          },
+          {
+            "name": "authSettlementLinkingProof",
+            "type": "tuple",
+            "internalType": "struct LinkingProof",
+            "components": [
+              {
+                "name": "linkingQuotientPolyComm",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
+              },
+              {
+                "name": "linkingPolyOpening",
+                "type": "tuple",
+                "internalType": "struct BN254.G1Point",
+                "components": [
+                  {
+                    "name": "x",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  },
+                  {
+                    "name": "y",
+                    "type": "uint256",
+                    "internalType": "BN254.BaseField"
+                  }
+                ]
               }
             ]
           }
@@ -11881,6 +13420,122 @@
                 ]
               }
             ]
+          },
+          {
+            "name": "proofLinkingArguments",
+            "type": "tuple",
+            "internalType": "struct ProofLinkingList",
+            "components": [
+              {
+                "name": "nextIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "instances",
+                "type": "tuple[]",
+                "internalType": "struct ProofLinkingInstance[]",
+                "components": [
+                  {
+                    "name": "wireComm0",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireComm1",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "proof",
+                    "type": "tuple",
+                    "internalType": "struct LinkingProof",
+                    "components": [
+                      {
+                        "name": "linkingQuotientPolyComm",
+                        "type": "tuple",
+                        "internalType": "struct BN254.G1Point",
+                        "components": [
+                          {
+                            "name": "x",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          },
+                          {
+                            "name": "y",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "linkingPolyOpening",
+                        "type": "tuple",
+                        "internalType": "struct BN254.G1Point",
+                        "components": [
+                          {
+                            "name": "x",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          },
+                          {
+                            "name": "y",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "vk",
+                    "type": "tuple",
+                    "internalType": "struct ProofLinkingVK",
+                    "components": [
+                      {
+                        "name": "linkGroupGenerator",
+                        "type": "uint256",
+                        "internalType": "BN254.ScalarField"
+                      },
+                      {
+                        "name": "linkGroupOffset",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "linkGroupSize",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       }
@@ -12220,6 +13875,122 @@
                         "name": "y1",
                         "type": "uint256",
                         "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "proofLinkingArguments",
+            "type": "tuple",
+            "internalType": "struct ProofLinkingList",
+            "components": [
+              {
+                "name": "nextIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "instances",
+                "type": "tuple[]",
+                "internalType": "struct ProofLinkingInstance[]",
+                "components": [
+                  {
+                    "name": "wireComm0",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "wireComm1",
+                    "type": "tuple",
+                    "internalType": "struct BN254.G1Point",
+                    "components": [
+                      {
+                        "name": "x",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      },
+                      {
+                        "name": "y",
+                        "type": "uint256",
+                        "internalType": "BN254.BaseField"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "proof",
+                    "type": "tuple",
+                    "internalType": "struct LinkingProof",
+                    "components": [
+                      {
+                        "name": "linkingQuotientPolyComm",
+                        "type": "tuple",
+                        "internalType": "struct BN254.G1Point",
+                        "components": [
+                          {
+                            "name": "x",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          },
+                          {
+                            "name": "y",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "linkingPolyOpening",
+                        "type": "tuple",
+                        "internalType": "struct BN254.G1Point",
+                        "components": [
+                          {
+                            "name": "x",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          },
+                          {
+                            "name": "y",
+                            "type": "uint256",
+                            "internalType": "BN254.BaseField"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "vk",
+                    "type": "tuple",
+                    "internalType": "struct ProofLinkingVK",
+                    "components": [
+                      {
+                        "name": "linkGroupGenerator",
+                        "type": "uint256",
+                        "internalType": "BN254.ScalarField"
+                      },
+                      {
+                        "name": "linkGroupOffset",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      },
+                      {
+                        "name": "linkGroupSize",
+                        "type": "uint256",
+                        "internalType": "uint256"
                       }
                     ]
                   }

--- a/abi/src/v2/calldata_bundles.rs
+++ b/abi/src/v2/calldata_bundles.rs
@@ -31,11 +31,13 @@ impl SettlementBundle {
         auth: PrivateIntentAuthBundleFirstFill,
         settlement_statement: IntentOnlyPublicSettlementStatement,
         settlement_proof: PlonkProof,
+        linking_proof: LinkingProof,
     ) -> Self {
         let inner = PrivateIntentPublicBalanceFirstFillBundle {
             auth,
             settlementStatement: settlement_statement,
             settlementProof: settlement_proof,
+            authSettlementLinkingProof: linking_proof,
         };
         let data = inner.abi_encode();
 

--- a/abi/src/v2/relayer_types/proof_bundles.rs
+++ b/abi/src/v2/relayer_types/proof_bundles.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::v2::IDarkpoolV2;
 use crate::v2::BN254::G1Point;
-use renegade_circuit_types_v2::{traits::BaseType, PlonkProof};
+use renegade_circuit_types_v2::{traits::BaseType, PlonkLinkProof, PlonkProof};
 use renegade_circuits_v2::zk_circuits::{
     settlement::intent_only_public_settlement::IntentOnlyPublicSettlementStatement,
     valid_balance_create::ValidBalanceCreateStatement, valid_deposit::ValidDepositStatement,
@@ -161,6 +161,15 @@ impl From<PlonkProof> for IDarkpoolV2::PlonkProof {
             wireEvals: size_vec(evals.wires_evals.into_iter().map(fr_to_u256).collect()),
             sigmaEvals: size_vec(evals.wire_sigma_evals.into_iter().map(fr_to_u256).collect()),
             zBar: fr_to_u256(evals.perm_next_eval),
+        }
+    }
+}
+
+impl From<PlonkLinkProof> for IDarkpoolV2::LinkingProof {
+    fn from(proof: PlonkLinkProof) -> Self {
+        Self {
+            linkingQuotientPolyComm: convert_jf_commitment(proof.quotient_commitment),
+            linkingPolyOpening: convert_g1_point(proof.opening_proof.proof),
         }
     }
 }

--- a/integration/v2/src/tests/create_balance.rs
+++ b/integration/v2/src/tests/create_balance.rs
@@ -59,7 +59,7 @@ integration_test_async!(test_create_balance);
 ///
 /// Assumes that the signer has already been funded with the deposit amount
 /// and that the Permit2 contract has been approved to spend the tokens
-pub(crate) async fn create_balance(
+pub async fn create_balance(
     args: &TestArgs,
     deposit: &Deposit,
 ) -> Result<(TransactionReceipt, DarkpoolStateBalance)> {

--- a/integration/v2/src/tests/deposit.rs
+++ b/integration/v2/src/tests/deposit.rs
@@ -79,7 +79,7 @@ integration_test_async!(test_deposit);
 // --- Circuits Helpers --- //
 
 /// Create a proof of the deposit
-fn create_proof_bundle(
+pub fn create_proof_bundle(
     deposit: &Deposit,
     balance: &DarkpoolStateBalance,
     opening: &MerkleAuthenticationPath,

--- a/integration/v2/src/tests/withdraw.rs
+++ b/integration/v2/src/tests/withdraw.rs
@@ -77,7 +77,7 @@ integration_test_async!(test_withdraw);
 // --- Circuits Helpers --- //
 
 /// Create a proof of the withdrawal
-fn create_proof_bundle(
+pub fn create_proof_bundle(
     withdrawal: &Withdrawal,
     balance: &DarkpoolStateBalance,
     opening: &MerkleAuthenticationPath,

--- a/src/darkpool/v2/libraries/TransferLib.sol
+++ b/src/darkpool/v2/libraries/TransferLib.sol
@@ -44,7 +44,7 @@ library ExternalTransferLib {
     /// @param transfer The transfer to execute
     /// @param wrapper The WETH9 wrapper contract for native token handling
     /// @param permit2 The permit2 contract instance
-    function executeTransfer(SimpleTransfer memory transfer, IWETH9 wrapper, IAllowanceTransfer permit2) internal {
+    function executeTransfer(SimpleTransfer memory transfer, IWETH9 wrapper, IAllowanceTransfer permit2) public {
         // If the amount is zero, do nothing
         if (transfer.amount == 0) {
             return;

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -275,7 +275,7 @@ library SettlementLib {
 
         // Create the extra commitment opening elements implied by the proof linking relation
         OpeningElements memory linkOpenings =
-            ProofLinkingCore.createOpeningElements(settlementContext.proofLinkingArguments.getInstances());
+            ProofLinkingCore.createOpeningElements(settlementContext.proofLinkingArguments.instances);
 
         // Call the core verifier
         bool valid = verifier.batchVerify(

--- a/src/darkpool/v2/types/VerificationList.sol
+++ b/src/darkpool/v2/types/VerificationList.sol
@@ -117,15 +117,4 @@ library ProofLinkingListLib {
         list.instances[list.nextIndex] = instance;
         ++list.nextIndex;
     }
-
-    /// @notice Get the instances array up to the current length
-    /// @param list The list to get instances from
-    /// @return The instances array with the correct length
-    function getInstances(ProofLinkingList memory list) internal pure returns (ProofLinkingInstance[] memory) {
-        ProofLinkingInstance[] memory instances = new ProofLinkingInstance[](list.nextIndex);
-        for (uint256 i = 0; i < list.nextIndex; i++) {
-            instances[i] = list.instances[i];
-        }
-        return instances;
-    }
 }


### PR DESCRIPTION
### Purpose
This PR includes the proof linking arguments in the ring 1 integration tests. Specifically, this is a proof link between a proof of `INTENT ONLY VALIDITY` and `INTENT ONLY PUBLIC SETTLEMENT`.

### Testing
- [x] Integration tests pass