### PR TITLE
darkpoolv2: external-match: Move settleExternalMatch into SettlementLib, errors into IDarkpool, validate price

### DIFF
--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -65,6 +65,14 @@ interface IDarkpoolV2 {
     error PriceTooLarge(uint256 price);
     /// @notice Thrown when a fee rate is too large
     error FeeRateTooLarge(uint256 feeRate);
+    /// @notice Thrown when a bounded match amount is out of bounds
+    error BoundedMatchAmountOutOfBounds(uint256 amount, uint256 minAmount, uint256 maxAmount);
+    /// @notice Thrown when the bounds of a bounded match result are invalid
+    error InvalidBoundedMatchBounds();
+    /// @notice Thrown when a bounded match has expired
+    error BoundedMatchExpired();
+    /// @notice Thrown when a bounded match amount is zero
+    error BoundedMatchZeroAmount();
 
     // --- Events --- //
 

--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -53,14 +53,6 @@ library DarkpoolConstants {
         }
     }
 
-    /// @notice Check whether a price is valid
-    /// @param price The price to check
-    function validatePrice(FixedPoint memory price) public pure {
-        if (price.repr > MAX_PRICE_REPR) {
-            revert IDarkpoolV2.PriceTooLarge(price.repr);
-        }
-    }
-
     /// @notice Check whether a fee rate is valid
     /// @param feeRate The fee rate to check
     function validateFeeRate(FixedPoint memory feeRate) public pure {
@@ -73,7 +65,7 @@ library DarkpoolConstants {
     /// @param price The price to check
     function validatePrice(FixedPoint memory price) public pure {
         if (price.repr > 2 ** PRICE_BITS - 1) {
-            revert PriceTooLarge(price.repr);
+            revert IDarkpoolV2.PriceTooLarge(price.repr);
         }
     }
 }

--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -35,7 +35,7 @@ library DarkpoolConstants {
     }
     /// @notice The number of bits allowed in a price's representation
     /// @dev This includes the fixed point precision
-    /// @dev This is the default fixed point precision plus 32 bits for the integral part
+    /// @dev This is the default fixed point precision plus 64 bits for the integral part
     uint256 internal constant PRICE_BITS = FixedPointLib.FIXED_POINT_PRECISION_BITS + 64;
 
     /// @notice Check whether an address is the native token address

--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -24,7 +24,8 @@ library DarkpoolConstants {
     /// @dev We allow PRICE_INTEGRAL_BITS integral bits for a price, and inherit the fractional bits from the fixed
     /// point precision.
     /// So the max price is `2 ** (FixedPointLib.FIXED_POINT_PRECISION_BITS + PRICE_INTEGRAL_BITS) - 1`.
-    uint256 internal constant MAX_PRICE_REPR = 2 ** (FixedPointLib.FIXED_POINT_PRECISION_BITS + PRICE_INTEGRAL_BITS) - 1;
+    uint256 internal constant MAX_PRICE_REPR = 2 ** (FixedPointLib.FIXED_POINT_PRECISION_BITS + PRICE_INTEGRAL_BITS)
+        - 1;
 
     /// @notice Get the maximum relayer fee as a FixedPoint struct
     /// @dev Returns the maximum relayer fee (1%) as a FixedPoint
@@ -32,6 +33,10 @@ library DarkpoolConstants {
     function maxRelayerFee() public pure returns (FixedPoint memory) {
         return FixedPoint({ repr: MAX_RELAYER_FEE_REPR });
     }
+    /// @notice The number of bits allowed in a price's representation
+    /// @dev This includes the fixed point precision
+    /// @dev This is the default fixed point precision plus 32 bits for the integral part
+    uint256 internal constant PRICE_BITS = FixedPointLib.FIXED_POINT_PRECISION_BITS + 64;
 
     /// @notice Check whether an address is the native token address
     /// @param addr The address to check
@@ -61,6 +66,14 @@ library DarkpoolConstants {
     function validateFeeRate(FixedPoint memory feeRate) public pure {
         if (feeRate.repr > MAX_RELAYER_FEE_REPR) {
             revert IDarkpoolV2.FeeRateTooLarge(feeRate.repr);
+        }
+    }
+
+    /// @notice Check whether a price is valid
+    /// @param price The price to check
+    function validatePrice(FixedPoint memory price) public pure {
+        if (price.repr > 2 ** PRICE_BITS - 1) {
+            revert PriceTooLarge(price.repr);
         }
     }
 }

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -142,14 +142,12 @@ library NativeSettledPublicIntentLib {
     // ------------------------
 
     /// @notice Validate the authorization of a public intent
-    /// @dev We require two checks to pass for a public intent to be authorized:
-    /// 1. The executor has signed the settlement obligation and relayer fee rate. This check authorizes the match.
-    /// 2. The intent owner has signed a tuple of (executor, intent). This authorizes the intent to be filled by the
-    /// executor across this and subsequent fills.
+    /// @dev We require that the intent owner has signed a tuple of (executor, intent). This authorizes the intent to be
+    /// filled by the executor.
     /// @param bundleData The auth bundle data to validate
     /// @param obligation The settlement obligation to validate
     /// @param state The darkpool state containing all storage references
-    /// @return amountRemaining The amount remaining of the intent
+    /// @return amountRemaining The amount remaining on the intent
     /// @return intentHash The hash of the intent
     function validatePublicIntentAuthorization(
         PublicIntentPublicBalanceBundle memory bundleData,
@@ -194,11 +192,11 @@ library NativeSettledPublicIntentLib {
     // ----------------------------
 
     /// @notice Validate the authorization of a settlement obligation
+    /// @dev We require that the executor has signed the settlement obligation. This authorizes the individual fill
+    /// parameters.
     /// @param auth The public intent authorization bundle to validate
     /// @param obligation The settlement obligation to validate
     /// @param state The darkpool state containing all storage references
-    /// @dev We require that the executor has signed the settlement obligation. This authorizes the individual fill
-    /// parameters.
     function validateObligationAuthorization(
         PublicIntentAuthBundle memory auth,
         SettlementObligation memory obligation,
@@ -217,10 +215,10 @@ library NativeSettledPublicIntentLib {
     // -------------------------------
 
     /// @notice Validate the authorization of a bounded match result
-    /// @param matchBundle The bounded match result authorization bundle to validate
-    /// @param state The darkpool state containing all storage references
     /// @dev We require that the executor has a tuple of (executor, match result). This authorizes the match result to
     /// be filled by the executor.
+    /// @param matchBundle The bounded match result authorization bundle to validate
+    /// @param state The darkpool state containing all storage references
     function validateBoundedMatchResultAuthorization(
         PublicIntentAuthBundle memory auth,
         BoundedMatchResultBundle calldata matchBundle,

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -11,6 +11,7 @@ import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 
 import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
+import { BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
 import {
     PartyId,
     SettlementBundle,
@@ -24,7 +25,7 @@ import {
     PrivateObligationBundle
 } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SimpleTransfer, SimpleTransferType } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
-import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
 import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol";
@@ -48,6 +49,7 @@ library SettlementLib {
     using ObligationLib for ObligationBundle;
     using SettlementBundleLib for SettlementBundle;
     using SettlementContextLib for SettlementContext;
+    using SettlementObligationLib for SettlementObligation;
     using SettlementTransfersLib for SettlementTransfers;
     using ProofLinkingListLib for ProofLinkingList;
     using PublicInputsLib for IntentAndBalancePrivateSettlementStatement;
@@ -99,6 +101,54 @@ library SettlementLib {
         verifySettlementProofs(settlementContext, verifier);
     }
 
+    /// @notice Settle a trade with an external party who decides the trade size
+    /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing commitments
+    /// @param verifier The verifier to use for verification
+    /// @param weth The WETH9 contract instance
+    /// @param permit2 The permit2 contract instance
+    /// @param externalPartyAmountIn The input amount for the trade
+    /// @param recipient The recipient of the withdrawal
+    /// @param matchBundle The bounded match result bundle
+    /// @param internalPartySettlementBundle The settlement bundle for the internal party
+    function settleExternalMatch(
+        DarkpoolState storage state,
+        IHasher hasher,
+        IVerifier verifier,
+        IWETH9 weth,
+        IPermit2 permit2,
+        uint256 externalPartyAmountIn,
+        address recipient,
+        BoundedMatchResultBundle calldata matchBundle,
+        SettlementBundle calldata internalPartySettlementBundle
+    )
+        external
+    {
+        // Allocate a settlement context
+        SettlementContext memory settlementContext = allocateExternalSettlementContext(internalPartySettlementBundle);
+
+        // Build settlement obligations from the bounded match result and external party amount in
+        (SettlementObligation memory externalObligation, SettlementObligation memory internalObligation) =
+            BoundedMatchResultLib.buildObligations(matchBundle.permit.matchResult, externalPartyAmountIn);
+
+        // Validate and authorize the settlement bundles
+        executeExternalSettlementBundle(
+            matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, state, hasher
+        );
+
+        // Allocate transfers for external party
+        // Authorization is implied by virtue of the external party being the one settling
+        allocateExternalSettlementTransfers(recipient, externalObligation, settlementContext);
+
+        // Execute the transfers necessary for settlement
+        // The helpers above will push transfers to the settlement context if necessary
+        executeTransfers(settlementContext, weth, permit2);
+
+        // Verify the proofs necessary for settlement
+        // The helpers above will push proofs to the settlement context if necessary
+        verifySettlementProofs(settlementContext, verifier);
+    }
+
     // --- Allocation --- //
 
     /// @notice Allocate a settlement transfers list for the match settlement
@@ -138,18 +188,27 @@ library SettlementLib {
         pure
         returns (SettlementContext memory)
     {
-        uint256 transferCapacity = SettlementBundleLib.getNumTransfers(internalPartySettlementBundle) + 2;
+        uint256 numDeposits = SettlementBundleLib.getNumDeposits(internalPartySettlementBundle) + 1;
+        uint256 numWithdrawals = SettlementBundleLib.getNumWithdrawals(internalPartySettlementBundle) + 1;
         uint256 proofCapacity = SettlementBundleLib.getNumProofs(internalPartySettlementBundle);
 
-        return SettlementContextLib.newContext(transferCapacity, proofCapacity);
+        return
+            SettlementContextLib.newContext(
+                numDeposits,
+                numWithdrawals,
+                proofCapacity,
+                0 /* proof linking capacity */
+            );
     }
 
     /// @notice Allocate transfers to settle an external party's obligation into the settlement context
-    /// @param recipient The recipient of the withdrawal
+    /// @dev TODO: Implement fee computation and withdrawal transfers for relayer/protocol fees, and use recipient
+    /// parameter for withdrawal
+    /// @param _recipient The recipient of the withdrawal
     /// @param externalObligation The external party's settlement obligation to settle
     /// @param settlementContext The settlement context to which we append post-validation updates.
     function allocateExternalSettlementTransfers(
-        address recipient,
+        address _recipient,
         SettlementObligation memory externalObligation,
         SettlementContext memory settlementContext
     )
@@ -163,7 +222,8 @@ library SettlementLib {
         settlementContext.pushDeposit(deposit);
 
         // Withdraw the output token from the darkpool
-        SimpleTransfer memory withdrawal = externalObligation.buildWithdrawalTransfer(recipient);
+        uint256 totalFee = 0;
+        SimpleTransfer memory withdrawal = externalObligation.buildWithdrawalTransfer(owner, totalFee);
         settlementContext.pushWithdrawal(withdrawal);
     }
 

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -138,7 +138,7 @@ library SettlementLib {
 
         // Allocate transfers for external party
         // Authorization is implied by virtue of the external party being the one settling
-        allocateExternalSettlementTransfers(recipient, externalObligation, settlementContext);
+        allocateExternalMatchSettlementTransfers(recipient, externalObligation, settlementContext);
 
         // Execute the transfers necessary for settlement
         // The helpers above will push transfers to the settlement context if necessary
@@ -204,11 +204,11 @@ library SettlementLib {
     /// @notice Allocate transfers to settle an external party's obligation into the settlement context
     /// @dev TODO: Implement fee computation and withdrawal transfers for relayer/protocol fees, and use recipient
     /// parameter for withdrawal
-    /// @param _recipient The recipient of the withdrawal
+    /// @param recipient The recipient of the withdrawal
     /// @param externalObligation The external party's settlement obligation to settle
     /// @param settlementContext The settlement context to which we append post-validation updates.
-    function allocateExternalSettlementTransfers(
-        address _recipient,
+    function allocateExternalMatchSettlementTransfers(
+        address recipient,
         SettlementObligation memory externalObligation,
         SettlementContext memory settlementContext
     )
@@ -223,7 +223,7 @@ library SettlementLib {
 
         // Withdraw the output token from the darkpool
         uint256 totalFee = 0;
-        SimpleTransfer memory withdrawal = externalObligation.buildWithdrawalTransfer(owner, totalFee);
+        SimpleTransfer memory withdrawal = externalObligation.buildWithdrawalTransfer(recipient, totalFee);
         settlementContext.pushWithdrawal(withdrawal);
     }
 

--- a/src/darkpool/v2/types/BoundedMatchResult.sol
+++ b/src/darkpool/v2/types/BoundedMatchResult.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 
 /// @notice A bounded match result for a trade between an internal and external party.
 /// @dev A bounded match result is one in which the size is not known until transaction submission when
@@ -29,15 +30,6 @@ struct BoundedMatchResult {
 /// @notice Library for bounded match result operations
 library BoundedMatchResultLib {
     using FixedPointLib for FixedPoint;
-
-    /// @notice Error thrown when an amount is out of bounds
-    error AmountOutOfBounds(uint256 amount, uint256 minAmount, uint256 maxAmount);
-    /// @notice Error thrown when the bounds are invalid
-    error InvalidBounds();
-    /// @notice Error thrown when the block deadline has passed
-    error MatchExpired();
-    /// @notice Error thrown when an amount is zero
-    error ZeroAmount();
 
     /// @notice Build two `SettlementObligation`s from a `BoundedMatchResult` and an input amount.
     /// @param matchResult The `BoundedMatchResult` to build the `SettlementObligation`s from
@@ -106,7 +98,7 @@ library BoundedMatchResultLib {
         DarkpoolConstants.validateAmount(externalPartyAmountIn);
 
         if (externalPartyAmountIn == 0) {
-            revert ZeroAmount();
+            revert IDarkpoolV2.BoundedMatchZeroAmount();
         }
 
         // Bounded match result is from the internal party's perspective, so we need to convert the external party input
@@ -116,7 +108,7 @@ library BoundedMatchResultLib {
         bool amountTooLow = internalPartyAmountIn < boundedMatchResult.minInternalPartyAmountIn;
         bool amountTooHigh = internalPartyAmountIn > boundedMatchResult.maxInternalPartyAmountIn;
         if (amountTooLow || amountTooHigh) {
-            revert AmountOutOfBounds(
+            revert IDarkpoolV2.BoundedMatchAmountOutOfBounds(
                 internalPartyAmountIn,
                 boundedMatchResult.minInternalPartyAmountIn,
                 boundedMatchResult.maxInternalPartyAmountIn
@@ -134,7 +126,7 @@ library BoundedMatchResultLib {
         // The min amount must be less than or equal to the max amount
         bool boundsInvalid = boundedMatchResult.minInternalPartyAmountIn > boundedMatchResult.maxInternalPartyAmountIn;
         if (boundsInvalid) {
-            revert InvalidBounds();
+            revert IDarkpoolV2.InvalidBoundedMatchBounds();
         }
     }
 
@@ -142,7 +134,7 @@ library BoundedMatchResultLib {
     /// @param boundedMatchResult The `BoundedMatchResult` to validate the deadline of
     function validateDeadline(BoundedMatchResult calldata boundedMatchResult) internal view {
         bool deadlinePassed = block.number > boundedMatchResult.blockDeadline;
-        if (deadlinePassed) revert MatchExpired();
+        if (deadlinePassed) revert IDarkpoolV2.BoundedMatchExpired();
     }
 
     /// @notice Validates the bitlength of a price in a `BoundedMatchResult`

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -34,6 +34,7 @@ import { PostMatchBalanceShare, PostMatchBalanceShareLib } from "darkpoolv2-type
 import { FeeRate } from "darkpoolv2-types/Fee.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 
 // ---------------------------
 // | Settlement Bundle Types |
@@ -159,9 +160,6 @@ library SettlementBundleLib {
     using IntentPublicShareLib for IntentPublicShare;
     using IntentPreMatchShareLib for IntentPreMatchShare;
     using PostMatchBalanceShareLib for PostMatchBalanceShare;
-
-    /// @notice The error type emitted when a settlement bundle type check fails
-    error InvalidSettlementBundleType();
 
     // --- Context Allocation --- //
 
@@ -587,7 +585,7 @@ library SettlementBundleLib {
     {
         bool validType =
             !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT;
-        require(validType, InvalidSettlementBundleType());
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
     }
 
@@ -601,7 +599,7 @@ library SettlementBundleLib {
     {
         bool validType =
             bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
-        require(validType, InvalidSettlementBundleType());
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceFirstFillBundle));
     }
 
@@ -615,7 +613,7 @@ library SettlementBundleLib {
     {
         bool validType =
             !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
-        require(validType, InvalidSettlementBundleType());
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundle));
     }
 
@@ -628,7 +626,7 @@ library SettlementBundleLib {
         returns (RenegadeSettledIntentFirstFillBundle memory bundleData)
     {
         bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT;
-        require(validType, InvalidSettlementBundleType());
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledIntentFirstFillBundle));
     }
 
@@ -641,7 +639,7 @@ library SettlementBundleLib {
         returns (RenegadeSettledIntentBundle memory bundleData)
     {
         bool validType = !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT;
-        require(validType, InvalidSettlementBundleType());
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledIntentBundle));
     }
 
@@ -655,7 +653,7 @@ library SettlementBundleLib {
     {
         bool validType =
             bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
-        require(validType, InvalidSettlementBundleType());
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFirstFillBundle));
     }
 
@@ -669,7 +667,7 @@ library SettlementBundleLib {
     {
         bool validType =
             !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
-        require(validType, InvalidSettlementBundleType());
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFillBundle));
     }
 }

--- a/test/darkpool/v2/bounded-match-result/BoundedMatchResultValidation.t.sol
+++ b/test/darkpool/v2/bounded-match-result/BoundedMatchResultValidation.t.sol
@@ -7,6 +7,7 @@ import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 
 import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 
 import { BoundedMatchResultTestUtils } from "./Utils.sol";
 
@@ -64,7 +65,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         );
 
         // Should revert with InvalidBounds
-        vm.expectRevert(BoundedMatchResultLib.InvalidBounds.selector);
+        vm.expectRevert(IDarkpoolV2.InvalidBoundedMatchBounds.selector);
         this._validateBounds(matchResult);
     }
 
@@ -88,7 +89,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         );
 
         // Should revert with AmountTooLarge
-        vm.expectRevert(abi.encodeWithSelector(DarkpoolConstants.AmountTooLarge.selector, invalidAmount));
+        vm.expectRevert(abi.encodeWithSelector(IDarkpoolV2.AmountTooLarge.selector, invalidAmount));
         this._validateBounds(matchResultMin);
 
         // Test with max too large
@@ -98,7 +99,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         );
 
         // Should revert with AmountTooLarge
-        vm.expectRevert(abi.encodeWithSelector(DarkpoolConstants.AmountTooLarge.selector, invalidAmount));
+        vm.expectRevert(abi.encodeWithSelector(IDarkpoolV2.AmountTooLarge.selector, invalidAmount));
         this._validateBounds(matchResultMax);
     }
 
@@ -108,7 +109,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         BoundedMatchResult memory matchResult = createBoundedMatchResultWithDeadline(block.number - 1); // Past deadline
 
         // Should revert with MatchExpired
-        vm.expectRevert(BoundedMatchResultLib.MatchExpired.selector);
+        vm.expectRevert(IDarkpoolV2.BoundedMatchExpired.selector);
         this._validateDeadline(matchResult);
     }
 
@@ -125,7 +126,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         BoundedMatchResult memory matchResult = createValidBoundedMatchResult();
 
         // Should revert with ZeroAmount
-        vm.expectRevert(BoundedMatchResultLib.ZeroAmount.selector);
+        vm.expectRevert(IDarkpoolV2.BoundedMatchZeroAmount.selector);
         this._validateAmountIn(matchResult, 0);
     }
 
@@ -142,7 +143,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         // Should revert with AmountOutOfBounds
         vm.expectRevert(
             abi.encodeWithSelector(
-                BoundedMatchResultLib.AmountOutOfBounds.selector,
+                IDarkpoolV2.BoundedMatchAmountOutOfBounds.selector,
                 minInternalPartyAmountIn - 1, // internalPartyAmountIn
                 minInternalPartyAmountIn, // minInternalPartyAmountIn
                 maxInternalPartyAmountIn // maxInternalPartyAmountIn
@@ -166,7 +167,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         // Should revert with AmountOutOfBounds
         vm.expectRevert(
             abi.encodeWithSelector(
-                BoundedMatchResultLib.AmountOutOfBounds.selector,
+                IDarkpoolV2.BoundedMatchAmountOutOfBounds.selector,
                 computedInternalAmount, // internalPartyAmountIn
                 minInternalPartyAmountIn, // minInternalPartyAmountIn
                 maxInternalPartyAmountIn // maxInternalPartyAmountIn
@@ -181,7 +182,7 @@ contract BoundedMatchResultValidationTest is BoundedMatchResultTestUtils {
         uint256 tooLargeAmount = 2 ** DarkpoolConstants.AMOUNT_BITS; // exceeds max
 
         // Should revert with AmountTooLarge
-        vm.expectRevert(abi.encodeWithSelector(DarkpoolConstants.AmountTooLarge.selector, tooLargeAmount));
+        vm.expectRevert(abi.encodeWithSelector(IDarkpoolV2.AmountTooLarge.selector, tooLargeAmount));
         this._validateAmountIn(matchResult, tooLargeAmount);
     }
 }


### PR DESCRIPTION
### Purpose
In this PR we bundle various changes to bring the external settlement flow closer to the internal settlement flow in style and checks including: 
- moving the settlement orchestration logic into `SettlementLib`
- moving bounded match result error definitions into `IDarkpool`
- validating that price is valid