### PR TITLE
integrationv2: settlement: Add ring 1 subsequent fills

### DIFF
--- a/abi/src/v2/calldata_bundles.rs
+++ b/abi/src/v2/calldata_bundles.rs
@@ -27,6 +27,7 @@ impl ObligationBundle {
 }
 
 impl SettlementBundle {
+    /// Build a private intent, public balance settlement bundle for a first fill
     pub fn private_intent_public_balance_first_fill(
         auth: PrivateIntentAuthBundleFirstFill,
         settlement_statement: IntentOnlyPublicSettlementStatement,
@@ -43,6 +44,28 @@ impl SettlementBundle {
 
         Self {
             isFirstFill: true,
+            bundleType: NATIVE_SETTLED_PRIVATE_INTENT_BUNDLE_TYPE,
+            data: data.into(),
+        }
+    }
+
+    /// Build a private intent, public balance settlement bundle for a subsequent fill
+    pub fn private_intent_public_balance(
+        auth: PrivateIntentAuthBundle,
+        settlement_statement: IntentOnlyPublicSettlementStatement,
+        settlement_proof: PlonkProof,
+        linking_proof: LinkingProof,
+    ) -> Self {
+        let inner = PrivateIntentPublicBalanceBundle {
+            auth,
+            settlementStatement: settlement_statement,
+            settlementProof: settlement_proof,
+            authSettlementLinkingProof: linking_proof,
+        };
+        let data = inner.abi_encode();
+
+        Self {
+            isFirstFill: false,
             bundleType: NATIVE_SETTLED_PRIVATE_INTENT_BUNDLE_TYPE,
             data: data.into(),
         }

--- a/abi/src/v2/relayer_types/commitments.rs
+++ b/abi/src/v2/relayer_types/commitments.rs
@@ -1,0 +1,15 @@
+//! Commitment type conversions
+
+use renegade_circuit_types_v2::state_wrapper::PartialCommitment;
+use renegade_crypto_v2::fields::scalar_to_u256;
+
+use crate::v2::IDarkpoolV2;
+
+impl From<PartialCommitment> for IDarkpoolV2::PartialCommitment {
+    fn from(partial_commitment: PartialCommitment) -> Self {
+        Self {
+            privateCommitment: scalar_to_u256(&partial_commitment.private_commitment),
+            partialPublicCommitment: scalar_to_u256(&partial_commitment.partial_public_commitment),
+        }
+    }
+}

--- a/abi/src/v2/relayer_types/mod.rs
+++ b/abi/src/v2/relayer_types/mod.rs
@@ -8,6 +8,7 @@ use renegade_crypto_v2::fields::scalar_to_u256;
 use crate::v2::IDarkpoolV2;
 use crate::v2::BN254;
 
+pub mod commitments;
 pub mod deposit;
 pub mod intent;
 pub mod obligation;

--- a/abi/src/v2/relayer_types/proof_bundles.rs
+++ b/abi/src/v2/relayer_types/proof_bundles.rs
@@ -6,9 +6,13 @@ use crate::v2::BN254::G1Point;
 use renegade_circuit_types_v2::{traits::BaseType, PlonkLinkProof, PlonkProof};
 use renegade_circuits_v2::zk_circuits::{
     settlement::intent_only_public_settlement::IntentOnlyPublicSettlementStatement,
-    valid_balance_create::ValidBalanceCreateStatement, valid_deposit::ValidDepositStatement,
+    valid_balance_create::ValidBalanceCreateStatement,
+    valid_deposit::ValidDepositStatement,
     valid_withdrawal::ValidWithdrawalStatement,
-    validity_proofs::intent_only_first_fill::IntentOnlyFirstFillValidityStatement,
+    validity_proofs::{
+        intent_only::IntentOnlyValidityStatement,
+        intent_only_first_fill::IntentOnlyFirstFillValidityStatement,
+    },
 };
 use renegade_crypto_v2::fields::scalar_to_u256;
 
@@ -117,6 +121,19 @@ impl From<IntentOnlyFirstFillValidityStatement>
             intentPrivateCommitment: scalar_to_u256(&statement.intent_private_commitment),
             recoveryId: scalar_to_u256(&statement.recovery_id),
             intentPublicShare: statement.intent_public_share.into(),
+        }
+    }
+}
+
+impl From<IntentOnlyValidityStatement> for IDarkpoolV2::IntentOnlyValidityStatement {
+    fn from(statement: IntentOnlyValidityStatement) -> Self {
+        Self {
+            intentOwner: statement.owner,
+            merkleRoot: scalar_to_u256(&statement.merkle_root),
+            oldIntentNullifier: scalar_to_u256(&statement.old_intent_nullifier),
+            newAmountShare: scalar_to_u256(&statement.new_amount_public_share),
+            newIntentPartialCommitment: statement.new_intent_partial_commitment.into(),
+            recoveryId: scalar_to_u256(&statement.recovery_id),
         }
     }
 }

--- a/integration/v2/src/tests/settlement/mod.rs
+++ b/integration/v2/src/tests/settlement/mod.rs
@@ -1,3 +1,38 @@
 //! Settlement tests
 
+use eyre::Result;
+use renegade_circuit_types::{
+    fee::FeeTake, fixed_point::FixedPoint, settlement_obligation::SettlementObligation,
+};
+use renegade_crypto::fields::scalar_to_u128;
+
+use crate::test_args::TestArgs;
+
 mod private_intent_public_balance;
+
+/// The settlement relayer fee to use for testing
+pub fn settlement_relayer_fee() -> FixedPoint {
+    FixedPoint::from_f64_round_down(0.0001) // 1bp
+}
+
+/// Get the total fee applicable to a settlement
+pub async fn get_total_fee(args: &TestArgs) -> Result<(FixedPoint, FixedPoint)> {
+    let protocol_fee = args.protocol_fee().await?;
+    let relayer_fee = settlement_relayer_fee();
+    Ok((relayer_fee, protocol_fee))
+}
+
+/// Compute the fee take for an obligation
+pub async fn compute_fee_take(
+    obligation: &SettlementObligation,
+    args: &TestArgs,
+) -> Result<FeeTake> {
+    let (relayer_fee_rate, protocol_fee_rate) = get_total_fee(args).await?;
+    let relayer_fee = relayer_fee_rate.floor_mul_int(obligation.amount_out);
+    let protocol_fee = protocol_fee_rate.floor_mul_int(obligation.amount_out);
+
+    Ok(FeeTake {
+        relayer_fee: scalar_to_u128(&relayer_fee),
+        protocol_fee: scalar_to_u128(&protocol_fee),
+    })
+}

--- a/integration/v2/src/util/merkle.rs
+++ b/integration/v2/src/util/merkle.rs
@@ -3,10 +3,17 @@
 use alloy::{
     primitives::{TxHash, U256},
     providers::Provider,
+    rpc::types::TransactionReceipt,
+    sol_types::SolEventInterface,
 };
 use eyre::{eyre, Result};
 use itertools::Itertools;
 use num_bigint::BigUint;
+use renegade_abi::v2::IDarkpoolV2::{self, IDarkpoolV2Events};
+use renegade_circuit_types::{
+    state_wrapper::StateWrapper,
+    traits::{CircuitBaseType, SecretShareBaseType},
+};
 use renegade_common::types::merkle::MerkleAuthenticationPath;
 use renegade_constants::{Scalar, MERKLE_HEIGHT};
 use renegade_crypto::fields::{scalar_to_u256, u256_to_scalar};
@@ -26,6 +33,19 @@ fn size_vec<const N: usize, T>(vec: Vec<T>) -> [T; N] {
 // | Merkle Proofs |
 // -----------------
 
+/// Find the Merkle opening for a state element
+pub async fn find_state_element_opening<T>(
+    state_element: &StateWrapper<T>,
+    receipt: &TransactionReceipt,
+) -> Result<MerkleAuthenticationPath>
+where
+    T: SecretShareBaseType + CircuitBaseType,
+    T::ShareType: CircuitBaseType,
+{
+    let commitment = state_element.compute_commitment();
+    parse_merkle_opening_from_receipt(commitment, receipt)
+}
+
 /// Fetch a Merkle opening for a given commitment in a tx
 ///
 /// Takes the commitment and returns the sibling path used to hash the commitment into the
@@ -35,25 +55,10 @@ pub async fn fetch_merkle_opening(
     darkpool: &Darkpool,
 ) -> Result<MerkleAuthenticationPath> {
     // 1. Find the commitment in the darkpool logs
-    let (merkle_index, tx_hash) = find_commitment(commitment, darkpool).await?;
+    let (_, tx_hash) = find_commitment(commitment, darkpool).await?;
 
     // 2. Fetch all Merkle opening logs for the tx
-    let siblings = fetch_merkle_openings(tx_hash, darkpool).await?;
-
-    // 3. Construct the authentication path
-    let leaf_index = BigUint::from(merkle_index);
-    let path_siblings = size_vec(
-        siblings
-            .into_iter()
-            .map(|(_, v)| u256_to_scalar(&v))
-            .collect_vec(),
-    );
-
-    Ok(MerkleAuthenticationPath {
-        path_siblings,
-        leaf_index,
-        value: commitment,
-    })
+    fetch_merkle_openings(commitment, tx_hash, darkpool).await
 }
 
 /// Find the given commitment in the Merkle insertion logs
@@ -80,25 +85,89 @@ async fn find_commitment(commitment: Scalar, darkpool: &Darkpool) -> Result<(u12
 /// Fetch the Merkle opening logs for a given tx hash
 ///
 /// Returns the logs in order of increasing height (decreasing depth)
-async fn fetch_merkle_openings(tx_hash: TxHash, darkpool: &Darkpool) -> Result<Vec<(u128, U256)>> {
+async fn fetch_merkle_openings(
+    commitment: Scalar,
+    tx_hash: TxHash,
+    darkpool: &Darkpool,
+) -> Result<MerkleAuthenticationPath> {
     let tx_receipt = darkpool
         .provider()
         .get_transaction_receipt(tx_hash)
         .await?
         .expect("no tx receipt");
 
-    let mut opening_nodes = Vec::with_capacity(MERKLE_HEIGHT);
-    for log in tx_receipt.logs() {
-        if let Ok(decoded) = log
-            .log_decode::<renegade_abi::v2::IDarkpoolV2::MerkleOpeningNode>()
-            .map(|l| l.into_inner())
-        {
-            opening_nodes.push((decoded.depth, decoded.index, decoded.new_value));
+    parse_merkle_opening_from_receipt(commitment, &tx_receipt)
+}
+
+/// Parse a Merkle opening from a tx receipt
+///
+/// Extracts MerkleOpeningNode events from the transaction receipt and returns them
+/// sorted by increasing height (decreasing depth).
+///
+/// Returns a vector of (index, value) tuples representing the sibling nodes
+pub fn parse_merkle_opening_from_receipt(
+    commitment: Scalar,
+    receipt: &TransactionReceipt,
+) -> Result<MerkleAuthenticationPath> {
+    let commitment_u256 = scalar_to_u256(&commitment);
+
+    let mut commitment_found = false;
+    let mut leaf_index = 0;
+    let mut opening_index = 0;
+    let mut all_sister_nodes = Vec::with_capacity(MERKLE_HEIGHT);
+    for log in receipt.logs() {
+        let log = match IDarkpoolV2::IDarkpoolV2Events::decode_log(&log.inner) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        match log.data {
+            IDarkpoolV2Events::MerkleInsertion(data) => {
+                if data.value == commitment_u256 {
+                    commitment_found = true;
+                    leaf_index = data.index;
+                } else {
+                    opening_index += 1;
+                }
+            }
+            IDarkpoolV2Events::MerkleOpeningNode(data) => {
+                all_sister_nodes.push((data.depth, data.index, data.new_value));
+            }
+            _ => continue,
         }
     }
+
+    if !commitment_found {
+        return Err(eyre!("commitment not found in transaction"));
+    }
+
+    // Multiple insertions may have been made in this transaction. We want the `opening_index`th group of `MERKLE_HEIGHT` sister nodes
+    let start_idx = opening_index * MERKLE_HEIGHT;
+    let end_idx = start_idx + MERKLE_HEIGHT;
+    let mut opening_nodes = all_sister_nodes[start_idx..end_idx].to_vec();
 
     // Sort by decreasing depth
     opening_nodes.sort_by_key(|s| -(s.0 as i8));
     let siblings = opening_nodes.into_iter().map(|(_, i, v)| (i, v)).collect();
-    Ok(siblings)
+    Ok(build_authentication_path(leaf_index, commitment, siblings))
+}
+
+/// Build an authentication path from a vector of sibling nodes
+fn build_authentication_path(
+    leaf_index: u128,
+    commitment: Scalar,
+    siblings: Vec<(u128, U256)>,
+) -> MerkleAuthenticationPath {
+    let path_siblings = size_vec(
+        siblings
+            .into_iter()
+            .map(|(_, v)| u256_to_scalar(&v))
+            .collect_vec(),
+    );
+
+    MerkleAuthenticationPath {
+        path_siblings,
+        leaf_index: BigUint::from(leaf_index),
+        value: commitment,
+    }
 }


### PR DESCRIPTION
### Purpose
This PR adds a subsequent fill to the ring 1 integration tests. The same parties trade a second time and use the subsequent fill verification path.

### Testing
- [x] All integration tests pass
- [x] All unit tests pass