### PR TITLE
darkpoolv2: external-match: add bounded settlement path of ring 1 intents

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[profile.lint]
+[lint]
 exclude_lints = ["incorrect-shift"]
 
 [fmt]

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -24,8 +24,6 @@ import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 
 import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
-import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
-import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
     DepositProofBundle,
@@ -277,6 +275,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
             verifier,
             weth,
             permit2,
+            vkeys,
             externalPartyAmountIn,
             recipient,
             matchBundle,

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -75,6 +75,10 @@ interface IDarkpoolV2 {
     error BoundedMatchExpired();
     /// @notice Thrown when a bounded match amount is zero
     error BoundedMatchZeroAmount();
+    /// @notice Thrown when a bounded match result is invalid
+    error InvalidBoundedMatchResult();
+    /// @notice Thrown when the protocol fee rates used in settlement do not match
+    error InvalidProtocolFeeRates();
 
     // --- Events --- //
 

--- a/src/darkpool/v2/interfaces/ISettlementTypes.sol
+++ b/src/darkpool/v2/interfaces/ISettlementTypes.sol
@@ -7,13 +7,15 @@ pragma solidity ^0.8.24;
 import { SettlementBundle, SettlementBundleType, PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
     PublicIntentPublicBalanceBundle,
-    PrivateIntentPublicBalanceFirstFillBundle,
-    PrivateIntentPublicBalanceBundle,
     RenegadeSettledIntentFirstFillBundle,
     RenegadeSettledIntentBundle,
     RenegadeSettledPrivateFirstFillBundle,
     RenegadeSettledPrivateFillBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    PrivateIntentPublicBalanceFirstFillBundle,
+    PrivateIntentPublicBalanceBundle
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
 import {
     PublicIntentAuthBundle,
     PublicIntentPermit,
@@ -24,7 +26,9 @@ import {
     SignatureWithNonce
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import {
-    ObligationBundle, ObligationType, PrivateObligationBundle
+    ObligationBundle,
+    ObligationType,
+    PrivateObligationBundle
 } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 

--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -319,9 +319,7 @@ library PublicInputsLib {
 
         // Add the fee rates
         publicInputs[6] = BN254.ScalarField.wrap(statement.externalRelayerFeeRate.repr);
-        publicInputs[7] = BN254.ScalarField.wrap(statement.externalProtocolFeeRate.repr);
         publicInputs[8] = BN254.ScalarField.wrap(statement.internalRelayerFeeRate.repr);
-        publicInputs[9] = BN254.ScalarField.wrap(statement.internalProtocolFeeRate.repr);
 
         // Add the relayer fee address
         publicInputs[10] = BN254.ScalarField.wrap(uint256(uint160(statement.relayerFeeAddress)));

--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -19,6 +19,7 @@ import {
     IntentAndBalanceValidityStatement
 } from "./ValidityProofs.sol";
 import {
+    IntentOnlyBoundedSettlementStatement,
     IntentOnlyPublicSettlementStatement,
     IntentAndBalancePublicSettlementStatement,
     IntentAndBalancePrivateSettlementStatement
@@ -294,6 +295,38 @@ library PublicInputsLib {
         publicInputs[5] = BN254.ScalarField.wrap(uint256(uint160(statement.relayerFeeRecipient)));
     }
 
+    /// @notice Serialize the public inputs for a proof of single-intent bounded match settlement
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    /// @dev NOTE: This is a temporary placeholder implementation until the circuits are completed.
+    /// The actual circuit public inputs format may differ from this serialization.
+    function statementSerialize(IntentOnlyBoundedSettlementStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 11;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+
+        // Add the bounded match result fields
+        publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.boundedMatchResult.internalPartyInputToken)));
+        publicInputs[1] =
+            BN254.ScalarField.wrap(uint256(uint160(statement.boundedMatchResult.internalPartyOutputToken)));
+        publicInputs[2] = BN254.ScalarField.wrap(statement.boundedMatchResult.price.repr);
+        publicInputs[3] = BN254.ScalarField.wrap(statement.boundedMatchResult.minInternalPartyAmountIn);
+        publicInputs[4] = BN254.ScalarField.wrap(statement.boundedMatchResult.maxInternalPartyAmountIn);
+        publicInputs[5] = BN254.ScalarField.wrap(statement.boundedMatchResult.blockDeadline);
+
+        // Add the fee rates
+        publicInputs[6] = BN254.ScalarField.wrap(statement.externalRelayerFeeRate.repr);
+        publicInputs[7] = BN254.ScalarField.wrap(statement.externalProtocolFeeRate.repr);
+        publicInputs[8] = BN254.ScalarField.wrap(statement.internalRelayerFeeRate.repr);
+        publicInputs[9] = BN254.ScalarField.wrap(statement.internalProtocolFeeRate.repr);
+
+        // Add the relayer fee address
+        publicInputs[10] = BN254.ScalarField.wrap(uint256(uint160(statement.relayerFeeAddress)));
+    }
+
     /// @notice Serialize the public inputs for a proof of intent and balance public settlement
     /// @param statement The statement to serialize
     /// @return publicInputs The serialized public inputs
@@ -394,5 +427,35 @@ library PublicInputsLib {
         publicInputs[14] = BN254.ScalarField.wrap(statement.relayerFee0.repr);
         publicInputs[15] = BN254.ScalarField.wrap(statement.relayerFee1.repr);
         publicInputs[16] = BN254.ScalarField.wrap(statement.protocolFee.repr);
+    }
+
+    /// @notice Get a dummy verification key for testing
+    /// @return A dummy verification key
+    /// @dev TODO: Replace with real verification key
+    function dummyVkey() internal pure returns (VerificationKey memory) {
+        return VerificationKey({
+            n: 0,
+            l: 0,
+            k: [BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO],
+            qComms: [
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1(),
+                BN254.P1()
+            ],
+            sigmaComms: [BN254.P1(), BN254.P1(), BN254.P1(), BN254.P1(), BN254.P1()],
+            g: BN254.P1(),
+            h: BN254.P2(),
+            xH: BN254.P2()
+        });
     }
 }

--- a/src/darkpool/v2/libraries/public_inputs/Settlement.sol
+++ b/src/darkpool/v2/libraries/public_inputs/Settlement.sol
@@ -32,13 +32,11 @@ struct IntentOnlyPublicSettlementStatement {
 struct IntentOnlyBoundedSettlementStatement {
     /// @dev The bounded match result that the intent must be able to capitalize
     BoundedMatchResult boundedMatchResult;
-    /// @dev The fee rates charged to the external party (relayer + protocol)
+    /// @dev The relayer fee rate charged to the external party
     FixedPoint externalRelayerFeeRate;
-    FixedPoint externalProtocolFeeRate;
-    /// @dev The fee rates charged to the internal party (relayer + protocol)
+    /// @dev The relayer fee rate charged to the internal party
     FixedPoint internalRelayerFeeRate;
-    FixedPoint internalProtocolFeeRate;
-    /// @dev The address at which the relayer receives their fee from the external party
+    /// @dev The address at which the relayer receives their fee
     address relayerFeeAddress;
 }
 

--- a/src/darkpool/v2/libraries/public_inputs/Settlement.sol
+++ b/src/darkpool/v2/libraries/public_inputs/Settlement.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
 import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
 
@@ -23,6 +24,22 @@ struct IntentOnlyPublicSettlementStatement {
     FixedPoint relayerFee;
     /// @dev The recipient of the relayer fee
     address relayerFeeRecipient;
+}
+
+/// @notice A statement for a proof of single-intent bounded settlement
+/// @dev The settlement proof validates that the intent can capitalize the bounded match result.
+/// The contract verifies that the calldata bounded match result matches this statement's bounded match result.
+struct IntentOnlyBoundedSettlementStatement {
+    /// @dev The bounded match result that the intent must be able to capitalize
+    BoundedMatchResult boundedMatchResult;
+    /// @dev The fee rates charged to the external party (relayer + protocol)
+    FixedPoint externalRelayerFeeRate;
+    FixedPoint externalProtocolFeeRate;
+    /// @dev The fee rates charged to the internal party (relayer + protocol)
+    FixedPoint internalRelayerFeeRate;
+    FixedPoint internalProtocolFeeRate;
+    /// @dev The address at which the relayer receives their fee from the external party
+    address relayerFeeAddress;
 }
 
 /// @notice A statement for a proof of intent and balance public settlement

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -13,6 +13,7 @@ import {
 } from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
 import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
@@ -133,6 +134,10 @@ library NativeSettledPrivateIntentLib {
 
         // Allocate transfers
         bundleData.allocateTransfers(obligation, settlementContext, state);
+
+        // Emit a recovery ID for the intent
+        BN254.ScalarField recoveryId = bundleData.auth.statement.recoveryId;
+        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
     }
 
     /// @notice Validate and execute a bounded match settlement bundle for a subsequent fill
@@ -164,7 +169,7 @@ library NativeSettledPrivateIntentLib {
         BN254.ScalarField postMatchCommitment = bundleData.computeFullIntentCommitment(obligation.amountIn, hasher);
 
         // Push validity and settlement proofs
-        bundleData.pushValidityProof(settlementContext, vkeys);
+        bundleData.pushValidityProof(settlementContext, vkeys, state);
         bundleData.pushSettlementProofs(settlementContext);
 
         // State mutation: spend old intent nullifier + insert post-match commitment to intent into Merkle tree
@@ -173,6 +178,10 @@ library NativeSettledPrivateIntentLib {
 
         // Allocate transfers
         bundleData.allocateTransfers(obligation, settlementContext, state);
+
+        // Emit a recovery ID for the intent
+        BN254.ScalarField recoveryId = bundleData.auth.statement.recoveryId;
+        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
     }
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a first fill
@@ -219,6 +228,10 @@ library NativeSettledPrivateIntentLib {
 
         // Allocate transfers
         bundleData.allocateTransfers(obligation, settlementContext, state);
+
+        // Emit a recovery ID for the intent
+        BN254.ScalarField recoveryId = bundleData.auth.statement.recoveryId;
+        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
     }
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a subsequent
@@ -253,7 +266,7 @@ library NativeSettledPrivateIntentLib {
         bundleData.validateObligation(obligation);
 
         // Push validity and settlement proofs
-        bundleData.pushValidityProof(settlementContext, vkeys);
+        bundleData.pushValidityProof(settlementContext, vkeys, state);
         bundleData.pushSettlementProofs(settlementContext, vkeys);
 
         // State mutation: spend old intent nullifier + insert post-match commitment to intent into Merkle tree
@@ -262,5 +275,9 @@ library NativeSettledPrivateIntentLib {
 
         // Allocate transfers
         bundleData.allocateTransfers(obligation, settlementContext, state);
+
+        // Emit a recovery ID for the intent
+        BN254.ScalarField recoveryId = bundleData.auth.statement.recoveryId;
+        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
     }
 }

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPrivateIntent.sol
@@ -3,67 +3,34 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import { PartyId, SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    PartyId,
-    SettlementBundle,
-    SettlementBundleLib,
-    PrivateIntentPublicBalanceBundle,
-    PrivateIntentPublicBalanceFirstFillBundle,
     PrivateIntentPublicBalanceBoundedBundle,
-    PrivateIntentPublicBalanceBoundedFirstFillBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
-import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
-import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
-import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+    PrivateIntentPublicBalanceBoundedFirstFillBundle,
+    PrivateIntentPublicBalanceBundle,
+    PrivateIntentPublicBalanceBundleLib,
+    PrivateIntentPublicBalanceFirstFillBundle
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
 import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
-import {
-    PrivateIntentAuthBundle,
-    PrivateIntentAuthBundleFirstFill
-} from "darkpoolv2-types/settlement/IntentBundle.sol";
-import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
-import {
-    IntentOnlyValidityStatement,
-    IntentOnlyValidityStatementFirstFill
-} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
-import {
-    IntentOnlyPublicSettlementStatement,
-    IntentOnlyBoundedSettlementStatement
-} from "darkpoolv2-lib/public_inputs/Settlement.sol";
-import { VerificationKey, ProofLinkingInstance } from "renegade-lib/verifier/Types.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
-import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
-import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
-import { FeeRate, FeeRateLib, FeeTake, FeeTakeLib } from "darkpoolv2-types/Fee.sol";
-
-import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-import { SignatureWithNonceLib, SignatureWithNonce } from "darkpoolv2-types/settlement/IntentBundle.sol";
-import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
-import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
+import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 
 /// @title Native Settled Private Intent Library
 /// @author Renegade Eng
 /// @notice Library for validating a natively settled private intent
 /// @dev A natively settled private intent is a private intent with a private (darkpool) balance.
 library NativeSettledPrivateIntentLib {
-    using BoundedMatchResultLib for BoundedMatchResult;
     using DarkpoolStateLib for DarkpoolState;
-    using FeeRateLib for FeeRate;
-    using FeeTakeLib for FeeTake;
     using ObligationLib for ObligationBundle;
-    using PublicInputsLib for IntentOnlyBoundedSettlementStatement;
-    using PublicInputsLib for IntentOnlyPublicSettlementStatement;
-    using PublicInputsLib for IntentOnlyValidityStatement;
-    using PublicInputsLib for IntentOnlyValidityStatementFirstFill;
-    using SettlementBundleLib for PrivateIntentPublicBalanceBoundedBundle;
-    using SettlementBundleLib for PrivateIntentPublicBalanceBoundedFirstFillBundle;
-    using SettlementBundleLib for PrivateIntentPublicBalanceBundle;
-    using SettlementBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
-    using SettlementBundleLib for SettlementBundle;
+    using PrivateIntentPublicBalanceBundleLib for PrivateIntentPublicBalanceBoundedBundle;
+    using PrivateIntentPublicBalanceBundleLib for PrivateIntentPublicBalanceBoundedFirstFillBundle;
+    using PrivateIntentPublicBalanceBundleLib for PrivateIntentPublicBalanceBundle;
+    using PrivateIntentPublicBalanceBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
+    using PrivateIntentPublicBalanceBundleLib for SettlementBundle;
     using SettlementContextLib for SettlementContext;
-    using SettlementObligationLib for SettlementObligation;
-    using SignatureWithNonceLib for SignatureWithNonce;
 
     // --- Implementation --- //
 
@@ -144,31 +111,28 @@ library NativeSettledPrivateIntentLib {
     )
         internal
     {
-        // Decode the bundle data
         PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData =
             settlementBundle.decodePrivateIntentBoundedBundleDataFirstFill();
-        BoundedMatchResult memory matchResult = matchBundle.permit.matchResult;
 
-        // Compute the pre- and post-update commitment to the intent
-        // We use `obligation.amountIn` rather than the `amountIn` value leaked by the statement since
-        // the size of a bounded match is determined at runtime by the external party.
-        (BN254.ScalarField preMatchIntentCommitment, BN254.ScalarField postMatchIntentCommitment) =
+        // Compute pre- and post-match intent commitments
+        (BN254.ScalarField preMatchCommitment, BN254.ScalarField postMatchCommitment) =
             bundleData.computeIntentCommitments(obligation.amountIn, hasher);
 
-        // 1. Validate intent authorization (same as exact settlement)
-        validatePrivateIntentAuthorizationFirstFill(
-            preMatchIntentCommitment, bundleData.auth, settlementContext, vkeys, state
-        );
+        // First-fill only: Verify intent commitment signature
+        PrivateIntentPublicBalanceBundleLib.verifyIntentCommitmentSignature(preMatchCommitment, bundleData.auth, state);
 
-        // 2. Validate intent constraints on the bounded match result
-        // This makes sure the bounded match result from calldata matches the one in the statement
-        // and appends settlement proof and proof linking argument
-        validateBoundedMatchResultConstraintsFirstFill(matchResult, bundleData, settlementContext, vkeys);
+        // Validate match result
+        bundleData.validateMatchResult(matchBundle.permit.matchResult);
 
-        // 3. Execute state updates
-        executeStateUpdatesFirstFill(
-            postMatchIntentCommitment, bundleData, obligation, settlementContext, state, hasher
-        );
+        // Push validity and settlement proofs
+        bundleData.pushValidityProof(settlementContext, vkeys);
+        bundleData.pushSettlementProofs(settlementContext);
+
+        // State mutation: Insert post-match intent commitment into Merkle tree
+        state.insertMerkleLeaf(bundleData.auth.merkleDepth, postMatchCommitment, hasher);
+
+        // Allocate transfers
+        bundleData.allocateTransfers(obligation, settlementContext, state);
     }
 
     /// @notice Validate and execute a bounded match settlement bundle for a subsequent fill
@@ -190,24 +154,25 @@ library NativeSettledPrivateIntentLib {
     )
         internal
     {
-        // Decode the bundle data
         PrivateIntentPublicBalanceBoundedBundle memory bundleData =
             settlementBundle.decodePrivateIntentBoundedBundleData();
-        BoundedMatchResult memory matchResult = matchBundle.permit.matchResult;
 
-        // 1. Validate intent authorization using preMatchIntentCommitment
-        // This appends validity proof
-        // Note that we don't need to validate the commitment signature here because it was already validated in the
-        // first fill
-        validatePrivateIntentAuthorization(bundleData.auth, vkeys, settlementContext);
+        // Validate match result
+        bundleData.validateMatchResult(matchBundle.permit.matchResult);
 
-        // 2. Validate intent constraints on the bounded match result
-        // This makes sure the bounded match result from calldata matches the one in the statement
-        // and appends settlement proof and proof linking argument
-        validateBoundedMatchResultConstraints(matchResult, bundleData, settlementContext, vkeys);
+        // Compute post-match commitment
+        BN254.ScalarField postMatchCommitment = bundleData.computeFullIntentCommitment(obligation.amountIn, hasher);
 
-        // 3. Execute state updates
-        executeStateUpdates(bundleData, obligation, settlementContext, state, hasher);
+        // Push validity and settlement proofs
+        bundleData.pushValidityProof(settlementContext, vkeys);
+        bundleData.pushSettlementProofs(settlementContext);
+
+        // State mutation: spend old intent nullifier + insert post-match commitment to intent into Merkle tree
+        state.spendNullifier(bundleData.auth.statement.oldIntentNullifier);
+        state.insertMerkleLeaf(bundleData.auth.merkleDepth, postMatchCommitment, hasher);
+
+        // Allocate transfers
+        bundleData.allocateTransfers(obligation, settlementContext, state);
     }
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a first fill
@@ -231,29 +196,29 @@ library NativeSettledPrivateIntentLib {
     )
         internal
     {
-        // Decode the bundle data
         PrivateIntentPublicBalanceFirstFillBundle memory bundleData =
             settlementBundle.decodePrivateIntentBundleDataFirstFill();
         SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
-        // Compute the pre- and post-update commitments to the intent
-        // We compute these upfront so that the helper may re-use their common share prefix to compute the pre- and
-        // post-match commitments
-        (BN254.ScalarField preMatchIntentCommitment, BN254.ScalarField postMatchIntentCommitment) =
+        // Compute pre- and post-match intent commitments
+        (BN254.ScalarField preMatchCommitment, BN254.ScalarField postMatchCommitment) =
             bundleData.computeIntentCommitments(hasher);
 
-        // 1. Validate the intent authorization
-        validatePrivateIntentAuthorizationFirstFill(
-            preMatchIntentCommitment, bundleData.auth, settlementContext, vkeys, state
-        );
+        // First-fill only: Verify intent commitment signature
+        PrivateIntentPublicBalanceBundleLib.verifyIntentCommitmentSignature(preMatchCommitment, bundleData.auth, state);
 
-        // 2. Validate the intent constraints on the obligation
-        validateObligationConstraintsFirstFill(obligation, bundleData, settlementContext, vkeys);
+        // Validate obligation
+        bundleData.validateObligation(obligation);
 
-        // 3. Execute state updates for the bundle
-        executeStateUpdatesFirstFill(
-            postMatchIntentCommitment, bundleData, obligation, settlementContext, state, hasher
-        );
+        // Push validity and settlement proofs
+        bundleData.pushValidityProof(settlementContext, vkeys);
+        bundleData.pushSettlementProofs(settlementContext, vkeys);
+
+        // State mutation: insert post-match commitment to intent into Merkle tree
+        state.insertMerkleLeaf(bundleData.auth.merkleDepth, postMatchCommitment, hasher);
+
+        // Allocate transfers
+        bundleData.allocateTransfers(obligation, settlementContext, state);
     }
 
     /// @notice Validate and execute a settlement bundle with a private intent with a public balance for a subsequent
@@ -278,465 +243,24 @@ library NativeSettledPrivateIntentLib {
     )
         internal
     {
-        // Decode the bundle data
         PrivateIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePrivateIntentBundleData();
         SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
-        // 1. Validate the intent authorization
-        validatePrivateIntentAuthorization(bundleData.auth, vkeys, settlementContext, state);
+        // Compute post-match commitment
+        BN254.ScalarField postMatchCommitment = bundleData.computeFullIntentCommitment(hasher);
 
-        // 2. Validate the intent constraints on the obligation
-        validateObligationConstraints(obligation, bundleData, settlementContext, vkeys);
+        // Validate obligation
+        bundleData.validateObligation(obligation);
 
-        // 3. Execute state updates for the bundle
-        executeStateUpdates(bundleData, obligation, settlementContext, state, hasher);
-    }
+        // Push validity and settlement proofs
+        bundleData.pushValidityProof(settlementContext, vkeys);
+        bundleData.pushSettlementProofs(settlementContext, vkeys);
 
-    // ------------------------
-    // | Intent Authorization |
-    // ------------------------
+        // State mutation: spend old intent nullifier + insert post-match commitment to intent into Merkle tree
+        state.spendNullifier(bundleData.auth.statement.oldIntentNullifier);
+        state.insertMerkleLeaf(bundleData.auth.merkleDepth, postMatchCommitment, hasher);
 
-    /// @notice Validate the authorization of a private intent for a first fill
-    /// @param preMatchIntentCommitment The pre-match commitment to the intent. The owner of the intent must authorize
-    /// this commitment with a signature.
-    /// @param auth The authorization bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    /// @param state The darkpool state containing all storage references
-    /// @dev On the first fill, we verify that the intent owner has signed the intent's commitment.
-    function validatePrivateIntentAuthorizationFirstFill(
-        BN254.ScalarField preMatchIntentCommitment,
-        PrivateIntentAuthBundleFirstFill memory auth,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys,
-        DarkpoolState storage state
-    )
-        internal
-    {
-        // Validate the Merkle depth
-        // TODO: Allow for dynamic Merkle depth
-        if (auth.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) revert IDarkpool.InvalidMerkleDepthRequested();
-
-        // On the first fill, we verify that the intent owner has signed the intent's commitment
-        verifyIntentCommitmentSignature(preMatchIntentCommitment, auth, state);
-
-        // Append a proof to the settlement context
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(auth.statement);
-        VerificationKey memory vk = vkeys.intentOnlyFirstFillValidityKeys();
-        settlementContext.pushProof(publicInputs, auth.validityProof, vk);
-    }
-
-    /// @notice Authorize a private intent
-    /// @param auth The authorization bundle to validate
-    /// @param vkeys The contract storing the verification keys
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param state The darkpool state containing all storage references
-    /// @dev Because this is not the first fill, the presence of the intent in the Merkle tree implies that the
-    /// intent owner's signature has already been verified (in a previous fill). So in this case, we need only
-    /// verify the proof attached to the bundle.
-    function validatePrivateIntentAuthorization(
-        PrivateIntentAuthBundle memory auth,
-        IVkeys vkeys,
-        SettlementContext memory settlementContext,
-        DarkpoolState storage state
-    )
-        internal
-        view
-    {
-        // Validate the Merkle root
-        // TODO: Allow for dynamic Merkle depth
-        if (auth.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) revert IDarkpool.InvalidMerkleDepthRequested();
-        state.assertRootInHistory(auth.statement.merkleRoot);
-
-        // Append a proof to the settlement context
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(auth.statement);
-        VerificationKey memory vk = vkeys.intentOnlyValidityKeys();
-        settlementContext.pushProof(publicInputs, auth.validityProof, vk);
-    }
-
-    /// @notice Verify the signature of the intent commitment by its owner
-    /// @param preMatchIntentCommitment The pre-match commitment to the intent
-    /// @param authBundle The authorization bundle to verify the signature for
-    /// @param state The darkpool state containing all storage references
-    function verifyIntentCommitmentSignature(
-        BN254.ScalarField preMatchIntentCommitment,
-        PrivateIntentAuthBundleFirstFill memory authBundle,
-        DarkpoolState storage state
-    )
-        internal
-    {
-        address intentOwner = authBundle.statement.intentOwner;
-        uint256 commitment = BN254.ScalarField.unwrap(preMatchIntentCommitment);
-
-        bytes32 commitmentHash = EfficientHashLib.hash(bytes32(commitment));
-        bool valid = authBundle.intentSignature.verifyPrehashed(intentOwner, commitmentHash);
-        if (!valid) revert IDarkpoolV2.InvalidIntentCommitmentSignature();
-        state.spendNonce(authBundle.intentSignature.nonce);
-    }
-
-    // --------------------------
-    // | Obligation Constraints |
-    // --------------------------
-
-    /// @notice Validate the obligation constraints for a natively settled private intent bundle for a first fill
-    /// @param obligation The obligation to validate
-    /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    function validateObligationConstraintsFirstFill(
-        SettlementObligation memory obligation,
-        PrivateIntentPublicBalanceFirstFillBundle memory settlementBundle,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys
-    )
-        internal
-        view
-    {
-        IntentOnlyPublicSettlementStatement memory settlementStatement = settlementBundle.settlementStatement;
-
-        // The obligation in the settlement statement must match the one from the obligation bundle
-        bool obligationMatches = obligation.isEqualTo(settlementStatement.obligation);
-        if (!obligationMatches) revert IDarkpoolV2.InvalidObligation();
-
-        // Push the settlement proof to the context for verification
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(settlementStatement);
-        VerificationKey memory vk = vkeys.intentOnlyPublicSettlementKeys();
-        settlementContext.pushProof(publicInputs, settlementBundle.settlementProof, vk);
-
-        // Push the proof linking argument to the context for verification
-        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
-            wireComm0: settlementBundle.auth.validityProof.wireComms[0],
-            wireComm1: settlementBundle.settlementProof.wireComms[0],
-            proof: settlementBundle.authSettlementLinkingProof,
-            vk: vkeys.intentOnlySettlementLinkingKey()
-        });
-        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
-    }
-
-    /// @notice Validate the obligation constraints for a natively settled private intent bundle for a subsequent fill;
-    /// i.e. not the first fill
-    /// @param obligation The obligation to validate
-    /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    function validateObligationConstraints(
-        SettlementObligation memory obligation,
-        PrivateIntentPublicBalanceBundle memory settlementBundle,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys
-    )
-        internal
-        view
-    {
-        IntentOnlyPublicSettlementStatement memory settlementStatement = settlementBundle.settlementStatement;
-
-        // The obligation in the settlement statement must match the one from the obligation bundle
-        bool obligationMatches = obligation.isEqualTo(settlementStatement.obligation);
-        if (!obligationMatches) revert IDarkpoolV2.InvalidObligation();
-
-        // Push the settlement proof to the context for verification
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(settlementStatement);
-        VerificationKey memory vk = vkeys.intentOnlyPublicSettlementKeys();
-        settlementContext.pushProof(publicInputs, settlementBundle.settlementProof, vk);
-
-        // Push the proof linking argument to the context for verification
-        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
-            wireComm0: settlementBundle.auth.validityProof.wireComms[0],
-            wireComm1: settlementBundle.settlementProof.wireComms[0],
-            proof: settlementBundle.authSettlementLinkingProof,
-            vk: vkeys.intentOnlySettlementLinkingKey()
-        });
-        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
-    }
-
-    // -------------------------------------
-    // | Bounded Match Result Constraints |
-    // -------------------------------------
-
-    /// @notice Validate the bounded match result constraints for a first fill
-    /// @dev The settlement proof validates that the intent can capitalize the bounded match result.
-    /// We verify that the bounded match result in the calldata matches the one in the settlement statement.
-    /// @param matchResult The bounded match result to validate against
-    /// @param bundleData The decoded settlement bundle containing the settlement proof
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param _vkeys The contract storing the verification keys
-    function validateBoundedMatchResultConstraintsFirstFill(
-        BoundedMatchResult memory matchResult,
-        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
-        SettlementContext memory settlementContext,
-        IVkeys _vkeys
-    )
-        internal
-        view
-    {
-        IntentOnlyBoundedSettlementStatement memory settlementStatement = bundleData.settlementStatement;
-
-        // The match result in the settlement statement must match the one in the calldata
-        bool matchResultMatches = matchResult.isEqualTo(settlementStatement.boundedMatchResult);
-        if (!matchResultMatches) revert IDarkpoolV2.InvalidBoundedMatchResult();
-
-        // Push the settlement proof to the context for verification
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(settlementStatement);
-        VerificationKey memory vk = PublicInputsLib.dummyVkey();
-        settlementContext.pushProof(publicInputs, bundleData.settlementProof, vk);
-
-        // Push the proof linking argument to the context for verification
-        // TODO: Implement proof linking
-    }
-
-    /// @notice Validate the bounded match result constraints for a subsequent fill
-    /// @dev The settlement proof validates that the intent can capitalize the bounded match result.
-    /// We verify that the bounded match result in the calldata matches the one in the settlement statement.
-    /// @param matchResult The bounded match result to validate against
-    /// @param bundleData The decoded settlement bundle containing the settlement proof
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param _vkeys The contract storing the verification keys
-    function validateBoundedMatchResultConstraints(
-        BoundedMatchResult memory matchResult,
-        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
-        SettlementContext memory settlementContext,
-        IVkeys _vkeys
-    )
-        internal
-        view
-    {
-        IntentOnlyBoundedSettlementStatement memory settlementStatement = bundleData.settlementStatement;
-
-        // The match result in the settlement statement must match the one in the calldata
-        bool matchResultMatches = matchResult.isEqualTo(settlementStatement.boundedMatchResult);
-        if (!matchResultMatches) revert IDarkpoolV2.InvalidBoundedMatchResult();
-
-        // Push the settlement proof to the context for verification
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(settlementStatement);
-        VerificationKey memory vk = PublicInputsLib.dummyVkey();
-        settlementContext.pushProof(publicInputs, bundleData.settlementProof, vk);
-
-        // Push the proof linking argument to the context for verification
-        // TODO: Implement proof linking
-    }
-
-    // -----------------
-    // | State Updates |
-    // -----------------
-
-    /// @notice Execute the state updates necessary to settle the bundle for a first fill
-    /// @param postMatchIntentCommitment The post-match commitment to the intent
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param obligation The settlement obligation to settle
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing
-    /// @dev On the first fill, no state needs to be nullified. We must only insert the new intent commitment and
-    /// allocate the transfers.
-    function executeStateUpdatesFirstFill(
-        BN254.ScalarField postMatchIntentCommitment,
-        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
-        SettlementObligation memory obligation,
-        SettlementContext memory settlementContext,
-        DarkpoolState storage state,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Insert a commitment to the updated intent into the Merkle tree
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        state.insertMerkleLeaf(merkleDepth, postMatchIntentCommitment, hasher);
-
-        // 2. Allocate transfers to settle the obligation in the settlement context
-        address owner = bundleData.auth.statement.intentOwner;
-        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) =
-            computeFeeTakes(obligation, bundleData.settlementStatement, state);
-        allocateTransfers(owner, relayerFeeTake, protocolFeeTake, obligation, settlementContext);
-
-        // 3. Emit a recovery ID for the intent
-        BN254.ScalarField recoveryId = bundleData.auth.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
-    }
-
-    /// @notice Execute the state updates necessary to settle a bounded match bundle for a first fill
-    /// @param postMatchIntentCommitment The post-match commitment to the intent
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param obligation The settlement obligation to settle
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing
-    /// @dev On the first fill, no state needs to be nullified. We must only insert the new intent commitment and
-    /// allocate the transfers.
-    function executeStateUpdatesFirstFill(
-        BN254.ScalarField postMatchIntentCommitment,
-        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
-        SettlementObligation memory obligation,
-        SettlementContext memory settlementContext,
-        DarkpoolState storage state,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Insert a commitment to the updated intent into the Merkle tree
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        state.insertMerkleLeaf(merkleDepth, postMatchIntentCommitment, hasher);
-
-        // 2. Allocate transfers to settle the obligation in the settlement context
-        address owner = bundleData.auth.statement.intentOwner;
-        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) =
-            computeFeeTakes(obligation, bundleData.settlementStatement, state);
-        allocateTransfers(owner, relayerFeeTake, protocolFeeTake, obligation, settlementContext);
-    }
-
-    /// @notice Execute the state updates necessary to settle the bundle
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param obligation The settlement obligation to settle
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing
-    function executeStateUpdates(
-        PrivateIntentPublicBalanceBundle memory bundleData,
-        SettlementObligation memory obligation,
-        SettlementContext memory settlementContext,
-        DarkpoolState storage state,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Spend the nullifier for the previous version of the intent
-        BN254.ScalarField nullifier = bundleData.auth.statement.oldIntentNullifier;
-        state.spendNullifier(nullifier);
-
-        // 2. Insert a commitment to the updated intent into the Merkle tree
-        BN254.ScalarField newIntentCommitment = bundleData.computeFullIntentCommitment(hasher);
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
-
-        // 3. Allocate transfers to settle the obligation in the settlement context
-        address owner = bundleData.auth.statement.intentOwner;
-        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) =
-            computeFeeTakes(obligation, bundleData.settlementStatement, state);
-        allocateTransfers(owner, relayerFeeTake, protocolFeeTake, obligation, settlementContext);
-
-        // 4. Emit a recovery ID for the intent
-        BN254.ScalarField recoveryId = bundleData.auth.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
-    }
-
-    /// @notice Execute the state updates necessary to settle a bounded match bundle
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param obligation The settlement obligation to settle
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing
-    function executeStateUpdates(
-        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
-        SettlementObligation memory obligation,
-        SettlementContext memory settlementContext,
-        DarkpoolState storage state,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Spend the nullifier for the previous version of the intent
-        BN254.ScalarField nullifier = bundleData.auth.statement.oldIntentNullifier;
-        state.spendNullifier(nullifier);
-
-        // 2. Insert a commitment to the updated intent into the Merkle tree
-        BN254.ScalarField newIntentCommitment = bundleData.computeFullIntentCommitment(obligation.amountIn, hasher);
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
-
-        // 3. Allocate transfers to settle the obligation in the settlement context
-        address owner = bundleData.auth.statement.intentOwner;
-        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) =
-            computeFeeTakes(obligation, bundleData.settlementStatement, state);
-        allocateTransfers(owner, relayerFeeTake, protocolFeeTake, obligation, settlementContext);
-    }
-
-    /// @notice Allocate transfers to settle the obligation into the settlement context
-    /// @param owner The owner of the intent
-    /// @param relayerFeeTake The relayer fee take
-    /// @param protocolFeeTake The protocol fee take
-    /// @param obligation The settlement obligation to settle
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    function allocateTransfers(
-        address owner,
-        FeeTake memory relayerFeeTake,
-        FeeTake memory protocolFeeTake,
-        SettlementObligation memory obligation,
-        SettlementContext memory settlementContext
-    )
-        internal
-        pure
-    {
-        // Deposit the input token into the darkpool
-        SimpleTransfer memory deposit = obligation.buildPermit2AllowanceDeposit(owner);
-        settlementContext.pushDeposit(deposit);
-
-        // Withdraw the output token from the darkpool
-        uint256 totalFee = relayerFeeTake.fee + protocolFeeTake.fee;
-        SimpleTransfer memory withdrawal = obligation.buildWithdrawalTransfer(owner, totalFee);
-        settlementContext.pushWithdrawal(withdrawal);
-
-        // Withdraw the relayer and protocol fees to their respective recipients
-        SimpleTransfer memory relayerWithdrawal = relayerFeeTake.buildWithdrawalTransfer();
-        SimpleTransfer memory protocolWithdrawal = protocolFeeTake.buildWithdrawalTransfer();
-        settlementContext.pushWithdrawal(relayerWithdrawal);
-        settlementContext.pushWithdrawal(protocolWithdrawal);
-    }
-
-    /// @notice Compute the fee takes for the match
-    /// @param obligation The settlement obligation to compute fee takes for
-    /// @param settlementStatement The settlement statement to compute fee takes for
-    /// @param state The darkpool state containing all storage references
-    /// @return relayerFeeTake The relayer fee take
-    /// @return protocolFeeTake The protocol fee take
-    function computeFeeTakes(
-        SettlementObligation memory obligation,
-        IntentOnlyPublicSettlementStatement memory settlementStatement,
-        DarkpoolState storage state
-    )
-        internal
-        view
-        returns (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake)
-    {
-        // Compute the fee rates
-        FeeRate memory relayerFeeRate =
-            FeeRate({ rate: settlementStatement.relayerFee, recipient: settlementStatement.relayerFeeRecipient });
-        FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
-
-        // Multiply the rates with the receive amount
-        uint256 receiveAmount = obligation.amountOut;
-        address receiveToken = obligation.outputToken;
-        relayerFeeTake = relayerFeeRate.computeFeeTake(receiveToken, receiveAmount);
-        protocolFeeTake = protocolFeeRate.computeFeeTake(receiveToken, receiveAmount);
-    }
-
-    /// @notice Compute the fee takes for a bounded match
-    /// @param obligation The settlement obligation to compute fee takes for
-    /// @param settlementStatement The settlement statement to compute fee takes for
-    /// @param state The darkpool state containing all storage references
-    /// @return relayerFeeTake The relayer fee take
-    /// @return protocolFeeTake The protocol fee take
-    function computeFeeTakes(
-        SettlementObligation memory obligation,
-        IntentOnlyBoundedSettlementStatement memory settlementStatement,
-        DarkpoolState storage state
-    )
-        internal
-        view
-        returns (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake)
-    {
-        // Compute the fee rates
-        FeeRate memory relayerFeeRate = FeeRate({
-            rate: settlementStatement.internalRelayerFeeRate, recipient: settlementStatement.relayerFeeAddress
-        });
-
-        // Verify the protocol fee rate used in settlement matches the darkpool state
-        FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
-        bool protocolFeeRateMatches = settlementStatement.internalProtocolFeeRate.repr == protocolFeeRate.rate.repr;
-        if (!protocolFeeRateMatches) revert IDarkpoolV2.InvalidProtocolFeeRates();
-
-        // Multiply the rates with the receive amount
-        uint256 receiveAmount = obligation.amountOut;
-        address receiveToken = obligation.outputToken;
-        relayerFeeTake = relayerFeeRate.computeFeeTake(receiveToken, receiveAmount);
-        protocolFeeTake = protocolFeeRate.computeFeeTake(receiveToken, receiveAmount);
+        // Allocate transfers
+        bundleData.allocateTransfers(obligation, settlementContext, state);
     }
 }

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
@@ -435,10 +435,12 @@ library PrivateIntentPublicBalanceBundleLib {
     /// @param bundleData The bundle containing the validity proof
     /// @param settlementContext The context to push to
     /// @param vkeys The verification keys contract
+    /// @param state The darkpool state for root validation
     function pushValidityProof(
         PrivateIntentPublicBalanceBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        IVkeys vkeys,
+        DarkpoolState storage state
     )
         internal
         view
@@ -448,6 +450,7 @@ library PrivateIntentPublicBalanceBundleLib {
         _pushValidityProofInner(
             bundleData.auth.merkleDepth, publicInputs, bundleData.auth.validityProof, vk, settlementContext
         );
+        state.assertRootInHistory(bundleData.auth.statement.merkleRoot);
     }
 
     /// @notice Push the validity proof to the context and validate merkle depth
@@ -473,10 +476,12 @@ library PrivateIntentPublicBalanceBundleLib {
     /// @param bundleData The bundle containing the validity proof
     /// @param settlementContext The context to push to
     /// @param vkeys The verification keys contract
+    /// @param state The darkpool state for root validation
     function pushValidityProof(
         PrivateIntentPublicBalanceBoundedBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        IVkeys vkeys,
+        DarkpoolState storage state
     )
         internal
         view
@@ -486,6 +491,7 @@ library PrivateIntentPublicBalanceBundleLib {
         _pushValidityProofInner(
             bundleData.auth.merkleDepth, publicInputs, bundleData.auth.validityProof, vk, settlementContext
         );
+        state.assertRootInHistory(bundleData.auth.statement.merkleRoot);
     }
 
     /// @notice Internal helper to validate merkle depth and push validity proof

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
@@ -1,0 +1,768 @@
+// SPDX-License-Identifier: Apache
+/* solhint-disable one-contract-per-file */
+pragma solidity ^0.8.24;
+
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import { PlonkProof, LinkingProof, VerificationKey, ProofLinkingInstance } from "renegade-lib/verifier/Types.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { CommitmentLib } from "darkpoolv2-lib/Commitments.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { FeeRate, FeeRateLib, FeeTake, FeeTakeLib } from "darkpoolv2-types/Fee.sol";
+import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import {
+    IntentOnlyBoundedSettlementStatement,
+    IntentOnlyPublicSettlementStatement
+} from "darkpoolv2-lib/public_inputs/Settlement.sol";
+import { IntentPublicShare, IntentPublicShareLib } from "darkpoolv2-types/Intent.sol";
+import {
+    IntentOnlyValidityStatement,
+    IntentOnlyValidityStatementFirstFill
+} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
+import { PartialCommitment } from "darkpoolv2-types/PartialCommitment.sol";
+import {
+    PrivateIntentAuthBundle,
+    PrivateIntentAuthBundleFirstFill
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
+import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+
+// ---------------------------------
+// | Private Intent Bundle Structs |
+// ---------------------------------
+
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bundle on the first fill
+struct PrivateIntentPublicBalanceFirstFillBundle {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentAuthBundleFirstFill auth;
+    /// @dev The statement of single-intent match settlement
+    IntentOnlyPublicSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent match settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bundle
+struct PrivateIntentPublicBalanceBundle {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentAuthBundle auth;
+    /// @dev The statement of single-intent match settlement
+    IntentOnlyPublicSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent match settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bounded settlement on the first fill
+struct PrivateIntentPublicBalanceBoundedFirstFillBundle {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentAuthBundleFirstFill auth;
+    /// @dev The statement of single-intent bounded settlement
+    IntentOnlyBoundedSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent bounded settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bounded settlement
+struct PrivateIntentPublicBalanceBoundedBundle {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentAuthBundle auth;
+    /// @dev The statement of single-intent bounded settlement
+    IntentOnlyBoundedSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent bounded settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+// ---------------------------------
+// | Private Intent Bundle Library |
+// ---------------------------------
+
+/// @title Private Intent Public Balance Bundle Library
+/// @author Renegade Eng
+/// @notice Library for decoding, computing commitments, and extracting values from private intent bundles
+library PrivateIntentPublicBalanceBundleLib {
+    using BN254 for BN254.ScalarField;
+    using BoundedMatchResultLib for BoundedMatchResult;
+    using FeeRateLib for FeeRate;
+    using FeeTakeLib for FeeTake;
+    using IntentPublicShareLib for IntentPublicShare;
+    using PublicInputsLib for IntentOnlyBoundedSettlementStatement;
+    using PublicInputsLib for IntentOnlyPublicSettlementStatement;
+    using PublicInputsLib for IntentOnlyValidityStatement;
+    using PublicInputsLib for IntentOnlyValidityStatementFirstFill;
+    using SettlementContextLib for SettlementContext;
+    using SettlementObligationLib for SettlementObligation;
+    using SignatureWithNonceLib for SignatureWithNonce;
+    using DarkpoolStateLib for DarkpoolState;
+
+    // ----------
+    // | Decode |
+    // ----------
+
+    /// @notice Decode a private settlement bundle for a first fill
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePrivateIntentBundleDataFirstFill(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateIntentPublicBalanceFirstFillBundle memory bundleData)
+    {
+        bool validType =
+            bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceFirstFillBundle));
+    }
+
+    /// @notice Decode a private settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePrivateIntentBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateIntentPublicBalanceBundle memory bundleData)
+    {
+        bool validType =
+            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundle));
+    }
+
+    /// @notice Decode a private intent bounded settlement bundle for a first fill
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePrivateIntentBoundedBundleDataFirstFill(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData)
+    {
+        bool validType =
+            bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBoundedFirstFillBundle));
+    }
+
+    /// @notice Decode a private intent bounded settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePrivateIntentBoundedBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateIntentPublicBalanceBoundedBundle memory bundleData)
+    {
+        bool validType =
+            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBoundedBundle));
+    }
+
+    // --------------------------
+    // | Commitment Computation |
+    // --------------------------
+
+    /// @notice Compute the full commitment to the updated intent for a natively settled public intent bundle
+    /// on its first fill
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return preUpdateIntentCommitment The commitment to the pre-updated intent
+    /// @return postUpdateIntentCommitment The commitment to the post-updated intent
+    function computeIntentCommitments(
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField preUpdateIntentCommitment, BN254.ScalarField postUpdateIntentCommitment)
+    {
+        uint256 settlementAmountIn = bundleData.settlementStatement.obligation.amountIn;
+        return _computeIntentCommitmentsInner(settlementAmountIn, bundleData.auth.statement, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a natively settled private intent bundle
+    /// on its first fill (bounded settlement variant)
+    /// @dev Unlike the exact match variant, the settlement amount is provided at runtime via `internalPartyAmountIn`
+    /// rather than being read from the bundle's settlement statement.
+    /// @param bundleData The bundle data to compute the commitments for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param hasher The hasher to use for hashing
+    /// @return preUpdateIntentCommitment The commitment to the pre-updated intent
+    /// @return postUpdateIntentCommitment The commitment to the post-updated intent
+    function computeIntentCommitments(
+        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField preUpdateIntentCommitment, BN254.ScalarField postUpdateIntentCommitment)
+    {
+        return _computeIntentCommitmentsInner(internalPartyAmountIn, bundleData.auth.statement, hasher);
+    }
+
+    /// @notice Internal helper to compute pre- and post-update intent commitments
+    /// @dev Only the amount share in the intent changes between the pre- and post-update intent shares, so we can
+    /// compute the shared prefix of the two commitments and then resume the commitment for each of the amount shares.
+    /// @param settlementAmountIn The settlement amount in (source varies by bundle type)
+    /// @param authStatement The validity statement from the authorization bundle
+    /// @param hasher The hasher to use for hashing
+    /// @return preUpdate The commitment to the pre-updated intent
+    /// @return postUpdate The commitment to the post-updated intent
+    function _computeIntentCommitmentsInner(
+        uint256 settlementAmountIn,
+        IntentOnlyValidityStatementFirstFill memory authStatement,
+        IHasher hasher
+    )
+        private
+        view
+        returns (BN254.ScalarField preUpdate, BN254.ScalarField postUpdate)
+    {
+        IntentPublicShare memory intentPublicShare = authStatement.intentPublicShare;
+
+        // 1. Compute the shared prefix of the two commitments
+        uint256[] memory intentPublicShareScalars = intentPublicShare.scalarSerializeMatchPrefix();
+        uint256 prefixHash = hasher.computeResumableCommitment(intentPublicShareScalars);
+
+        // 2. Compute the full pre-update commitment; i.e. the commitment to the original shares
+        PartialCommitment memory sharedPrefixPartialComm = PartialCommitment({
+            privateCommitment: authStatement.intentPrivateCommitment,
+            partialPublicCommitment: BN254.ScalarField.wrap(prefixHash)
+        });
+
+        uint256[] memory preUpdateRemainingShares = new uint256[](1);
+        preUpdateRemainingShares[0] = BN254.ScalarField.unwrap(authStatement.intentPublicShare.amountIn);
+        preUpdate = CommitmentLib.computeResumableCommitment(preUpdateRemainingShares, sharedPrefixPartialComm, hasher);
+
+        // 3. Compute the full post-update commitment
+        // To do so we must update the `amountIn` field in the intent public shares to reflect the settlement
+        uint256[] memory postUpdateRemainingShares = new uint256[](1);
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementAmountIn);
+        BN254.ScalarField newAmountInShare = authStatement.intentPublicShare.amountIn.sub(settlementAmount);
+        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountInShare);
+        postUpdate =
+            CommitmentLib.computeResumableCommitment(postUpdateRemainingShares, sharedPrefixPartialComm, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a natively settled private intent bundle
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        PrivateIntentPublicBalanceBundle memory bundleData,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        uint256 settlementAmountIn = bundleData.settlementStatement.obligation.amountIn;
+        return _computeFullIntentCommitmentInner(settlementAmountIn, bundleData.auth.statement, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a natively settled private intent bundle
+    /// (bounded settlement variant)
+    /// @dev Unlike the exact match variant, the settlement amount is provided at runtime via `internalPartyAmountIn`
+    /// rather than being read from the bundle's settlement statement.
+    /// @param bundleData The bundle data to compute the commitments for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        return _computeFullIntentCommitmentInner(internalPartyAmountIn, bundleData.auth.statement, hasher);
+    }
+
+    /// @notice Internal helper to compute full intent commitment for subsequent fill
+    /// @dev The only remaining share left out of the partial commitment is the public share of the amount field, which
+    /// must be updated to reflect the settlement before committing.
+    /// @param settlementAmountIn The settlement amount in (source varies by bundle type)
+    /// @param authStatement The validity statement from the authorization bundle
+    /// @param hasher The hasher to use for hashing
+    /// @return The full commitment to the updated intent
+    function _computeFullIntentCommitmentInner(
+        uint256 settlementAmountIn,
+        IntentOnlyValidityStatement memory authStatement,
+        IHasher hasher
+    )
+        private
+        view
+        returns (BN254.ScalarField)
+    {
+        // 1. Apply the settlement to the intent public share
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementAmountIn);
+        BN254.ScalarField newAmountShareScalar = authStatement.newAmountShare.sub(settlementAmount);
+
+        // 2. Compute the full commitment to the updated intent by resuming from the partial commitment
+        uint256[] memory postUpdateRemainingShares = new uint256[](1);
+        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountShareScalar);
+        return CommitmentLib.computeResumableCommitment(
+            postUpdateRemainingShares, authStatement.newIntentPartialCommitment, hasher
+        );
+    }
+
+    // ------------------------
+    // | Intent Authorization |
+    // ------------------------
+
+    /// @notice Internal helper to verify intent commitment signature
+    /// @param preMatchIntentCommitment The pre-match commitment to the intent
+    /// @param authBundle The authorization bundle containing the signature
+    /// @param state The darkpool state containing all storage references
+    function verifyIntentCommitmentSignature(
+        BN254.ScalarField preMatchIntentCommitment,
+        PrivateIntentAuthBundleFirstFill memory authBundle,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        address intentOwner = authBundle.statement.intentOwner;
+        uint256 commitment = BN254.ScalarField.unwrap(preMatchIntentCommitment);
+
+        bytes32 commitmentHash = EfficientHashLib.hash(bytes32(commitment));
+        bool valid = authBundle.intentSignature.verifyPrehashed(intentOwner, commitmentHash);
+        if (!valid) revert IDarkpoolV2.InvalidIntentCommitmentSignature();
+        state.spendNonce(authBundle.intentSignature.nonce);
+    }
+
+    // -------------------------
+    // | Constraint Validation |
+    // -------------------------
+
+    /// @notice Validate that the obligation matches the settlement statement
+    /// @param bundleData The bundle to validate
+    /// @param obligation The obligation to match against
+    /// @dev Reverts if the obligation does not match
+    function validateObligation(
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
+        SettlementObligation memory obligation
+    )
+        internal
+        pure
+    {
+        bool matches = obligation.isEqualTo(bundleData.settlementStatement.obligation);
+        if (!matches) revert IDarkpoolV2.InvalidObligation();
+    }
+
+    /// @notice Validate that the obligation matches the settlement statement
+    /// @param bundleData The bundle to validate
+    /// @param obligation The obligation to match against
+    /// @dev Reverts if the obligation does not match
+    function validateObligation(
+        PrivateIntentPublicBalanceBundle memory bundleData,
+        SettlementObligation memory obligation
+    )
+        internal
+        pure
+    {
+        bool matches = obligation.isEqualTo(bundleData.settlementStatement.obligation);
+        if (!matches) revert IDarkpoolV2.InvalidObligation();
+    }
+
+    /// @notice Validate that the bounded match result matches the settlement statement
+    /// @param bundleData The bundle to validate
+    /// @param matchResult The match result to match against
+    /// @dev Reverts if the match result does not match
+    function validateMatchResult(
+        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
+        BoundedMatchResult memory matchResult
+    )
+        internal
+        pure
+    {
+        bool matches = matchResult.isEqualTo(bundleData.settlementStatement.boundedMatchResult);
+        if (!matches) revert IDarkpoolV2.InvalidBoundedMatchResult();
+    }
+
+    /// @notice Validate that the bounded match result matches the settlement statement
+    /// @param bundleData The bundle to validate
+    /// @param matchResult The match result to match against
+    /// @dev Reverts if the match result does not match
+    function validateMatchResult(
+        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
+        BoundedMatchResult memory matchResult
+    )
+        internal
+        pure
+    {
+        bool matches = matchResult.isEqualTo(bundleData.settlementStatement.boundedMatchResult);
+        if (!matches) revert IDarkpoolV2.InvalidBoundedMatchResult();
+    }
+
+    // -------------------
+    // | Validity Proofs |
+    // -------------------
+
+    /// @notice Push the validity proof to the context and validate merkle depth
+    /// @param bundleData The bundle containing the validity proof
+    /// @param settlementContext The context to push to
+    /// @param vkeys The verification keys contract
+    function pushValidityProof(
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+        view
+    {
+        BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
+        VerificationKey memory vk = vkeys.intentOnlyFirstFillValidityKeys();
+        _pushValidityProofInner(
+            bundleData.auth.merkleDepth, publicInputs, bundleData.auth.validityProof, vk, settlementContext
+        );
+    }
+
+    /// @notice Push the validity proof to the context and validate merkle depth
+    /// @param bundleData The bundle containing the validity proof
+    /// @param settlementContext The context to push to
+    /// @param vkeys The verification keys contract
+    function pushValidityProof(
+        PrivateIntentPublicBalanceBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+        view
+    {
+        BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
+        VerificationKey memory vk = vkeys.intentOnlyValidityKeys();
+        _pushValidityProofInner(
+            bundleData.auth.merkleDepth, publicInputs, bundleData.auth.validityProof, vk, settlementContext
+        );
+    }
+
+    /// @notice Push the validity proof to the context and validate merkle depth
+    /// @param bundleData The bundle containing the validity proof
+    /// @param settlementContext The context to push to
+    /// @param vkeys The verification keys contract
+    function pushValidityProof(
+        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+        view
+    {
+        BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
+        VerificationKey memory vk = vkeys.intentOnlyFirstFillValidityKeys();
+        _pushValidityProofInner(
+            bundleData.auth.merkleDepth, publicInputs, bundleData.auth.validityProof, vk, settlementContext
+        );
+    }
+
+    /// @notice Push the validity proof to the context and validate merkle depth
+    /// @param bundleData The bundle containing the validity proof
+    /// @param settlementContext The context to push to
+    /// @param vkeys The verification keys contract
+    function pushValidityProof(
+        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+        view
+    {
+        BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
+        VerificationKey memory vk = vkeys.intentOnlyValidityKeys();
+        _pushValidityProofInner(
+            bundleData.auth.merkleDepth, publicInputs, bundleData.auth.validityProof, vk, settlementContext
+        );
+    }
+
+    /// @notice Internal helper to validate merkle depth and push validity proof
+    /// @param merkleDepth The merkle depth to validate
+    /// @param publicInputs The serialized public inputs
+    /// @param validityProof The validity proof to push
+    /// @param vk The verification key to use
+    /// @param settlementContext The context to push to
+    function _pushValidityProofInner(
+        uint256 merkleDepth,
+        BN254.ScalarField[] memory publicInputs,
+        PlonkProof memory validityProof,
+        VerificationKey memory vk,
+        SettlementContext memory settlementContext
+    )
+        private
+        pure
+    {
+        if (merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
+            revert IDarkpool.InvalidMerkleDepthRequested();
+        }
+        settlementContext.pushProof(publicInputs, validityProof, vk);
+    }
+
+    // ---------------------
+    // | Settlement Proofs |
+    // ---------------------
+
+    /// @notice Push the settlement proof and proof linking argument to the context
+    /// @param bundleData The bundle containing proofs
+    /// @param settlementContext The context to push to
+    /// @param vkeys The verification keys contract
+    function pushSettlementProofs(
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+        view
+    {
+        _pushSettlementProofsInner(
+            bundleData.settlementStatement,
+            bundleData.settlementProof,
+            bundleData.auth.validityProof,
+            bundleData.authSettlementLinkingProof,
+            settlementContext,
+            vkeys
+        );
+    }
+
+    /// @notice Push the settlement proof and proof linking argument to the context
+    /// @param bundleData The bundle containing proofs
+    /// @param settlementContext The context to push to
+    /// @param vkeys The verification keys contract
+    function pushSettlementProofs(
+        PrivateIntentPublicBalanceBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+        view
+    {
+        _pushSettlementProofsInner(
+            bundleData.settlementStatement,
+            bundleData.settlementProof,
+            bundleData.auth.validityProof,
+            bundleData.authSettlementLinkingProof,
+            settlementContext,
+            vkeys
+        );
+    }
+
+    /// @notice Push the settlement proof to the context for a bounded settlement
+    /// @param bundleData The bundle containing proofs
+    /// @param settlementContext The context to push to
+    function pushSettlementProofs(
+        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
+        SettlementContext memory settlementContext
+    )
+        internal
+        pure
+    {
+        _pushBoundedSettlementProofInner(bundleData.settlementStatement, bundleData.settlementProof, settlementContext);
+    }
+
+    /// @notice Push the settlement proof to the context for a bounded settlement
+    /// @param bundleData The bundle containing proofs
+    /// @param settlementContext The context to push to
+    function pushSettlementProofs(
+        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
+        SettlementContext memory settlementContext
+    )
+        internal
+        pure
+    {
+        _pushBoundedSettlementProofInner(bundleData.settlementStatement, bundleData.settlementProof, settlementContext);
+    }
+
+    /// @notice Internal helper to push settlement proof and proof linking for exact match
+    /// @param settlementStatement The settlement statement
+    /// @param settlementProof The settlement proof
+    /// @param validityProof The validity proof (for proof linking)
+    /// @param authSettlementLinkingProof The proof linking the auth and settlement proofs
+    /// @param settlementContext The context to push to
+    /// @param vkeys The verification keys contract
+    function _pushSettlementProofsInner(
+        IntentOnlyPublicSettlementStatement memory settlementStatement,
+        PlonkProof memory settlementProof,
+        PlonkProof memory validityProof,
+        LinkingProof memory authSettlementLinkingProof,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        private
+        view
+    {
+        // Push the settlement proof
+        BN254.ScalarField[] memory publicInputs = settlementStatement.statementSerialize();
+        VerificationKey memory vk = vkeys.intentOnlyPublicSettlementKeys();
+        settlementContext.pushProof(publicInputs, settlementProof, vk);
+
+        // Push the proof linking argument
+        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
+            wireComm0: validityProof.wireComms[0],
+            wireComm1: settlementProof.wireComms[0],
+            proof: authSettlementLinkingProof,
+            vk: vkeys.intentOnlySettlementLinkingKey()
+        });
+        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
+    }
+
+    /// @notice Internal helper to push settlement proof for bounded match
+    /// @param settlementStatement The bounded settlement statement
+    /// @param settlementProof The settlement proof
+    /// @param settlementContext The context to push to
+    function _pushBoundedSettlementProofInner(
+        IntentOnlyBoundedSettlementStatement memory settlementStatement,
+        PlonkProof memory settlementProof,
+        SettlementContext memory settlementContext
+    )
+        private
+        pure
+    {
+        // Push the settlement proof
+        BN254.ScalarField[] memory publicInputs = settlementStatement.statementSerialize();
+        VerificationKey memory vk = PublicInputsLib.dummyVkey();
+        settlementContext.pushProof(publicInputs, settlementProof, vk);
+
+        // TODO: Push the proof linking argument
+    }
+
+    // -------------
+    // | Transfers |
+    // -------------
+
+    /// @notice Allocate transfers to settle the obligation for a first fill exact bundle
+    /// @param bundleData The bundle to extract owner and fee rate from
+    /// @param obligation The settlement obligation
+    /// @param settlementContext The context to push transfers to
+    /// @param state The darkpool state containing all storage references
+    function allocateTransfers(
+        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        internal
+        view
+    {
+        address owner = bundleData.auth.statement.intentOwner;
+        FeeRate memory relayerFeeRate = FeeRate({
+            rate: bundleData.settlementStatement.relayerFee,
+            recipient: bundleData.settlementStatement.relayerFeeRecipient
+        });
+        _allocateTransfersInner(owner, relayerFeeRate, obligation, settlementContext, state);
+    }
+
+    /// @notice Allocate transfers to settle the obligation for a subsequent fill exact bundle
+    /// @param bundleData The bundle to extract owner and fee rate from
+    /// @param obligation The settlement obligation
+    /// @param settlementContext The context to push transfers to
+    /// @param state The darkpool state containing all storage references
+    function allocateTransfers(
+        PrivateIntentPublicBalanceBundle memory bundleData,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        internal
+        view
+    {
+        address owner = bundleData.auth.statement.intentOwner;
+        FeeRate memory relayerFeeRate = FeeRate({
+            rate: bundleData.settlementStatement.relayerFee,
+            recipient: bundleData.settlementStatement.relayerFeeRecipient
+        });
+        _allocateTransfersInner(owner, relayerFeeRate, obligation, settlementContext, state);
+    }
+
+    /// @notice Allocate transfers to settle the obligation for a first fill bounded bundle
+    /// @param bundleData The bundle to extract owner and fee rate from
+    /// @param obligation The settlement obligation
+    /// @param settlementContext The context to push transfers to
+    /// @param state The darkpool state containing all storage references
+    function allocateTransfers(
+        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        internal
+        view
+    {
+        address owner = bundleData.auth.statement.intentOwner;
+        FeeRate memory relayerFeeRate = FeeRate({
+            rate: bundleData.settlementStatement.internalRelayerFeeRate,
+            recipient: bundleData.settlementStatement.relayerFeeAddress
+        });
+        _allocateTransfersInner(owner, relayerFeeRate, obligation, settlementContext, state);
+    }
+
+    /// @notice Allocate transfers to settle the obligation for a subsequent fill bounded bundle
+    /// @param bundleData The bundle to extract owner and fee rate from
+    /// @param obligation The settlement obligation
+    /// @param settlementContext The context to push transfers to
+    /// @param state The darkpool state containing all storage references
+    function allocateTransfers(
+        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        internal
+        view
+    {
+        address owner = bundleData.auth.statement.intentOwner;
+        FeeRate memory relayerFeeRate = FeeRate({
+            rate: bundleData.settlementStatement.internalRelayerFeeRate,
+            recipient: bundleData.settlementStatement.relayerFeeAddress
+        });
+        _allocateTransfersInner(owner, relayerFeeRate, obligation, settlementContext, state);
+    }
+
+    /// @notice Internal helper to allocate transfers - not exposed to orchestrator
+    /// @param owner The owner of the intent
+    /// @param relayerFeeRate The relayer fee rate (extracted from bundle)
+    /// @param obligation The settlement obligation
+    /// @param settlementContext The context to push transfers to
+    /// @param state The darkpool state containing all storage references
+    function _allocateTransfersInner(
+        address owner,
+        FeeRate memory relayerFeeRate,
+        SettlementObligation memory obligation,
+        SettlementContext memory settlementContext,
+        DarkpoolState storage state
+    )
+        private
+        view
+    {
+        // Fetch protocol fee rate from state
+        FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
+
+        // Compute fee takes
+        FeeTake memory relayerFeeTake = relayerFeeRate.computeFeeTake(obligation.outputToken, obligation.amountOut);
+        FeeTake memory protocolFeeTake = protocolFeeRate.computeFeeTake(obligation.outputToken, obligation.amountOut);
+
+        // Deposit the input token into the darkpool
+        SimpleTransfer memory deposit = obligation.buildPermit2AllowanceDeposit(owner);
+        settlementContext.pushDeposit(deposit);
+
+        // Withdraw the output token from the darkpool (minus fees)
+        uint256 totalFee = relayerFeeTake.fee + protocolFeeTake.fee;
+        SimpleTransfer memory withdrawal = obligation.buildWithdrawalTransfer(owner, totalFee);
+        settlementContext.pushWithdrawal(withdrawal);
+
+        // Withdraw the relayer and protocol fees to their respective recipients
+        settlementContext.pushWithdrawal(relayerFeeTake.buildWithdrawalTransfer());
+        settlementContext.pushWithdrawal(protocolFeeTake.buildWithdrawalTransfer());
+    }
+}

--- a/src/darkpool/v2/types/BoundedMatchResult.sol
+++ b/src/darkpool/v2/types/BoundedMatchResult.sol
@@ -31,6 +31,26 @@ struct BoundedMatchResult {
 library BoundedMatchResultLib {
     using FixedPointLib for FixedPoint;
 
+    /// @notice Return whether two bounded match results are equal
+    /// @param boundedMatchResult0 The first bounded match result to compare
+    /// @param boundedMatchResult1 The second bounded match result to compare
+    /// @return Whether the bounded match results are equal
+    function isEqualTo(
+        BoundedMatchResult memory boundedMatchResult0,
+        BoundedMatchResult memory boundedMatchResult1
+    )
+        internal
+        pure
+        returns (bool)
+    {
+        return boundedMatchResult0.internalPartyInputToken == boundedMatchResult1.internalPartyInputToken
+            && boundedMatchResult0.internalPartyOutputToken == boundedMatchResult1.internalPartyOutputToken
+            && boundedMatchResult0.price.repr == boundedMatchResult1.price.repr
+            && boundedMatchResult0.minInternalPartyAmountIn == boundedMatchResult1.minInternalPartyAmountIn
+            && boundedMatchResult0.maxInternalPartyAmountIn == boundedMatchResult1.maxInternalPartyAmountIn
+            && boundedMatchResult0.blockDeadline == boundedMatchResult1.blockDeadline;
+    }
+
     /// @notice Build two `SettlementObligation`s from a `BoundedMatchResult` and an input amount.
     /// @param matchResult The `BoundedMatchResult` to build the `SettlementObligation`s from
     /// @param externalPartyAmountIn The amount of the input token to trade for the external party

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -91,54 +91,6 @@ struct PublicIntentPublicBalanceBundle {
     FeeRate relayerFeeRate;
 }
 
-/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bundle on the first fill
-struct PrivateIntentPublicBalanceFirstFillBundle {
-    /// @dev The private intent authorization payload with signature attached
-    PrivateIntentAuthBundleFirstFill auth;
-    /// @dev The statement of single-intent match settlement
-    IntentOnlyPublicSettlementStatement settlementStatement;
-    /// @dev The proof of single-intent match settlement
-    PlonkProof settlementProof;
-    /// @dev The proof linking the authorization and settlement proofs
-    LinkingProof authSettlementLinkingProof;
-}
-
-/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bundle
-struct PrivateIntentPublicBalanceBundle {
-    /// @dev The private intent authorization payload with signature attached
-    PrivateIntentAuthBundle auth;
-    /// @dev The statement of single-intent match settlement
-    IntentOnlyPublicSettlementStatement settlementStatement;
-    /// @dev The proof of single-intent match settlement
-    PlonkProof settlementProof;
-    /// @dev The proof linking the authorization and settlement proofs
-    LinkingProof authSettlementLinkingProof;
-}
-
-/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bounded settlement on the first fill
-struct PrivateIntentPublicBalanceBoundedFirstFillBundle {
-    /// @dev The private intent authorization payload with signature attached
-    PrivateIntentAuthBundleFirstFill auth;
-    /// @dev The statement of single-intent bounded settlement
-    IntentOnlyBoundedSettlementStatement settlementStatement;
-    /// @dev The proof of single-intent bounded settlement
-    PlonkProof settlementProof;
-    /// @dev The proof linking the authorization and settlement proofs
-    LinkingProof authSettlementLinkingProof;
-}
-
-/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bounded settlement
-struct PrivateIntentPublicBalanceBoundedBundle {
-    /// @dev The private intent authorization payload with signature attached
-    PrivateIntentAuthBundle auth;
-    /// @dev The statement of single-intent bounded settlement
-    IntentOnlyBoundedSettlementStatement settlementStatement;
-    /// @dev The proof of single-intent bounded settlement
-    PlonkProof settlementProof;
-    /// @dev The proof linking the authorization and settlement proofs
-    LinkingProof authSettlementLinkingProof;
-}
-
 /// @notice The settlement bundle data for a `RENEGADE_SETTLED_PRIVATE_INTENT` bundle on the first fill
 struct RenegadeSettledIntentFirstFillBundle {
     /// @dev The private intent authorization payload with signature attached
@@ -289,159 +241,6 @@ library SettlementBundleLib {
     }
 
     // --- Commitments --- //
-
-    /// @notice Compute the full commitment to the updated intent for a natively settled public intent bundle
-    /// on its first fill
-    /// @param bundleData The bundle data to compute the commitment for
-    /// @param hasher The hasher to use for hashing
-    /// @return preUpdateIntentCommitment The commitment to the pre-updated intent
-    /// @return postUpdateIntentCommitment The commitment to the post-updated intent
-    /// @dev Only the amount share in the intent changes between the pre- and post-update intent shares, so we can
-    /// compute the shared prefix of the two commitments and then resume the commitment for each of the amount shares.
-    function computeIntentCommitments(
-        PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
-        IHasher hasher
-    )
-        internal
-        view
-        returns (BN254.ScalarField preUpdateIntentCommitment, BN254.ScalarField postUpdateIntentCommitment)
-    {
-        IntentOnlyValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
-        IntentOnlyPublicSettlementStatement memory settlementStatement = bundleData.settlementStatement;
-        IntentPublicShare memory intentPublicShare = authStatement.intentPublicShare;
-
-        // 1. Compute the shared prefix of the two commitments
-        uint256[] memory intentPublicShareScalars = intentPublicShare.scalarSerializeMatchPrefix();
-        uint256 prefixHash = hasher.computeResumableCommitment(intentPublicShareScalars);
-
-        // 2. Compute the full pre-update commitment; i.e. the commitment to the original shares
-        PartialCommitment memory sharedPrefixPartialComm = PartialCommitment({
-            privateCommitment: authStatement.intentPrivateCommitment,
-            partialPublicCommitment: BN254.ScalarField.wrap(prefixHash)
-        });
-
-        uint256[] memory preUpdateRemainingShares = new uint256[](1);
-        preUpdateRemainingShares[0] = BN254.ScalarField.unwrap(authStatement.intentPublicShare.amountIn);
-        preUpdateIntentCommitment =
-            CommitmentLib.computeResumableCommitment(preUpdateRemainingShares, sharedPrefixPartialComm, hasher);
-
-        // 3. Compute the full post-update commitment
-        // To do so we must update the `amountIn` field in the intent public shares to reflect the settlement
-        uint256[] memory postUpdateRemainingShares = new uint256[](1);
-        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementStatement.obligation.amountIn);
-        BN254.ScalarField newAmountInShare = authStatement.intentPublicShare.amountIn.sub(settlementAmount);
-        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountInShare);
-        postUpdateIntentCommitment =
-            CommitmentLib.computeResumableCommitment(postUpdateRemainingShares, sharedPrefixPartialComm, hasher);
-    }
-
-    /// @notice Compute the pre- and post-update intent commitments for a bounded match first fill
-    /// @dev This differs from the method above in that the settlement amount comes from the obligation rather than the
-    /// statement since because trade size is determined at runtime.
-    /// @param bundleData The bundle data to compute the commitments for
-    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
-    /// @param hasher The hasher to use for hashing
-    /// @return preUpdateIntentCommitment The commitment to the pre-updated intent
-    /// @return postUpdateIntentCommitment The commitment to the post-updated intent
-    function computeIntentCommitments(
-        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
-        uint256 internalPartyAmountIn,
-        IHasher hasher
-    )
-        internal
-        view
-        returns (BN254.ScalarField preUpdateIntentCommitment, BN254.ScalarField postUpdateIntentCommitment)
-    {
-        IntentOnlyValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
-        IntentPublicShare memory intentPublicShare = authStatement.intentPublicShare;
-
-        // 1. Compute the shared prefix of the two commitments (same as regular case)
-        uint256[] memory intentPublicShareScalars = intentPublicShare.scalarSerializeMatchPrefix();
-        uint256 prefixHash = hasher.computeResumableCommitment(intentPublicShareScalars);
-
-        // 2. Compute the full pre-update commitment; i.e. the commitment to the original shares
-        PartialCommitment memory sharedPrefixPartialComm = PartialCommitment({
-            privateCommitment: authStatement.intentPrivateCommitment,
-            partialPublicCommitment: BN254.ScalarField.wrap(prefixHash)
-        });
-
-        uint256[] memory preUpdateRemainingShares = new uint256[](1);
-        preUpdateRemainingShares[0] = BN254.ScalarField.unwrap(authStatement.intentPublicShare.amountIn);
-        preUpdateIntentCommitment =
-            CommitmentLib.computeResumableCommitment(preUpdateRemainingShares, sharedPrefixPartialComm, hasher);
-
-        // 3. Compute the full post-update commitment
-        // To do so we must update the `amountIn` field in the intent public shares to reflect the settlement
-        uint256[] memory postUpdateRemainingShares = new uint256[](1);
-        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
-        // SAFETY: intent.amountIn >= maxBound (constrained in circuit) >= settlementAmount (checked
-        // inBoundedMatchResultLib.validateAmountIn)
-        BN254.ScalarField newAmountInShare = authStatement.intentPublicShare.amountIn.sub(settlementAmount);
-        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountInShare);
-        postUpdateIntentCommitment =
-            CommitmentLib.computeResumableCommitment(postUpdateRemainingShares, sharedPrefixPartialComm, hasher);
-    }
-
-    /// @notice Compute the full commitment to the updated intent for a natively settled private intent bundle
-    /// @param bundleData The bundle data to compute the commitment for
-    /// @param hasher The hasher to use for hashing
-    /// @return newIntentCommitment The full commitment to the updated intent
-    /// @dev The only remaining share left out of the partial commitment is the public share of the amount field, which
-    /// must be updated to reflect the settlement before committing.
-    function computeFullIntentCommitment(
-        PrivateIntentPublicBalanceBundle memory bundleData,
-        IHasher hasher
-    )
-        internal
-        view
-        returns (BN254.ScalarField newIntentCommitment)
-    {
-        IntentOnlyValidityStatement memory authStatement = bundleData.auth.statement;
-        IntentOnlyPublicSettlementStatement memory settlementStatement = bundleData.settlementStatement;
-
-        // 1. Apply the settlement to the intent public share
-        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementStatement.obligation.amountIn);
-        BN254.ScalarField newAmountShareScalar = authStatement.newAmountShare.sub(settlementAmount);
-
-        // 2. Compute the full commitment to the updated intent by resuming from the partial commitment
-        uint256[] memory postUpdateRemainingShares = new uint256[](1);
-        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountShareScalar);
-        newIntentCommitment = CommitmentLib.computeResumableCommitment(
-            postUpdateRemainingShares, authStatement.newIntentPartialCommitment, hasher
-        );
-    }
-
-    /// @notice Compute the full commitment to the updated intent for a bounded match subsequent fill
-    /// @dev This differs from the method above in that the settlement amount comes from the obligation rather than the
-    /// statement since trade size is determined at runtime.
-    /// @param bundleData The bundle data to compute the commitments for
-    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
-    /// @param hasher The hasher to use for hashing
-    /// @return newIntentCommitment The full commitment to the updated intent
-    function computeFullIntentCommitment(
-        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
-        uint256 internalPartyAmountIn,
-        IHasher hasher
-    )
-        internal
-        view
-        returns (BN254.ScalarField newIntentCommitment)
-    {
-        IntentOnlyValidityStatement memory authStatement = bundleData.auth.statement;
-
-        // 1. Apply the settlement to the intent public share
-        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
-        // SAFETY: intent.amountIn >= maxBound (constrained in circuit) >= settlementAmount (checked
-        // inBoundedMatchResultLib.validateAmountIn)
-        BN254.ScalarField newAmountShareScalar = authStatement.newAmountShare.sub(settlementAmount);
-
-        // 2. Compute the full commitment to the updated intent by resuming from the partial commitment
-        uint256[] memory postUpdateRemainingShares = new uint256[](1);
-        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountShareScalar);
-        newIntentCommitment = CommitmentLib.computeResumableCommitment(
-            postUpdateRemainingShares, authStatement.newIntentPartialCommitment, hasher
-        );
-    }
 
     /// @notice Compute the full commitment to the updated intent for a renegade settled private intent bundle
     /// on its first fill
@@ -691,64 +490,10 @@ library SettlementBundleLib {
         pure
         returns (PublicIntentPublicBalanceBundle memory bundleData)
     {
-        bool validType = !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT;
+        bool validType =
+            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT;
         require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
-    }
-
-    /// @notice Decode a private settlement bundle for a first fill
-    /// @param bundle The settlement bundle to decode
-    /// @return bundleData The decoded bundle data
-    function decodePrivateIntentBundleDataFirstFill(SettlementBundle calldata bundle)
-        internal
-        pure
-        returns (PrivateIntentPublicBalanceFirstFillBundle memory bundleData)
-    {
-        bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
-        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
-        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceFirstFillBundle));
-    }
-
-    /// @notice Decode a private settlement bundle
-    /// @param bundle The settlement bundle to decode
-    /// @return bundleData The decoded bundle data
-    function decodePrivateIntentBundleData(SettlementBundle calldata bundle)
-        internal
-        pure
-        returns (PrivateIntentPublicBalanceBundle memory bundleData)
-    {
-        bool validType =
-            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
-        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
-        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundle));
-    }
-
-    /// @notice Decode a private intent bounded settlement bundle for a first fill
-    /// @param bundle The settlement bundle to decode
-    /// @return bundleData The decoded bundle data
-    function decodePrivateIntentBoundedBundleDataFirstFill(SettlementBundle calldata bundle)
-        internal
-        pure
-        returns (PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData)
-    {
-        bool validType =
-            bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
-        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
-        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBoundedFirstFillBundle));
-    }
-
-    /// @notice Decode a private intent bounded settlement bundle
-    /// @param bundle The settlement bundle to decode
-    /// @return bundleData The decoded bundle data
-    function decodePrivateIntentBoundedBundleData(SettlementBundle calldata bundle)
-        internal
-        pure
-        returns (PrivateIntentPublicBalanceBoundedBundle memory bundleData)
-    {
-        bool validType =
-            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
-        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
-        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBoundedBundle));
     }
 
     /// @notice Decode a renegade settled private intent settlement bundle
@@ -785,7 +530,8 @@ library SettlementBundleLib {
         pure
         returns (RenegadeSettledPrivateFirstFillBundle memory bundleData)
     {
-        bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
+        bool validType =
+            bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
         require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFirstFillBundle));
     }
@@ -798,7 +544,8 @@ library SettlementBundleLib {
         pure
         returns (RenegadeSettledPrivateFillBundle memory bundleData)
     {
-        bool validType = !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
+        bool validType =
+            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
         require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFillBundle));
     }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -12,6 +12,7 @@ import {
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import {
     IntentOnlyPublicSettlementStatement,
+    IntentOnlyBoundedSettlementStatement,
     IntentAndBalancePublicSettlementStatement
 } from "darkpoolv2-lib/public_inputs/Settlement.sol";
 import {
@@ -109,6 +110,30 @@ struct PrivateIntentPublicBalanceBundle {
     /// @dev The statement of single-intent match settlement
     IntentOnlyPublicSettlementStatement settlementStatement;
     /// @dev The proof of single-intent match settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bounded settlement on the first fill
+struct PrivateIntentPublicBalanceBoundedFirstFillBundle {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentAuthBundleFirstFill auth;
+    /// @dev The statement of single-intent bounded settlement
+    IntentOnlyBoundedSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent bounded settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @notice The settlement bundle data for a `NATIVELY_SETTLED_PRIVATE_INTENT` bounded settlement
+struct PrivateIntentPublicBalanceBoundedBundle {
+    /// @dev The private intent authorization payload with signature attached
+    PrivateIntentAuthBundle auth;
+    /// @dev The statement of single-intent bounded settlement
+    IntentOnlyBoundedSettlementStatement settlementStatement;
+    /// @dev The proof of single-intent bounded settlement
     PlonkProof settlementProof;
     /// @dev The proof linking the authorization and settlement proofs
     LinkingProof authSettlementLinkingProof;
@@ -310,6 +335,53 @@ library SettlementBundleLib {
             CommitmentLib.computeResumableCommitment(postUpdateRemainingShares, sharedPrefixPartialComm, hasher);
     }
 
+    /// @notice Compute the pre- and post-update intent commitments for a bounded match first fill
+    /// @dev This differs from the method above in that the settlement amount comes from the obligation rather than the
+    /// statement since because trade size is determined at runtime.
+    /// @param bundleData The bundle data to compute the commitments for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param hasher The hasher to use for hashing
+    /// @return preUpdateIntentCommitment The commitment to the pre-updated intent
+    /// @return postUpdateIntentCommitment The commitment to the post-updated intent
+    function computeIntentCommitments(
+        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField preUpdateIntentCommitment, BN254.ScalarField postUpdateIntentCommitment)
+    {
+        IntentOnlyValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+        IntentPublicShare memory intentPublicShare = authStatement.intentPublicShare;
+
+        // 1. Compute the shared prefix of the two commitments (same as regular case)
+        uint256[] memory intentPublicShareScalars = intentPublicShare.scalarSerializeMatchPrefix();
+        uint256 prefixHash = hasher.computeResumableCommitment(intentPublicShareScalars);
+
+        // 2. Compute the full pre-update commitment; i.e. the commitment to the original shares
+        PartialCommitment memory sharedPrefixPartialComm = PartialCommitment({
+            privateCommitment: authStatement.intentPrivateCommitment,
+            partialPublicCommitment: BN254.ScalarField.wrap(prefixHash)
+        });
+
+        uint256[] memory preUpdateRemainingShares = new uint256[](1);
+        preUpdateRemainingShares[0] = BN254.ScalarField.unwrap(authStatement.intentPublicShare.amountIn);
+        preUpdateIntentCommitment =
+            CommitmentLib.computeResumableCommitment(preUpdateRemainingShares, sharedPrefixPartialComm, hasher);
+
+        // 3. Compute the full post-update commitment
+        // To do so we must update the `amountIn` field in the intent public shares to reflect the settlement
+        uint256[] memory postUpdateRemainingShares = new uint256[](1);
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
+        // SAFETY: intent.amountIn >= maxBound (constrained in circuit) >= settlementAmount (checked
+        // inBoundedMatchResultLib.validateAmountIn)
+        BN254.ScalarField newAmountInShare = authStatement.intentPublicShare.amountIn.sub(settlementAmount);
+        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountInShare);
+        postUpdateIntentCommitment =
+            CommitmentLib.computeResumableCommitment(postUpdateRemainingShares, sharedPrefixPartialComm, hasher);
+    }
+
     /// @notice Compute the full commitment to the updated intent for a natively settled private intent bundle
     /// @param bundleData The bundle data to compute the commitment for
     /// @param hasher The hasher to use for hashing
@@ -329,6 +401,38 @@ library SettlementBundleLib {
 
         // 1. Apply the settlement to the intent public share
         BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementStatement.obligation.amountIn);
+        BN254.ScalarField newAmountShareScalar = authStatement.newAmountShare.sub(settlementAmount);
+
+        // 2. Compute the full commitment to the updated intent by resuming from the partial commitment
+        uint256[] memory postUpdateRemainingShares = new uint256[](1);
+        postUpdateRemainingShares[0] = BN254.ScalarField.unwrap(newAmountShareScalar);
+        newIntentCommitment = CommitmentLib.computeResumableCommitment(
+            postUpdateRemainingShares, authStatement.newIntentPartialCommitment, hasher
+        );
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a bounded match subsequent fill
+    /// @dev This differs from the method above in that the settlement amount comes from the obligation rather than the
+    /// statement since trade size is determined at runtime.
+    /// @param bundleData The bundle data to compute the commitments for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        PrivateIntentPublicBalanceBoundedBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        IntentOnlyValidityStatement memory authStatement = bundleData.auth.statement;
+
+        // 1. Apply the settlement to the intent public share
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
+        // SAFETY: intent.amountIn >= maxBound (constrained in circuit) >= settlementAmount (checked
+        // inBoundedMatchResultLib.validateAmountIn)
         BN254.ScalarField newAmountShareScalar = authStatement.newAmountShare.sub(settlementAmount);
 
         // 2. Compute the full commitment to the updated intent by resuming from the partial commitment
@@ -617,6 +721,34 @@ library SettlementBundleLib {
             !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
         require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundle));
+    }
+
+    /// @notice Decode a private intent bounded settlement bundle for a first fill
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePrivateIntentBoundedBundleDataFirstFill(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData)
+    {
+        bool validType =
+            bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBoundedFirstFillBundle));
+    }
+
+    /// @notice Decode a private intent bounded settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodePrivateIntentBoundedBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (PrivateIntentPublicBalanceBoundedBundle memory bundleData)
+    {
+        bool validType =
+            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBoundedBundle));
     }
 
     /// @notice Decode a renegade settled private intent settlement bundle

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -97,6 +97,7 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
         // Approve the darkpool contract directly (external party doesn't use permit2)
         vm.startPrank(externalParty.addr);
         erc20.approve(address(darkpool), type(uint256).max);
+        erc20.approve(address(darkpoolRealVerifier), type(uint256).max);
         vm.stopPrank();
     }
 

--- a/test/darkpool/v2/bounded-match-result/Utils.sol
+++ b/test/darkpool/v2/bounded-match-result/Utils.sol
@@ -5,12 +5,12 @@ import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 
 import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
 
-import { ExternalMatchTestUtils } from "../settlement/external-match/Utils.sol";
+import { DarkpoolV2TestUtils } from "../DarkpoolV2TestUtils.sol";
 
 /// @title Bounded Match Result Test Utils
 /// @notice Shared utilities for bounded match result tests
 /// @author Renegade Eng
-contract BoundedMatchResultTestUtils is ExternalMatchTestUtils {
+contract BoundedMatchResultTestUtils is DarkpoolV2TestUtils {
     using BoundedMatchResultLib for BoundedMatchResult;
     using FixedPointLib for FixedPoint;
 

--- a/test/darkpool/v2/settlement/external-match/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/Utils.sol
@@ -1,20 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import { Intent } from "darkpoolv2-types/Intent.sol";
+import { Vm } from "forge-std/Vm.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
-import {
-    SettlementBundle,
-    SettlementBundleType,
-    PublicIntentPublicBalanceBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import {
-    SignatureWithNonce,
-    PublicIntentAuthBundle,
-    PublicIntentPermit,
-    PublicIntentPermitLib
-} from "darkpoolv2-types/settlement/IntentBundle.sol";
 import {
     BoundedMatchResultPermit,
     BoundedMatchResultBundle,
@@ -22,70 +12,19 @@ import {
 } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
 import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { FeeRate } from "darkpoolv2-types/Fee.sol";
-import { BalanceSnapshots, ExpectedDifferences, SettlementTestUtils } from "../SettlementTestUtils.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SettlementTestUtils } from "../SettlementTestUtils.sol";
 
 contract ExternalMatchTestUtils is SettlementTestUtils {
     using BoundedMatchResultLib for BoundedMatchResult;
     using BoundedMatchResultPermitLib for BoundedMatchResultPermit;
-    using PublicIntentPermitLib for PublicIntentPermit;
     using FixedPointLib for FixedPoint;
 
     // ---------
     // | Utils |
     // ---------
 
-    // --- Signatures --- //
-
-    /// @dev Sign an intent permit
-    function signIntentPermit(
-        PublicIntentPermit memory permit,
-        uint256 signerPrivateKey
-    )
-        internal
-        returns (SignatureWithNonce memory)
-    {
-        // Sign with the private key
-        uint256 nonce = randomUint();
-        bytes32 permitHash = permit.computeHash();
-        bytes32 signatureDigest = EfficientHashLib.hash(permitHash, bytes32(nonce));
-
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, signatureDigest);
-        return SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
-    }
-
-    /// @dev Sign an obligation (memory version)
-    function createExecutorSignature(
-        FeeRate memory feeRate,
-        SettlementObligation memory obligation,
-        uint256 signerPrivateKey
-    )
-        internal
-        returns (SignatureWithNonce memory)
-    {
-        // Use the calldata version via external call for memory-to-calldata conversion
-        return this._createExecutorSignatureCalldata(obligation, feeRate, signerPrivateKey);
-    }
-
-    /// @dev Sign an obligation (calldata version)
-    function _createExecutorSignatureCalldata(
-        SettlementObligation memory obligation,
-        FeeRate memory feeRate,
-        uint256 signerPrivateKey
-    )
-        external
-        returns (SignatureWithNonce memory)
-    {
-        // Hash the fee with obligation
-        bytes memory encoded = abi.encode(feeRate, obligation);
-        bytes32 digest = EfficientHashLib.hash(encoded);
-
-        // Sign with the private key
-        uint256 nonce = randomUint();
-        bytes32 signatureHash = EfficientHashLib.hash(digest, bytes32(nonce));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, signatureHash);
-        return SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
-    }
+    // --- Bounded Match Result --- //
 
     /// @dev Sign a bounded match result
     function signMatchResult(
@@ -104,44 +43,7 @@ contract ExternalMatchTestUtils is SettlementTestUtils {
         return SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
     }
 
-    // --- Dummy Data --- //
-
-    /// @dev Create a complete settlement bundle with custom signers
-    function createPublicIntentSettlementBundleWithSigners(
-        Intent memory intent,
-        SettlementObligation memory obligation,
-        uint256 intentOwnerPrivateKey,
-        uint256 executorPrivateKey
-    )
-        internal
-        returns (SettlementBundle memory)
-    {
-        // Create the permit and sign it with the owner key
-        PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
-        SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
-
-        // Create relayer fee rate and sign the executor digest with the executor key
-        FeeRate memory feeRate = relayerFeeRate();
-        SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
-
-        // Create auth bundle
-        PublicIntentAuthBundle memory auth = PublicIntentAuthBundle({
-            permit: permit, intentSignature: intentSignature, executorSignature: executorSignature
-        });
-        PublicIntentPublicBalanceBundle memory bundleData =
-            PublicIntentPublicBalanceBundle({ auth: auth, relayerFeeRate: feeRate });
-
-        // Create the complete settlement bundle
-        return SettlementBundle({
-            isFirstFill: false,
-            bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,
-            data: abi.encode(bundleData)
-        });
-    }
-
-    // --- Bounded Match Result --- //
-
-    /// @dev Create a bounded match result authorization for a given intent
+    /// @dev Create a bounded match result authorization for a given obligation
     /// @param obligation The obligation to create the bounded match result for
     /// @param price The price of the obligation (inToken/outToken)
     /// @return matchResult The bounded match result
@@ -150,6 +52,7 @@ contract ExternalMatchTestUtils is SettlementTestUtils {
         FixedPoint memory price
     )
         internal
+        view
         returns (BoundedMatchResult memory matchResult)
     {
         uint256 minInternalPartyAmountIn = 0;
@@ -165,21 +68,6 @@ contract ExternalMatchTestUtils is SettlementTestUtils {
         });
 
         return matchResult;
-    }
-
-    /// @dev Create a bounded match result authorization bundle for a given obligation
-    /// @param obligation The obligation to create the bounded match result for
-    /// @param price The price of the obligation (inToken/outToken)
-    /// @return matchBundle The bounded match result authorization bundle
-    function createBoundedMatchResultBundleForObligation(
-        SettlementObligation memory obligation,
-        FixedPoint memory price
-    )
-        internal
-        returns (BoundedMatchResultBundle memory)
-    {
-        BoundedMatchResult memory matchResult = createBoundedMatchResultForObligation(obligation, price);
-        return createBoundedMatchResultBundleWithSigners(matchResult, executor.privateKey);
     }
 
     /// @dev Create a bounded match result authorization bundle with custom signers
@@ -201,7 +89,7 @@ contract ExternalMatchTestUtils is SettlementTestUtils {
         return BoundedMatchResultBundle({ permit: permit, executorSignature: matchResultSignature });
     }
 
-    // --- External Match --- //
+    // --- External Match Helpers --- //
 
     /// @dev Generate a random external party amount in and expected amount out
     /// @param externalObligation The external party's obligation to generate the amount in for

--- a/test/darkpool/v2/settlement/external-match/native-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-private-intents/FullMatchTests.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/* solhint-disable func-name-mixedcase */
+
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+
+import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
+import { FeeTake } from "darkpoolv2-types/Fee.sol";
+import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+
+import { BalanceSnapshots, ExpectedDifferences } from "../../SettlementTestUtils.sol";
+import { BoundedPrivateIntentTestUtils } from "./Utils.sol";
+
+contract FullMatchTests is BoundedPrivateIntentTestUtils {
+    using FixedPointLib for FixedPoint;
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @dev Create match data for a simulated trade
+    function _createMatchData(bool isFirstFill)
+        internal
+        returns (
+            SettlementObligation memory internalPartyObligation,
+            SettlementObligation memory externalPartyObligation,
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
+        )
+    {
+        // Create obligations for the trade
+        FixedPoint memory price;
+        (internalPartyObligation, externalPartyObligation, price) = createTradeObligations();
+
+        // Create bounded match result and bundle
+        BoundedMatchResult memory matchResult = createBoundedMatchResultForObligation(internalPartyObligation, price);
+        matchBundle = createBoundedMatchResultBundleWithSigners(matchResult, executor.privateKey);
+
+        // Create the internal party settlement bundle
+        internalPartySettlementBundle =
+            createBoundedPrivateIntentSettlementBundle(isFirstFill, matchResult, internalParty);
+
+        // Capitalize the parties for their obligations
+        capitalizeParty(internalParty.addr, internalPartyObligation);
+        capitalizeExternalParty(externalPartyObligation);
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    // --- Valid Test Cases --- //
+
+    /// @notice Test a basic bounded match settlement with first fill
+    function test_boundedMatch_firstFill() public {
+        // Create match data for first fill
+        (
+            SettlementObligation memory internalPartyObligation,
+            SettlementObligation memory externalPartyObligation,
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
+        ) =
+            _createMatchData(
+                true /* isFirstFill */
+            );
+
+        // Choose a trade size and build the actual obligations that will be used in settlement
+        (uint256 externalPartyAmountIn,) =
+            randomExternalPartyAmountIn(externalPartyObligation, matchBundle.permit.matchResult.price);
+        address recipient = externalParty.addr;
+        (SettlementObligation memory actualExternalObligation, SettlementObligation memory actualInternalObligation) =
+            buildObligationsFromMatchResult(matchBundle.permit.matchResult, externalPartyAmountIn);
+
+        // Compute fees that will be deducted from internal party's output
+        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) = computeMatchFees(actualInternalObligation);
+        uint256 totalFee = relayerFeeTake.fee + protocolFeeTake.fee;
+
+        // Set up expected differences accounting for fees
+        ExpectedDifferences memory expectedDifferences = createEmptyExpectedDifferences();
+        expectedDifferences.party0BaseChange = -int256(actualInternalObligation.amountIn);
+        expectedDifferences.party0QuoteChange = int256(actualInternalObligation.amountOut) - int256(totalFee);
+        expectedDifferences.party1BaseChange = int256(actualExternalObligation.amountOut);
+        expectedDifferences.party1QuoteChange = -int256(actualExternalObligation.amountIn);
+        expectedDifferences.relayerFeeBaseChange = 0;
+        expectedDifferences.relayerFeeQuoteChange = int256(relayerFeeTake.fee);
+        expectedDifferences.protocolFeeBaseChange = 0;
+        expectedDifferences.protocolFeeQuoteChange = int256(protocolFeeTake.fee);
+        expectedDifferences.darkpoolBaseChange = 0;
+        expectedDifferences.darkpoolQuoteChange = 0;
+
+        // Check balances before and after settlement
+        BalanceSnapshots memory preMatch = _captureBalances();
+        vm.prank(externalParty.addr);
+        darkpool.settleExternalMatch(externalPartyAmountIn, recipient, matchBundle, internalPartySettlementBundle);
+        BalanceSnapshots memory postMatch = _captureBalances();
+        _verifyBalanceChanges(preMatch, postMatch, expectedDifferences);
+    }
+
+    /// @notice Test a bounded match settlement with subsequent fill
+    function test_boundedMatch_subsequentFill() public {
+        // Create match data for subsequent fill
+        (
+            SettlementObligation memory internalPartyObligation,
+            SettlementObligation memory externalPartyObligation,
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
+        ) =
+            _createMatchData(
+                false /* isFirstFill */
+            );
+
+        // Choose a trade size and build the actual obligations that will be used in settlement
+        (uint256 externalPartyAmountIn,) =
+            randomExternalPartyAmountIn(externalPartyObligation, matchBundle.permit.matchResult.price);
+        address recipient = externalParty.addr;
+        (SettlementObligation memory actualExternalObligation, SettlementObligation memory actualInternalObligation) =
+            buildObligationsFromMatchResult(matchBundle.permit.matchResult, externalPartyAmountIn);
+
+        // Compute fees that will be deducted from internal party's output
+        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) = computeMatchFees(actualInternalObligation);
+        uint256 totalFee = relayerFeeTake.fee + protocolFeeTake.fee;
+
+        // Set up expected differences accounting for fees
+        ExpectedDifferences memory expectedDifferences = createEmptyExpectedDifferences();
+        expectedDifferences.party0BaseChange = -int256(actualInternalObligation.amountIn);
+        expectedDifferences.party0QuoteChange = int256(actualInternalObligation.amountOut) - int256(totalFee);
+        expectedDifferences.party1BaseChange = int256(actualExternalObligation.amountOut);
+        expectedDifferences.party1QuoteChange = -int256(actualExternalObligation.amountIn);
+        expectedDifferences.relayerFeeBaseChange = 0;
+        expectedDifferences.relayerFeeQuoteChange = int256(relayerFeeTake.fee);
+        expectedDifferences.protocolFeeBaseChange = 0;
+        expectedDifferences.protocolFeeQuoteChange = int256(protocolFeeTake.fee);
+        expectedDifferences.darkpoolBaseChange = 0;
+        expectedDifferences.darkpoolQuoteChange = 0;
+
+        // Check balances before and after settlement
+        BalanceSnapshots memory preMatch = _captureBalances();
+        vm.prank(externalParty.addr);
+        darkpool.settleExternalMatch(externalPartyAmountIn, recipient, matchBundle, internalPartySettlementBundle);
+        BalanceSnapshots memory postMatch = _captureBalances();
+        _verifyBalanceChanges(preMatch, postMatch, expectedDifferences);
+    }
+}

--- a/test/darkpool/v2/settlement/external-match/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-private-intents/Utils.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { Vm } from "forge-std/Vm.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
+import {
+    SettlementBundle,
+    SettlementBundleType,
+    PrivateIntentPublicBalanceBoundedFirstFillBundle,
+    PrivateIntentPublicBalanceBoundedBundle
+} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    SignatureWithNonce,
+    PrivateIntentAuthBundle,
+    PrivateIntentAuthBundleFirstFill
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { IntentOnlyBoundedSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
+import {
+    IntentOnlyValidityStatement,
+    IntentOnlyValidityStatementFirstFill
+} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import { IntentPublicShare, IntentPublicShareLib } from "darkpoolv2-types/Intent.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import { ExternalMatchTestUtils } from "../Utils.sol";
+
+contract BoundedPrivateIntentTestUtils is ExternalMatchTestUtils {
+    using BoundedMatchResultLib for BoundedMatchResult;
+    using IntentPublicShareLib for IntentPublicShare;
+    using FixedPointLib for FixedPoint;
+
+    // ---------
+    // | Utils |
+    // ---------
+
+    // --- Intent Commitment --- //
+
+    /// @dev Compute the full commitment to an intent's shares
+    function computeIntentSharesCommitment(
+        IntentPublicShare memory intentPublicShare,
+        BN254.ScalarField intentPrivateCommitment,
+        IHasher _hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField commitment)
+    {
+        uint256[] memory intentPublicShareScalars = intentPublicShare.scalarSerialize();
+        uint256 commitmentHash = _hasher.computeResumableCommitment(intentPublicShareScalars);
+
+        // Compute the full commitment: H(private commitment || public commitment)
+        uint256[] memory commitmentInputs = new uint256[](2);
+        commitmentInputs[0] = BN254.ScalarField.unwrap(intentPrivateCommitment);
+        commitmentInputs[1] = commitmentHash;
+        uint256 hashResult = _hasher.spongeHash(commitmentInputs);
+        commitment = BN254.ScalarField.wrap(hashResult);
+    }
+
+    /// @dev Sign an intent commitment
+    function signIntentCommitment(
+        BN254.ScalarField intentCommitment,
+        uint256 signerPrivateKey
+    )
+        internal
+        returns (SignatureWithNonce memory)
+    {
+        // Hash the intent commitment with a random nonce
+        uint256 nonce = randomUint();
+        bytes32 intentCommitmentBytes = bytes32(BN254.ScalarField.unwrap(intentCommitment));
+        bytes32 commitmentHash = EfficientHashLib.hash(abi.encode(intentCommitmentBytes));
+        bytes32 signatureDigest = EfficientHashLib.hash(commitmentHash, bytes32(nonce));
+
+        // Sign with the private key
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, signatureDigest);
+        return SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
+    }
+
+    // --- Bounded Settlement Statement --- //
+
+    /// @dev Create a bounded settlement statement for a given bounded match result
+    /// @param matchResult The bounded match result to create the statement for
+    /// @return statement The bounded settlement statement
+    function createBoundedSettlementStatement(BoundedMatchResult memory matchResult)
+        internal
+        view
+        returns (IntentOnlyBoundedSettlementStatement memory statement)
+    {
+        FixedPoint memory protocolFeeRate =
+            darkpool.getProtocolFee(matchResult.internalPartyInputToken, matchResult.internalPartyOutputToken);
+
+        statement = IntentOnlyBoundedSettlementStatement({
+            boundedMatchResult: matchResult,
+            externalRelayerFeeRate: relayerFeeRateFixedPoint,
+            externalProtocolFeeRate: protocolFeeRate,
+            internalRelayerFeeRate: relayerFeeRateFixedPoint,
+            internalProtocolFeeRate: protocolFeeRate,
+            relayerFeeAddress: relayerFeeAddr
+        });
+    }
+
+    // --- Private Intent Settlement Bundle --- //
+
+    /// @dev Create a complete bounded private intent settlement bundle
+    function createBoundedPrivateIntentSettlementBundle(
+        bool isFirstFill,
+        BoundedMatchResult memory matchResult,
+        Vm.Wallet memory owner
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
+        if (isFirstFill) {
+            return createBoundedPrivateIntentBundleFirstFill(merkleDepth, matchResult, owner);
+        } else {
+            return createBoundedPrivateIntentBundleSubsequent(merkleDepth, matchResult, owner);
+        }
+    }
+
+    /// @dev Create a bounded private intent settlement bundle for first fill
+    function createBoundedPrivateIntentBundleFirstFill(
+        uint256 merkleDepth,
+        BoundedMatchResult memory matchResult,
+        Vm.Wallet memory owner
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        // Create the validity statement
+        IntentOnlyValidityStatementFirstFill memory validityStatement = IntentOnlyValidityStatementFirstFill({
+            intentOwner: owner.addr,
+            intentPrivateCommitment: randomScalar(),
+            recoveryId: randomScalar(),
+            intentPublicShare: randomIntentPublicShare()
+        });
+
+        // Sign the pre-update intent commitment
+        BN254.ScalarField intentCommitment = computeIntentSharesCommitment(
+            validityStatement.intentPublicShare, validityStatement.intentPrivateCommitment, hasher
+        );
+        SignatureWithNonce memory intentSignature = signIntentCommitment(intentCommitment, owner.privateKey);
+
+        // Create auth bundle
+        PrivateIntentAuthBundleFirstFill memory auth = PrivateIntentAuthBundleFirstFill({
+            intentSignature: intentSignature,
+            merkleDepth: merkleDepth,
+            statement: validityStatement,
+            validityProof: createDummyProof()
+        });
+
+        // Create bounded settlement statement
+        IntentOnlyBoundedSettlementStatement memory settlementStatement = createBoundedSettlementStatement(matchResult);
+
+        // Create the bundle data
+        PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData =
+            PrivateIntentPublicBalanceBoundedFirstFillBundle({
+                auth: auth,
+                settlementStatement: settlementStatement,
+                settlementProof: createDummyProof(),
+                authSettlementLinkingProof: createDummyLinkingProof()
+            });
+
+        // Encode and return the settlement bundle
+        return SettlementBundle({
+            isFirstFill: true,
+            bundleType: SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT,
+            data: abi.encode(bundleData)
+        });
+    }
+
+    /// @dev Create a bounded private intent settlement bundle for subsequent fills
+    function createBoundedPrivateIntentBundleSubsequent(
+        uint256 merkleDepth,
+        BoundedMatchResult memory matchResult,
+        Vm.Wallet memory owner
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        // Create the validity statement
+        IntentOnlyValidityStatement memory validityStatement = IntentOnlyValidityStatement({
+            intentOwner: owner.addr,
+            merkleRoot: randomScalar(),
+            oldIntentNullifier: randomScalar(),
+            newAmountShare: randomScalar(),
+            newIntentPartialCommitment: randomPartialCommitment(),
+            recoveryId: randomScalar()
+        });
+
+        // Create auth bundle (no signature needed for subsequent fills)
+        PrivateIntentAuthBundle memory auth = PrivateIntentAuthBundle({
+            merkleDepth: merkleDepth, statement: validityStatement, validityProof: createDummyProof()
+        });
+
+        // Create bounded settlement statement
+        IntentOnlyBoundedSettlementStatement memory settlementStatement = createBoundedSettlementStatement(matchResult);
+
+        // Create the bundle data
+        PrivateIntentPublicBalanceBoundedBundle memory bundleData = PrivateIntentPublicBalanceBoundedBundle({
+            auth: auth,
+            settlementStatement: settlementStatement,
+            settlementProof: createDummyProof(),
+            authSettlementLinkingProof: createDummyLinkingProof()
+        });
+
+        // Encode and return the settlement bundle
+        return SettlementBundle({
+            isFirstFill: false,
+            bundleType: SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT,
+            data: abi.encode(bundleData)
+        });
+    }
+}

--- a/test/darkpool/v2/settlement/external-match/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-private-intents/Utils.sol
@@ -25,12 +25,14 @@ import { IntentPublicShare, IntentPublicShareLib } from "darkpoolv2-types/Intent
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { ExternalMatchTestUtils } from "../Utils.sol";
 
 contract BoundedPrivateIntentTestUtils is ExternalMatchTestUtils {
     using BoundedMatchResultLib for BoundedMatchResult;
     using IntentPublicShareLib for IntentPublicShare;
     using FixedPointLib for FixedPoint;
+    using DarkpoolStateLib for DarkpoolState;
 
     // ---------
     // | Utils |
@@ -175,10 +177,13 @@ contract BoundedPrivateIntentTestUtils is ExternalMatchTestUtils {
         internal
         returns (SettlementBundle memory)
     {
+        // Get the actual Merkle root from the test state (must be in history for subsequent fills)
+        BN254.ScalarField merkleRoot = darkpoolState.getMerkleRoot(merkleDepth);
+
         // Create the validity statement
         IntentOnlyValidityStatement memory validityStatement = IntentOnlyValidityStatement({
             intentOwner: owner.addr,
-            merkleRoot: randomScalar(),
+            merkleRoot: merkleRoot,
             oldIntentNullifier: randomScalar(),
             newAmountShare: randomScalar(),
             newIntentPartialCommitment: randomPartialCommitment(),

--- a/test/darkpool/v2/settlement/external-match/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-private-intents/Utils.sol
@@ -5,12 +5,11 @@ import { Vm } from "forge-std/Vm.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    SettlementBundle,
-    SettlementBundleType,
     PrivateIntentPublicBalanceBoundedFirstFillBundle,
     PrivateIntentPublicBalanceBoundedBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
 import {
     SignatureWithNonce,
     PrivateIntentAuthBundle,
@@ -89,15 +88,10 @@ contract BoundedPrivateIntentTestUtils is ExternalMatchTestUtils {
         view
         returns (IntentOnlyBoundedSettlementStatement memory statement)
     {
-        FixedPoint memory protocolFeeRate =
-            darkpool.getProtocolFee(matchResult.internalPartyInputToken, matchResult.internalPartyOutputToken);
-
         statement = IntentOnlyBoundedSettlementStatement({
             boundedMatchResult: matchResult,
             externalRelayerFeeRate: relayerFeeRateFixedPoint,
-            externalProtocolFeeRate: protocolFeeRate,
             internalRelayerFeeRate: relayerFeeRateFixedPoint,
-            internalProtocolFeeRate: protocolFeeRate,
             relayerFeeAddress: relayerFeeAddr
         });
     }

--- a/test/darkpool/v2/settlement/external-match/native-settled-public-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-public-intents/FullMatchTests.t.sol
@@ -11,11 +11,11 @@ import { Intent } from "darkpoolv2-types/Intent.sol";
 import { PublicIntentPermit, PublicIntentPermitLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
-import { BalanceSnapshots, ExpectedDifferences } from "../SettlementTestUtils.sol";
+import { BalanceSnapshots, ExpectedDifferences } from "../../SettlementTestUtils.sol";
 
-import { ExternalMatchTestUtils } from "./Utils.sol";
+import { PublicIntentExternalMatchTestUtils } from "./Utils.sol";
 
-contract FullMatchTests is ExternalMatchTestUtils {
+contract FullMatchTests is PublicIntentExternalMatchTestUtils {
     using FixedPointLib for FixedPoint;
     using PublicIntentPermitLib for PublicIntentPermit;
 

--- a/test/darkpool/v2/settlement/external-match/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-public-intents/Utils.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { Intent } from "darkpoolv2-types/Intent.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import {
+    SettlementBundle,
+    SettlementBundleType,
+    PublicIntentPublicBalanceBundle
+} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    SignatureWithNonce,
+    PublicIntentAuthBundle,
+    PublicIntentPermit,
+    PublicIntentPermitLib
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import {
+    BoundedMatchResultPermit,
+    BoundedMatchResultBundle,
+    BoundedMatchResultPermitLib
+} from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { FeeRate } from "darkpoolv2-types/Fee.sol";
+import { BalanceSnapshots, ExpectedDifferences } from "../../SettlementTestUtils.sol";
+import { ExternalMatchTestUtils } from "../Utils.sol";
+
+contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
+    using BoundedMatchResultLib for BoundedMatchResult;
+    using BoundedMatchResultPermitLib for BoundedMatchResultPermit;
+    using PublicIntentPermitLib for PublicIntentPermit;
+    using FixedPointLib for FixedPoint;
+
+    // ---------
+    // | Utils |
+    // ---------
+
+    // --- Signatures --- //
+
+    /// @dev Sign an intent permit
+    function signIntentPermit(
+        PublicIntentPermit memory permit,
+        uint256 signerPrivateKey
+    )
+        internal
+        returns (SignatureWithNonce memory)
+    {
+        // Sign with the private key
+        uint256 nonce = randomUint();
+        bytes32 permitHash = permit.computeHash();
+        bytes32 signatureDigest = EfficientHashLib.hash(permitHash, bytes32(nonce));
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, signatureDigest);
+        return SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
+    }
+
+    /// @dev Sign an obligation (memory version)
+    function createExecutorSignature(
+        FeeRate memory feeRate,
+        SettlementObligation memory obligation,
+        uint256 signerPrivateKey
+    )
+        internal
+        returns (SignatureWithNonce memory)
+    {
+        // Use the calldata version via external call for memory-to-calldata conversion
+        return this._createExecutorSignatureCalldata(obligation, feeRate, signerPrivateKey);
+    }
+
+    /// @dev Sign an obligation (calldata version)
+    function _createExecutorSignatureCalldata(
+        SettlementObligation memory obligation,
+        FeeRate memory feeRate,
+        uint256 signerPrivateKey
+    )
+        external
+        returns (SignatureWithNonce memory)
+    {
+        // Hash the fee with obligation
+        bytes memory encoded = abi.encode(feeRate, obligation);
+        bytes32 digest = EfficientHashLib.hash(encoded);
+
+        // Sign with the private key
+        uint256 nonce = randomUint();
+        bytes32 signatureHash = EfficientHashLib.hash(digest, bytes32(nonce));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, signatureHash);
+        return SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
+    }
+
+    // --- Dummy Data --- //
+
+    /// @dev Create a complete settlement bundle with custom signers
+    function createPublicIntentSettlementBundleWithSigners(
+        Intent memory intent,
+        SettlementObligation memory obligation,
+        uint256 intentOwnerPrivateKey,
+        uint256 executorPrivateKey
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        // Create the permit and sign it with the owner key
+        PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
+        SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
+
+        // Create relayer fee rate and sign the executor digest with the executor key
+        FeeRate memory feeRate = relayerFeeRate();
+        SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
+
+        // Create auth bundle
+        PublicIntentAuthBundle memory auth = PublicIntentAuthBundle({
+            permit: permit, intentSignature: intentSignature, executorSignature: executorSignature
+        });
+        PublicIntentPublicBalanceBundle memory bundleData =
+            PublicIntentPublicBalanceBundle({ auth: auth, relayerFeeRate: feeRate });
+
+        // Create the complete settlement bundle
+        return SettlementBundle({
+            isFirstFill: false,
+            bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,
+            data: abi.encode(bundleData)
+        });
+    }
+
+    // --- Bounded Match Result --- //
+
+    /// @dev Create a bounded match result authorization bundle for a given obligation
+    /// @param obligation The obligation to create the bounded match result for
+    /// @param price The price of the obligation (inToken/outToken)
+    /// @return matchBundle The bounded match result authorization bundle
+    function createBoundedMatchResultBundleForObligation(
+        SettlementObligation memory obligation,
+        FixedPoint memory price
+    )
+        internal
+        returns (BoundedMatchResultBundle memory)
+    {
+        BoundedMatchResult memory matchResult = createBoundedMatchResultForObligation(obligation, price);
+        return createBoundedMatchResultBundleWithSigners(matchResult, executor.privateKey);
+    }
+}

--- a/test/darkpool/v2/settlement/native-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/FullMatchTests.t.sol
@@ -8,11 +8,12 @@ import { BN254 } from "solidity-bn254/BN254.sol";
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { ObligationType, ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    PrivateIntentPublicBalanceBundle,
+    PrivateIntentPublicBalanceBundleLib,
     PrivateIntentPublicBalanceFirstFillBundle,
-    SettlementBundleLib
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+    PrivateIntentPublicBalanceBundle
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
 import { PrivateIntentSettlementTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
@@ -24,8 +25,9 @@ import { ExpectedDifferences } from "../SettlementTestUtils.sol";
 
 contract FullMatchTests is PrivateIntentSettlementTestUtils {
     using ObligationLib for ObligationBundle;
-    using SettlementBundleLib for PrivateIntentPublicBalanceBundle;
-    using SettlementBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
+    using PrivateIntentPublicBalanceBundleLib for PrivateIntentPublicBalanceBundle;
+    using PrivateIntentPublicBalanceBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
+    using SettlementBundleLib for SettlementBundle;
     using FixedPointLib for FixedPoint;
     using MerkleTreeLib for MerkleTreeLib.MerkleTree;
 
@@ -234,7 +236,13 @@ contract FullMatchTests is PrivateIntentSettlementTestUtils {
             abi.decode(obligationBundle.data, (SettlementObligation, SettlementObligation));
 
         vm.startPrank(party0.addr);
-        permit2.approve(obligation0.inputToken, address(darkpool), 0, /* amount */ uint48(block.timestamp + 1 days));
+        permit2.approve(
+            obligation0.inputToken,
+            address(darkpool),
+            0,
+            /* amount */
+            uint48(block.timestamp + 1 days)
+        );
         vm.stopPrank();
 
         // Try settling the match, the permit should be revoked

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -5,18 +5,12 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { ObligationBundle, ObligationType } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { PartyId, SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    PartyId,
-    SettlementBundle,
-    SettlementBundleLib,
-    PrivateIntentPublicBalanceFirstFillBundle,
-    PrivateIntentPublicBalanceBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
-import {
-    SignatureWithNonce,
-    PrivateIntentAuthBundleFirstFill,
-    PrivateIntentAuthBundle
-} from "darkpoolv2-types/settlement/IntentBundle.sol";
+    PrivateIntentPublicBalanceBundleLib,
+    PrivateIntentPublicBalanceFirstFillBundle
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
+import { SignatureWithNonce, PrivateIntentAuthBundleFirstFill } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
@@ -27,7 +21,8 @@ import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { PrivateIntentSettlementTestUtils } from "./Utils.sol";
 
 contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
-    using SettlementBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
+    using PrivateIntentPublicBalanceBundleLib for PrivateIntentPublicBalanceFirstFillBundle;
+    using SettlementBundleLib for SettlementBundle;
 
     // -----------
     // | Helpers |
@@ -79,8 +74,12 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         (SettlementObligation memory obligation0, SettlementObligation memory obligation1,) = createTradeObligations();
         ObligationBundle memory obligationBundle =
             ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
-        SettlementBundle memory bundle =
-            createPrivateIntentSettlementBundle(false, /* isFirstFill */ obligation0, intentOwner);
+        SettlementBundle memory bundle = createPrivateIntentSettlementBundle(
+            false,
+            /* isFirstFill */
+            obligation0,
+            intentOwner
+        );
 
         // Should not revert even though we're not checking the signature
         authorizeIntentHelper(obligationBundle, bundle);
@@ -90,7 +89,9 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
     function test_invalidIntentCommitmentSignature_wrongSigner() public {
         // Create bundle and replace the intent commitment signature with a signature from wrong signer
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
-            createSamplePrivateIntentBundle(true /* isFirstFill */ );
+            createSamplePrivateIntentBundle(
+                true /* isFirstFill */
+            );
         PrivateIntentPublicBalanceFirstFillBundle memory bundleData =
             abi.decode(bundle.data, (PrivateIntentPublicBalanceFirstFillBundle));
         PrivateIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
@@ -130,7 +131,9 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
     function test_invalidMerkleRoot() public {
         // Create bundle for subsequent fill (not first fill)
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
-            createSamplePrivateIntentBundle(false /* isFirstFill */ );
+            createSamplePrivateIntentBundle(
+                false /* isFirstFill */
+            );
 
         // Decode the bundle data
         PrivateIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundle));

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -8,9 +8,14 @@ import { ObligationBundle, ObligationType } from "darkpoolv2-types/settlement/Ob
 import { PartyId, SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
     PrivateIntentPublicBalanceBundleLib,
-    PrivateIntentPublicBalanceFirstFillBundle
+    PrivateIntentPublicBalanceFirstFillBundle,
+    PrivateIntentPublicBalanceBundle
 } from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
-import { SignatureWithNonce, PrivateIntentAuthBundleFirstFill } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import {
+    SignatureWithNonce,
+    PrivateIntentAuthBundleFirstFill,
+    PrivateIntentAuthBundle
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";

--- a/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/Utils.sol
@@ -5,12 +5,12 @@ import { Vm } from "forge-std/Vm.sol";
 import { console2 } from "forge-std/console2.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+
 import {
-    SettlementBundle,
-    SettlementBundleType,
     PrivateIntentPublicBalanceBundle,
     PrivateIntentPublicBalanceFirstFillBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
 import { ObligationBundle, ObligationType, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     SignatureWithNonce,
@@ -89,7 +89,13 @@ contract PrivateIntentSettlementTestUtils is SettlementTestUtils {
     /// @dev Create a dummy `SettlementContext` for the test
     function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
         context = SettlementContextLib.newContext(
-            1, /* numDeposits */ 3, /* numWithdrawals */ 2, /* verificationCapacity */ 2 /* proofLinkingCapacity */
+            1,
+            /* numDeposits */
+            3,
+            /* numWithdrawals */
+            2,
+            /* verificationCapacity */
+            2 /* proofLinkingCapacity */
         );
     }
 
@@ -111,9 +117,7 @@ contract PrivateIntentSettlementTestUtils is SettlementTestUtils {
         returns (IntentOnlyPublicSettlementStatement memory)
     {
         return IntentOnlyPublicSettlementStatement({
-            obligation: obligation,
-            relayerFee: relayerFeeRateFixedPoint,
-            relayerFeeRecipient: relayerFeeAddr
+            obligation: obligation, relayerFee: relayerFeeRateFixedPoint, relayerFeeRecipient: relayerFeeAddr
         });
     }
 
@@ -216,9 +220,7 @@ contract PrivateIntentSettlementTestUtils is SettlementTestUtils {
 
         // Create auth bundle
         PrivateIntentAuthBundle memory auth = PrivateIntentAuthBundle({
-            merkleDepth: merkleDepth,
-            statement: validityStatement,
-            validityProof: createDummyProof()
+            merkleDepth: merkleDepth, statement: validityStatement, validityProof: createDummyProof()
         });
         PrivateIntentPublicBalanceBundle memory bundleData = PrivateIntentPublicBalanceBundle({
             auth: auth,


### PR DESCRIPTION
### Purpose
This PR adds code paths for settling a bounded match between an external party and an internal party's ring 1 intent.

Lots of intentionally duplicated code and overloaded methods; I find it nice to see the parallels between the two settlement paths. While we could create helpers that house the shared logic between similar helpers, I decided against this to maintain the logical boundaries currently created by the helpers. Happy to discuss further.

### Testing
- Match tests will be added in the following PR