### PR TITLE
darkpoolv2: settlement: OutputBalance: Add output balance auth bundle

### DIFF
--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -55,6 +55,8 @@ interface IDarkpoolV2 {
     error InvalidObligation();
     /// @notice Thrown when the settlement bundle type is invalid
     error InvalidSettlementBundleType();
+    /// @notice Thrown when the output balance bundle type is invalid
+    error InvalidOutputBalanceBundleType();
     /// @notice Thrown when verification fails for a settlement
     error SettlementVerificationFailed();
     /// @notice Thrown when an intent commitment signature is invalid

--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -16,7 +16,9 @@ import {
     IntentOnlyValidityStatementFirstFill,
     IntentOnlyValidityStatement,
     IntentAndBalanceValidityStatementFirstFill,
-    IntentAndBalanceValidityStatement
+    IntentAndBalanceValidityStatement,
+    NewOutputBalanceValidityStatement,
+    OutputBalanceValidityStatement
 } from "./ValidityProofs.sol";
 import {
     IntentOnlyBoundedSettlementStatement,
@@ -382,6 +384,39 @@ library PublicInputsLib {
         publicInputs[7] = statement.balancePartialCommitment.privateCommitment;
         publicInputs[8] = statement.balancePartialCommitment.partialPublicCommitment;
         publicInputs[9] = statement.balanceRecoveryId;
+    }
+
+    /// @notice Serialize the public inputs for a proof of new output balance validity
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(NewOutputBalanceValidityStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 4;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = statement.originalBalanceCommitment;
+        publicInputs[1] = statement.newBalancePartialCommitment.privateCommitment;
+        publicInputs[2] = statement.newBalancePartialCommitment.partialPublicCommitment;
+        publicInputs[3] = statement.recoveryId;
+    }
+
+    /// @notice Serialize the public inputs for a proof of output balance validity
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    function statementSerialize(OutputBalanceValidityStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 5;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+        publicInputs[0] = statement.merkleRoot;
+        publicInputs[1] = statement.oldBalanceNullifier;
+        publicInputs[2] = statement.newPartialCommitment.privateCommitment;
+        publicInputs[3] = statement.newPartialCommitment.partialPublicCommitment;
+        publicInputs[4] = statement.recoveryId;
     }
 
     /// @notice Serialize the public inputs for a proof of intent and balance private settlement

--- a/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
+++ b/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
@@ -113,3 +113,29 @@ struct IntentAndBalanceValidityStatement {
     /// @dev The recovery identifier of the new balance
     BN254.ScalarField balanceRecoveryId;
 }
+
+// --- Output Balance Validity Statements --- //
+
+/// @notice A statement for a proof of new output balance validity
+/// @dev The statement type for `NEW OUTPUT BALANCE VALIDITY`
+struct NewOutputBalanceValidityStatement {
+    /// @dev A commitment to the original balance before update
+    BN254.ScalarField originalBalanceCommitment;
+    /// @dev A partial commitment to the new output balance
+    PartialCommitment newBalancePartialCommitment;
+    /// @dev The recovery identifier of the new output balance
+    BN254.ScalarField recoveryId;
+}
+
+/// @notice A statement for a proof of output balance validity
+/// @dev The statement type for `OUTPUT BALANCE VALIDITY`
+struct OutputBalanceValidityStatement {
+    /// @dev The Merkle root to which the balance opens
+    BN254.ScalarField merkleRoot;
+    /// @dev The nullifier of the balance
+    BN254.ScalarField oldBalanceNullifier;
+    /// @dev The partial commitment to the balance
+    PartialCommitment newPartialCommitment;
+    /// @dev The recovery identifier of the balance
+    BN254.ScalarField recoveryId;
+}

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -300,6 +300,24 @@ library RenegadeSettledPrivateIntentLib {
         settlementContext.pushProofLinkingArgument(proofLinkingArgument);
     }
 
+    // ------------------------------
+    // | Output Balance Constraints |
+    // ------------------------------
+
+    /// @notice Validate the output balance validity proof on a first fill
+    /// @param bundleData The bundle data to validate
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param vkeys The contract storing the verification keys
+    function validateOutputBalanceConstraintsFirstFill(
+        RenegadeSettledIntentFirstFillBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+    {
+        // Decode the output balance bundle
+    }
+
     // -----------------
     // | State Updates |
     // -----------------

--- a/src/darkpool/v2/types/settlement/OutputBalanceBundle.sol
+++ b/src/darkpool/v2/types/settlement/OutputBalanceBundle.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache
+pragma solidity ^0.8.24;
+
+import { PlonkProof, LinkingProof } from "renegade-lib/verifier/Types.sol";
+import {
+    OutputBalanceValidityStatement,
+    NewOutputBalanceValidityStatement
+} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+
+// ------------------------
+// | Output Balance Types |
+// ------------------------
+
+/// @notice The output balance bundle for a user
+/// @dev This type encapsulates the authorization data for use of a balance as the output of a trade.
+struct OutputBalanceBundle {
+    /// @dev The type of output balance bundle
+    OutputBalanceBundleType bundleType;
+    /// @dev The data validating the output balance bundle
+    bytes data;
+    /// @dev The plonk proof of output balance validity
+    PlonkProof proof;
+    /// @dev The proof linking argument between the output balance validity proof and the settlement proof
+    LinkingProof settlementLinkingProof;
+}
+
+/// @notice The type of output balance bundle
+/// @dev There are two types of output balance bundles:
+/// 1. EXISTING_BALANCE: A bundle representing a balance that already exists in the Merkle tree.
+/// 2. NEW_BALANCE: A bundle representing a new balance that is created as part of the settlement.
+enum OutputBalanceBundleType {
+    EXISTING_BALANCE,
+    NEW_BALANCE
+}
+
+/// @notice The verification data for an existing balance bundle
+struct ExistingBalanceBundle {
+    /// @dev The statement for the balance validity proof
+    OutputBalanceValidityStatement statement;
+}
+
+/// @notice The verification data for a new balance bundle
+struct NewBalanceBundle {
+    /// @dev The statement for the balance creation proof
+    NewOutputBalanceValidityStatement statement;
+}
+
+/// @title Output Balance Bundle Library
+/// @author Renegade Eng
+/// @notice Library for decoding output balance bundle data
+library OutputBalanceBundleLib {
+    /// @notice Decode an existing balance bundle
+    /// @param bundle The output balance bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeExistingBalanceBundle(OutputBalanceBundle calldata bundle)
+        internal
+        pure
+        returns (ExistingBalanceBundle memory bundleData)
+    {
+        bool validType = bundle.bundleType == OutputBalanceBundleType.EXISTING_BALANCE;
+        require(validType, IDarkpoolV2.InvalidOutputBalanceBundleType());
+        bundleData = abi.decode(bundle.data, (ExistingBalanceBundle));
+    }
+
+    /// @notice Decode a new balance bundle
+    /// @param bundle The output balance bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeNewBalanceBundle(OutputBalanceBundle calldata bundle)
+        internal
+        pure
+        returns (NewBalanceBundle memory bundleData)
+    {
+        bool validType = bundle.bundleType == OutputBalanceBundleType.NEW_BALANCE;
+        require(validType, IDarkpoolV2.InvalidOutputBalanceBundleType());
+        bundleData = abi.decode(bundle.data, (NewBalanceBundle));
+    }
+}

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -36,6 +36,7 @@ import { FeeRate } from "darkpoolv2-types/Fee.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { OutputBalanceBundle } from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
 
 // ---------------------------
 // | Settlement Bundle Types |
@@ -95,6 +96,8 @@ struct PublicIntentPublicBalanceBundle {
 struct RenegadeSettledIntentFirstFillBundle {
     /// @dev The private intent authorization payload with signature attached
     RenegadeSettledIntentAuthBundleFirstFill auth;
+    /// @dev The calldata bundle containing a proof of output balance validity
+    OutputBalanceBundle outputBalanceBundle;
     /// @dev The statement of intent and balance public settlement
     IntentAndBalancePublicSettlementStatement settlementStatement;
     /// @dev The proof of intent and balance public settlement
@@ -107,6 +110,8 @@ struct RenegadeSettledIntentFirstFillBundle {
 struct RenegadeSettledIntentBundle {
     /// @dev The private intent authorization payload with signature attached
     RenegadeSettledIntentAuthBundle auth;
+    /// @dev The calldata bundle containing a proof of output balance validity
+    OutputBalanceBundle outputBalanceBundle;
     /// @dev The statement of intent and balance public settlement
     IntentAndBalancePublicSettlementStatement settlementStatement;
     /// @dev The proof of intent and balance public settlement

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -17,12 +17,14 @@ import {
     RenegadeSettledIntentAuthBundleFirstFill,
     RenegadeSettledIntentAuthBundle
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { OutputBalanceBundle, OutputBalanceBundleType } from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import {
     IntentAndBalanceValidityStatementFirstFill,
-    IntentAndBalanceValidityStatement
+    IntentAndBalanceValidityStatement,
+    OutputBalanceValidityStatement
 } from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
 import { IntentPreMatchShare } from "darkpoolv2-types/Intent.sol";
 import { IntentAndBalancePublicSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
@@ -139,6 +141,24 @@ contract RenegadeSettledPrivateIntentTestUtils is SettlementTestUtils {
         });
     }
 
+    /// @dev Create a sample output balance bundle
+    function createSampleOutputBalanceBundle() internal returns (OutputBalanceBundle memory) {
+        BN254.ScalarField merkleRoot = darkpoolState.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+        OutputBalanceValidityStatement memory statement = OutputBalanceValidityStatement({
+            merkleRoot: merkleRoot,
+            oldBalanceNullifier: randomScalar(),
+            newPartialCommitment: randomPartialCommitment(),
+            recoveryId: randomScalar()
+        });
+
+        return OutputBalanceBundle({
+            bundleType: OutputBalanceBundleType.EXISTING_BALANCE,
+            data: abi.encode(statement),
+            proof: createDummyProof(),
+            settlementLinkingProof: createDummyLinkingProof()
+        });
+    }
+
     /// @dev Helper to create a sample settlement bundle
     function createSampleRenegadeSettledBundle(bool isFirstFill)
         internal
@@ -197,8 +217,10 @@ contract RenegadeSettledPrivateIntentTestUtils is SettlementTestUtils {
             statement: validityStatement,
             validityProof: createDummyProof()
         });
+        OutputBalanceBundle memory outputBalanceBundle = createSampleOutputBalanceBundle();
         RenegadeSettledIntentFirstFillBundle memory bundleData = RenegadeSettledIntentFirstFillBundle({
             auth: auth,
+            outputBalanceBundle: outputBalanceBundle,
             settlementStatement: settlementStatement,
             settlementProof: createDummyProof(),
             authSettlementLinkingProof: createDummyLinkingProof()
@@ -231,8 +253,10 @@ contract RenegadeSettledPrivateIntentTestUtils is SettlementTestUtils {
             statement: validityStatement,
             validityProof: createDummyProof()
         });
+        OutputBalanceBundle memory outputBalanceBundle = createSampleOutputBalanceBundle();
         RenegadeSettledIntentBundle memory bundleData = RenegadeSettledIntentBundle({
             auth: auth,
+            outputBalanceBundle: outputBalanceBundle,
             settlementStatement: settlementStatement,
             settlementProof: createDummyProof(),
             authSettlementLinkingProof: createDummyLinkingProof()


### PR DESCRIPTION
### Purpose
This PR adds output balance bundles to the ring 2 settlement bundles. These validation bundles authorize the use (or creation) of a balance to receive a party's output in a Renegade-settled trade.

### Todo
- Verify these bundles in the ring 2 handlers

### Testing
- [x] Unit tests pass