### PR TITLE
darkpoolv2: RenegadeSettledPrivateIntent: Factor into settlement library

### DIFF
--- a/src/darkpool/v2/contracts/vkeys/VKeys.sol
+++ b/src/darkpool/v2/contracts/vkeys/VKeys.sol
@@ -137,7 +137,7 @@ contract VKeys is IVkeys {
 
     /// @notice Get the verification key for `NEW OUTPUT BALANCE VALIDITY`
     /// @return The verification key for `NEW OUTPUT BALANCE VALIDITY`
-    function newOutputBalanceValidityVkeys() external view override returns (VerificationKey memory) {
+    function newOutputBalanceValidityKeys() external view override returns (VerificationKey memory) {
         return settlementVKeys.newOutputBalanceValidityKeys();
     }
 

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -61,6 +61,8 @@ interface IDarkpoolV2 {
     error SettlementVerificationFailed();
     /// @notice Thrown when an intent commitment signature is invalid
     error InvalidIntentCommitmentSignature();
+    /// @notice Thrown when the owner signature is invalid
+    error InvalidOwnerSignature();
     /// @notice Thrown when the public input length is invalid
     error InvalidPublicInputLength();
     /// @notice Thrown when an amount is too large

--- a/src/darkpool/v2/interfaces/ISettlementTypes.sol
+++ b/src/darkpool/v2/interfaces/ISettlementTypes.sol
@@ -7,8 +7,6 @@ pragma solidity ^0.8.24;
 import { SettlementBundle, SettlementBundleType, PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
     PublicIntentPublicBalanceBundle,
-    RenegadeSettledIntentFirstFillBundle,
-    RenegadeSettledIntentBundle,
     RenegadeSettledPrivateFirstFillBundle,
     RenegadeSettledPrivateFillBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
@@ -16,6 +14,10 @@ import {
     PrivateIntentPublicBalanceFirstFillBundle,
     PrivateIntentPublicBalanceBundle
 } from "darkpoolv2-lib/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol";
+import {
+    RenegadeSettledIntentFirstFillBundle,
+    RenegadeSettledIntentBundle
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
 import {
     PublicIntentAuthBundle,
     PublicIntentPermit,
@@ -26,9 +28,7 @@ import {
     SignatureWithNonce
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import {
-    ObligationBundle,
-    ObligationType,
-    PrivateObligationBundle
+    ObligationBundle, ObligationType, PrivateObligationBundle
 } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 

--- a/src/darkpool/v2/interfaces/IVkeys.sol
+++ b/src/darkpool/v2/interfaces/IVkeys.sol
@@ -65,7 +65,7 @@ interface IVkeys {
     function outputBalanceValidityKeys() external view returns (VerificationKey memory);
     /// @notice Get the verification key for `NEW OUTPUT BALANCE VALIDITY`
     /// @return The verification key for `NEW OUTPUT BALANCE VALIDITY`
-    function newOutputBalanceValidityVkeys() external view returns (VerificationKey memory);
+    function newOutputBalanceValidityKeys() external view returns (VerificationKey memory);
 
     // --------------------
     // | Settlement VKeys |

--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -394,12 +394,11 @@ library PublicInputsLib {
         pure
         returns (BN254.ScalarField[] memory publicInputs)
     {
-        uint256 nPublicInputs = 4;
+        uint256 nPublicInputs = 3;
         publicInputs = new BN254.ScalarField[](nPublicInputs);
-        publicInputs[0] = statement.originalBalanceCommitment;
-        publicInputs[1] = statement.newBalancePartialCommitment.privateCommitment;
-        publicInputs[2] = statement.newBalancePartialCommitment.partialPublicCommitment;
-        publicInputs[3] = statement.recoveryId;
+        publicInputs[0] = statement.newBalancePartialCommitment.privateCommitment;
+        publicInputs[1] = statement.newBalancePartialCommitment.partialPublicCommitment;
+        publicInputs[2] = statement.recoveryId;
     }
 
     /// @notice Serialize the public inputs for a proof of output balance validity

--- a/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
+++ b/src/darkpool/v2/libraries/public_inputs/ValidityProofs.sol
@@ -119,8 +119,6 @@ struct IntentAndBalanceValidityStatement {
 /// @notice A statement for a proof of new output balance validity
 /// @dev The statement type for `NEW OUTPUT BALANCE VALIDITY`
 struct NewOutputBalanceValidityStatement {
-    /// @dev A commitment to the original balance before update
-    BN254.ScalarField originalBalanceCommitment;
     /// @dev A partial commitment to the new output balance
     PartialCommitment newBalancePartialCommitment;
     /// @dev The recovery identifier of the new output balance

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
@@ -106,9 +106,10 @@ library RenegadeSettledPrivateFillLib {
 
         // 1. Validate the intent authorization
         // Uses the same logic as the `RENEGADE_SETTLED_INTENT` bundle
-        RenegadeSettledPrivateIntentLib.validateIntentAuthorizationFirstFill(
-            bundleData.auth, settlementContext, vkeys, state
-        );
+        // TODO: Add settlement library here
+        // RenegadeSettledPrivateIntentLib.authorizeIntent(
+        //     bundleData.auth, settlementContext, vkeys, state
+        // );
 
         // 2. Validate the obligation constraints
         validateObligationConstraintsFirstFill(
@@ -143,7 +144,8 @@ library RenegadeSettledPrivateFillLib {
 
         // 1. Validate the intent authorization
         // Uses the same logic as the `RENEGADE_SETTLED_INTENT` bundle
-        RenegadeSettledPrivateIntentLib.validateIntentAuthorization(bundleData.auth, vkeys, settlementContext, state);
+        // TODO: Add settlement library here
+        // RenegadeSettledPrivateIntentLib.authorizeIntent(bundleData.auth, settlementContext, vkeys, state);
 
         // 2. Validate the obligation constraints
         validateObligationConstraints(partyId, obligationBundle, settlementBundle, settlementContext, vkeys, state);

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -1,64 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import { BN254 } from "solidity-bn254/BN254.sol";
+import { PartyId, SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    PartyId,
-    SettlementBundle,
-    SettlementBundleLib,
     RenegadeSettledIntentFirstFillBundle,
-    RenegadeSettledIntentBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+    RenegadeSettledIntentBundle,
+    PrivateIntentPrivateBalanceBundleLib
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
 import { OutputBalanceBundle, OutputBalanceBundleLib } from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
-import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
-import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
-import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
-import {
-    IntentAndBalanceValidityStatementFirstFill,
-    IntentAndBalanceValidityStatement,
-    OutputBalanceValidityStatement,
-    NewOutputBalanceValidityStatement
-} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
-import { IntentAndBalancePublicSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
-import { VerificationKey, ProofLinkingInstance } from "renegade-lib/verifier/Types.sol";
-import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
-import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
-import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
-import { FeeRate, FeeRateLib, FeeTake, FeeTakeLib } from "darkpoolv2-types/Fee.sol";
-
-import {
-    SignatureWithNonce,
-    SignatureWithNonceLib,
-    RenegadeSettledIntentAuthBundleFirstFill,
-    RenegadeSettledIntentAuthBundle,
-    PrivateIntentPrivateBalanceAuthBundleLib
-} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 
 /// @title Renegade Settled Private Intent Library
 /// @author Renegade Eng
 /// @notice Library for validating a renegade settled private intents
 /// @dev A renegade settled private intent is a private intent with a private (darkpool) balance.
 library RenegadeSettledPrivateIntentLib {
-    using SignatureWithNonceLib for SignatureWithNonce;
     using SettlementBundleLib for SettlementBundle;
-    using SettlementBundleLib for RenegadeSettledIntentFirstFillBundle;
-    using SettlementBundleLib for RenegadeSettledIntentBundle;
+    using PrivateIntentPrivateBalanceBundleLib for SettlementBundle;
+    using PrivateIntentPrivateBalanceBundleLib for RenegadeSettledIntentFirstFillBundle;
+    using PrivateIntentPrivateBalanceBundleLib for RenegadeSettledIntentBundle;
     using SettlementContextLib for SettlementContext;
     using DarkpoolStateLib for DarkpoolState;
     using ObligationLib for ObligationBundle;
-    using SettlementObligationLib for SettlementObligation;
-    using PublicInputsLib for IntentAndBalanceValidityStatementFirstFill;
-    using PublicInputsLib for IntentAndBalanceValidityStatement;
-    using PublicInputsLib for OutputBalanceValidityStatement;
-    using PublicInputsLib for NewOutputBalanceValidityStatement;
     using OutputBalanceBundleLib for OutputBalanceBundle;
-    using FeeRateLib for FeeRate;
-    using FeeTakeLib for FeeTake;
+    using PrivateIntentPrivateBalanceBundleLib for OutputBalanceBundle;
 
     // --- Errors --- //
 
@@ -115,21 +85,23 @@ library RenegadeSettledPrivateIntentLib {
         internal
     {
         // Decode the bundle data
-        RenegadeSettledIntentFirstFillBundle memory bundleData =
+        RenegadeSettledIntentFirstFillBundle memory bundle =
             settlementBundle.decodeRenegadeSettledIntentBundleDataFirstFill();
         SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
-        // 1. Validate the intent authorization
-        validateIntentAuthorizationFirstFill(bundleData.auth, settlementContext, vkeys, state);
+        // 1. Validate the intent and input (capitalizing) balance authorization
+        bundle.authorizeIntent(settlementContext, vkeys, state);
 
         // 2. Validate the output balance validity
-        validateOutputBalanceConstraintsFirstFill(bundleData, settlementContext, vkeys);
+        bundle.outputBalanceBundle.authorizeOutputBalance(bundle.settlementProof, settlementContext, vkeys, state);
 
-        // 3. Validate the intent constraints on the obligation
-        validateObligationConstraintsFirstFill(obligation, bundleData, settlementContext, vkeys);
+        // 3. Validate the obligation settlement
+        PrivateIntentPrivateBalanceBundleLib.verifySettlement(
+            obligation, bundle.settlementStatement, bundle.settlementProof, vkeys, settlementContext
+        );
 
         // 4. Execute state updates for the bundle
-        executeStateUpdatesFirstFill(bundleData, state, settlementContext, hasher);
+        bundle.executeStateUpdatesFirstFill(state, settlementContext, hasher);
     }
 
     /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill
@@ -152,358 +124,21 @@ library RenegadeSettledPrivateIntentLib {
         internal
     {
         // Decode the bundle data
-        RenegadeSettledIntentBundle memory bundleData = settlementBundle.decodeRenegadeSettledIntentBundleData();
+        RenegadeSettledIntentBundle memory bundle = settlementBundle.decodeRenegadeSettledIntentBundleData();
         SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
 
-        // 1. Validate the intent authorization
-        validateIntentAuthorization(bundleData.auth, vkeys, settlementContext, state);
+        // 1. Validate the intent and input (capitalizing) balance authorization
+        bundle.authorizeIntent(settlementContext, vkeys, state);
 
         // 2. Validate the output balance validity
-        validateOutputBalanceConstraints(bundleData, settlementContext, vkeys);
+        bundle.outputBalanceBundle.authorizeOutputBalance(bundle.settlementProof, settlementContext, vkeys, state);
 
-        // 3. Validate the intent constraints on the obligation
-        validateObligationConstraints(obligation, bundleData, settlementContext, vkeys);
+        // 3. Validate the obligation settlement
+        PrivateIntentPrivateBalanceBundleLib.verifySettlement(
+            obligation, bundle.settlementStatement, bundle.settlementProof, vkeys, settlementContext
+        );
 
         // 4. Execute state updates for the bundle
-        executeStateUpdates(bundleData, state, settlementContext, hasher);
-    }
-
-    // ------------------------
-    // | Intent Authorization |
-    // ------------------------
-
-    /// @notice Execute the state updates necessary to authorize the intent for a first fill
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    /// @param state The darkpool state containing all storage references
-    /// @dev On the first fill, we verify that the balance-leaked one-time key has signed the initial
-    /// intent commitment as well as the rotated one-time key.
-    function validateIntentAuthorizationFirstFill(
-        RenegadeSettledIntentAuthBundleFirstFill memory bundleData,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys,
-        DarkpoolState storage state
-    )
-        internal
-    {
-        // Validate the Merkle root used for the input balance
-        // TODO: Allow for dynamic Merkle depth
-        if (bundleData.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
-            revert IDarkpool.InvalidMerkleDepthRequested();
-        }
-        state.assertRootInHistory(bundleData.statement.merkleRoot);
-
-        // Verify the owner signature and spend the nonce
-        bytes32 digest = PrivateIntentPrivateBalanceAuthBundleLib.getOwnerSignatureDigest(bundleData);
-        address signer = bundleData.statement.oneTimeAuthorizingAddress;
-
-        bool valid = bundleData.ownerSignature.verifyPrehashed(signer, digest);
-        if (!valid) revert InvalidOwnerSignature();
-        state.spendNonce(bundleData.ownerSignature.nonce);
-
-        // Register a proof of validity for the intent and balance
-        BN254.ScalarField[] memory publicInputs = bundleData.statement.statementSerialize();
-        VerificationKey memory vk = vkeys.intentAndBalanceFirstFillValidityKeys();
-        settlementContext.pushProof(publicInputs, bundleData.validityProof, vk);
-    }
-
-    /// @notice Execute the state updates necessary to authorize the intent for a subsequent fill
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param vkeys The contract storing the verification keys
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param state The darkpool state containing all storage references
-    /// @dev On a subsequent fill, we need not verify the owner signature. The presence of the intent in the Merkle tree
-    /// implies that the owner's signature has already been verified (in a previous fill). So in this case, we need only
-    /// verify the proof attached to the bundle.
-    function validateIntentAuthorization(
-        RenegadeSettledIntentAuthBundle memory bundleData,
-        IVkeys vkeys,
-        SettlementContext memory settlementContext,
-        DarkpoolState storage state
-    )
-        internal
-        view
-    {
-        // Validate the Merkle roots used for the input balance and intent
-        // TODO: Allow for dynamic Merkle depth
-        if (bundleData.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
-            revert IDarkpool.InvalidMerkleDepthRequested();
-        }
-        state.assertRootInHistory(bundleData.statement.intentMerkleRoot);
-        state.assertRootInHistory(bundleData.statement.balanceMerkleRoot);
-
-        // Register a proof of validity for the intent and balance
-        BN254.ScalarField[] memory publicInputs = bundleData.statement.statementSerialize();
-        VerificationKey memory vk = vkeys.intentAndBalanceValidityKeys();
-        settlementContext.pushProof(publicInputs, bundleData.validityProof, vk);
-    }
-
-    // --------------------------
-    // | Obligation Constraints |
-    // --------------------------
-
-    /// @notice Validate the obligation constraints for a renegade settled private intent bundle for a first fill
-    /// @param obligation The obligation to validate
-    /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    function validateObligationConstraintsFirstFill(
-        SettlementObligation memory obligation,
-        RenegadeSettledIntentFirstFillBundle memory settlementBundle,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys
-    )
-        internal
-        view
-    {
-        // The obligation in the settlement statement must match the one from the obligation bundle
-        IntentAndBalancePublicSettlementStatement memory settlementStatement = settlementBundle.settlementStatement;
-        bool obligationMatches = obligation.isEqualTo(settlementStatement.settlementObligation);
-        if (!obligationMatches) revert IDarkpoolV2.InvalidObligation();
-
-        // Register the settlement proof to the context for subsequent verification
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(settlementStatement);
-        VerificationKey memory vk = vkeys.intentAndBalancePublicSettlementKeys();
-        settlementContext.pushProof(publicInputs, settlementBundle.settlementProof, vk);
-
-        // Push the proof linking argument between the authorization and settlement proofs to the context
-        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
-            wireComm0: settlementBundle.auth.validityProof.wireComms[0],
-            wireComm1: settlementBundle.settlementProof.wireComms[0],
-            proof: settlementBundle.authSettlementLinkingProof,
-            vk: vkeys.intentAndBalanceSettlement0LinkingKey()
-        });
-        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
-    }
-
-    /// @notice Validate the obligation constraints for a renegade settled private intent bundle for a subsequent fill;
-    /// i.e. not the first fill
-    /// @param obligation The obligation to validate
-    /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    function validateObligationConstraints(
-        SettlementObligation memory obligation,
-        RenegadeSettledIntentBundle memory settlementBundle,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys
-    )
-        internal
-        view
-    {
-        // The obligation in the settlement statement must match the one from the obligation bundle
-        IntentAndBalancePublicSettlementStatement memory settlementStatement = settlementBundle.settlementStatement;
-        bool obligationMatches = obligation.isEqualTo(settlementStatement.settlementObligation);
-        if (!obligationMatches) revert IDarkpoolV2.InvalidObligation();
-
-        // Register the settlement proof to the context for subsequent verification
-        BN254.ScalarField[] memory publicInputs = PublicInputsLib.statementSerialize(settlementStatement);
-        VerificationKey memory vk = vkeys.intentAndBalancePublicSettlementKeys();
-        settlementContext.pushProof(publicInputs, settlementBundle.settlementProof, vk);
-
-        // Push the proof linking argument between the authorization and settlement proofs to the context
-        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
-            wireComm0: settlementBundle.auth.validityProof.wireComms[0],
-            wireComm1: settlementBundle.settlementProof.wireComms[0],
-            proof: settlementBundle.authSettlementLinkingProof,
-            vk: vkeys.intentAndBalanceSettlement0LinkingKey()
-        });
-        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
-    }
-
-    // ------------------------------
-    // | Output Balance Constraints |
-    // ------------------------------
-
-    /// @notice Validate the output balance validity proof on a first fill
-    /// @param bundleData The bundle data to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    function validateOutputBalanceConstraintsFirstFill(
-        RenegadeSettledIntentFirstFillBundle memory bundleData,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys
-    )
-        internal
-        view
-    {
-        // Extract the public inputs and verification key for the output balance validity proof
-        OutputBalanceBundle memory outputBalanceBundle = bundleData.outputBalanceBundle;
-        (BN254.ScalarField[] memory publicInputs, VerificationKey memory vk) =
-            OutputBalanceBundleLib.getStatementAndVerificationKey(outputBalanceBundle, vkeys);
-
-        // Register the plonk proof of output balance validity to the settlement context
-        settlementContext.pushProof(publicInputs, outputBalanceBundle.proof, vk);
-
-        // Register the proof linking argument between the output balance validity proof and the settlement proof
-        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
-            wireComm0: outputBalanceBundle.proof.wireComms[0],
-            wireComm1: bundleData.settlementProof.wireComms[0],
-            proof: outputBalanceBundle.settlementLinkingProof,
-            // We use the first party's link group layout for this linking argument regardless of the party ID
-            // because in this settlement ring, the settlement proof is per-party, and only has link groups for one
-            // output balance.
-            vk: vkeys.outputBalanceSettlement0LinkingKey()
-        });
-        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
-    }
-
-    /// @notice Validate the output balance validity proof on a subsequent fill
-    /// @param bundleData The bundle data to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    function validateOutputBalanceConstraints(
-        RenegadeSettledIntentBundle memory bundleData,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys
-    )
-        internal
-        view
-    {
-        // Extract the public inputs and verification key for the output balance validity proof
-        OutputBalanceBundle memory outputBalanceBundle = bundleData.outputBalanceBundle;
-        (BN254.ScalarField[] memory publicInputs, VerificationKey memory vk) =
-            OutputBalanceBundleLib.getStatementAndVerificationKey(outputBalanceBundle, vkeys);
-
-        // Register the plonk proof of output balance validity to the settlement context
-        settlementContext.pushProof(publicInputs, outputBalanceBundle.proof, vk);
-
-        // Register the proof linking argument between the output balance validity proof and the settlement proof
-        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
-            wireComm0: outputBalanceBundle.proof.wireComms[0],
-            wireComm1: bundleData.settlementProof.wireComms[0],
-            proof: outputBalanceBundle.settlementLinkingProof,
-            // We use the first party's link group layout for this linking argument regardless of the party ID
-            // because in this settlement ring, the settlement proof is per-party, and only has link groups for one
-            // output balance.
-            vk: vkeys.outputBalanceSettlement0LinkingKey()
-        });
-        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
-    }
-
-    // -----------------
-    // | State Updates |
-    // -----------------
-
-    /// @notice Execute the state updates necessary to settle the bundle for a first fill
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param state The darkpool state containing all storage references
-    /// @param settlementContext The settlement context to which we append post-execution updates.
-    /// @param hasher The hasher to use for hashing
-    /// @dev On the first fill, no intent state needs to be nullified, however the balance state must be.
-    function executeStateUpdatesFirstFill(
-        RenegadeSettledIntentFirstFillBundle memory bundleData,
-        DarkpoolState storage state,
-        SettlementContext memory settlementContext,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Nullify the balance state
-        BN254.ScalarField nullifier = bundleData.auth.statement.oldBalanceNullifier;
-        state.spendNullifier(nullifier);
-
-        // 2. Insert commitments to the updated intent and balance into the Merkle tree
-        // TODO: Add output balances; no need to update the fees
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        BN254.ScalarField newIntentCommitment = bundleData.computeFullIntentCommitment(hasher);
-        BN254.ScalarField newBalanceCommitment = bundleData.computeFullBalanceCommitment(hasher);
-        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
-        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
-
-        // 3. Allocate transfers to settle the fees due from the obligation
-        allocateTransfers(bundleData.settlementStatement, state, settlementContext);
-
-        // 4. Emit recovery IDs for the intent and balance
-        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
-    }
-
-    /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param state The darkpool state containing all storage references
-    /// @param settlementContext The settlement context to which we append post-execution updates.
-    /// @param hasher The hasher to use for hashing
-    function executeStateUpdates(
-        RenegadeSettledIntentBundle memory bundleData,
-        DarkpoolState storage state,
-        SettlementContext memory settlementContext,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Nullify both the balance and intent states
-        BN254.ScalarField balanceNullifier = bundleData.auth.statement.oldBalanceNullifier;
-        BN254.ScalarField intentNullifier = bundleData.auth.statement.oldIntentNullifier;
-        state.spendNullifier(balanceNullifier);
-        state.spendNullifier(intentNullifier);
-
-        // 2. Insert commitments to the updated intent and balance into the Merkle tree
-        // TODO: Add output balances; no need to update the fees
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        BN254.ScalarField newIntentCommitment = bundleData.computeFullIntentCommitment(hasher);
-        BN254.ScalarField newBalanceCommitment = bundleData.computeFullBalanceCommitment(hasher);
-        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
-        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
-
-        // 3. Allocate transfers to settle the fees due from the obligation
-        allocateTransfers(bundleData.settlementStatement, state, settlementContext);
-
-        // 4. Emit recovery IDs for the intent and balance
-        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
-    }
-
-    /// @notice Allocate the transfers to settle the obligation
-    /// @dev We transfer fees out of the balance immediately. This is done to avoid the need to update the balance later
-    /// to pay fees. It leaks no extra privacy, because the settlement obligation in this case is known.
-    /// @param settlementStatement The settlement statement to allocate the transfers for
-    /// @param state The darkpool state containing all storage references
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    function allocateTransfers(
-        IntentAndBalancePublicSettlementStatement memory settlementStatement,
-        DarkpoolState storage state,
-        SettlementContext memory settlementContext
-    )
-        internal
-        view
-    {
-        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) = computeFeeTakes(settlementStatement, state);
-
-        // Add withdrawal transfers for the fees
-        SimpleTransfer memory relayerWithdrawal = relayerFeeTake.buildWithdrawalTransfer();
-        SimpleTransfer memory protocolWithdrawal = protocolFeeTake.buildWithdrawalTransfer();
-        settlementContext.pushWithdrawal(relayerWithdrawal);
-        settlementContext.pushWithdrawal(protocolWithdrawal);
-    }
-
-    /// @notice Compute the fee takes for the match
-    /// @param settlementStatement The settlement statement to compute the fee takes for
-    /// @param state The darkpool state containing all storage references
-    /// @return relayerFeeTake The relayer fee take
-    /// @return protocolFeeTake The protocol fee take
-    function computeFeeTakes(
-        IntentAndBalancePublicSettlementStatement memory settlementStatement,
-        DarkpoolState storage state
-    )
-        internal
-        view
-        returns (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake)
-    {
-        SettlementObligation memory obligation = settlementStatement.settlementObligation;
-
-        // First compute the fee rates
-        FeeRate memory relayerFeeRate =
-            FeeRate({ rate: settlementStatement.relayerFee, recipient: settlementStatement.relayerFeeRecipient });
-        FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
-
-        // Then multiply the rates with the receive amount
-        uint256 receiveAmount = obligation.amountOut;
-        address receiveToken = obligation.outputToken;
-        relayerFeeTake = relayerFeeRate.computeFeeTake(receiveToken, receiveAmount);
-        protocolFeeTake = protocolFeeRate.computeFeeTake(receiveToken, receiveAmount);
+        bundle.executeStateUpdates(state, settlementContext, hasher);
     }
 }

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol
@@ -1,0 +1,669 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import {
+    PlonkProof,
+    LinkingProof,
+    VerificationKey,
+    ProofLinkingInstance,
+    ProofLinkingVK
+} from "renegade-lib/verifier/Types.sol";
+
+import { CommitmentLib } from "darkpoolv2-lib/Commitments.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { FeeRate, FeeRateLib, FeeTake, FeeTakeLib } from "darkpoolv2-types/Fee.sol";
+import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import {
+    RenegadeSettledIntentAuthBundleFirstFill,
+    RenegadeSettledIntentAuthBundle,
+    SignatureWithNonce,
+    SignatureWithNonceLib,
+    PrivateIntentPrivateBalanceAuthBundleLib
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import {
+    OutputBalanceBundle,
+    OutputBalanceBundleLib,
+    NewBalanceBundle,
+    ExistingBalanceBundle,
+    OutputBalanceBundleType
+} from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
+import { IntentAndBalancePublicSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
+import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
+import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    IntentAndBalanceValidityStatementFirstFill,
+    IntentAndBalanceValidityStatement,
+    NewOutputBalanceValidityStatement,
+    OutputBalanceValidityStatement
+} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import {
+    IntentPublicShare,
+    IntentPublicShareLib,
+    IntentPreMatchShare,
+    IntentPreMatchShareLib
+} from "darkpoolv2-types/Intent.sol";
+import { PostMatchBalanceShare, PostMatchBalanceShareLib } from "darkpoolv2-types/Balance.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
+import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
+
+// ----------------
+// | Bundle Types |
+// ----------------
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_PRIVATE_INTENT` bundle on the first fill
+struct RenegadeSettledIntentFirstFillBundle {
+    /// @dev The private intent authorization payload with signature attached
+    RenegadeSettledIntentAuthBundleFirstFill auth;
+    /// @dev The calldata bundle containing a proof of output balance validity
+    OutputBalanceBundle outputBalanceBundle;
+    /// @dev The statement of intent and balance public settlement
+    IntentAndBalancePublicSettlementStatement settlementStatement;
+    /// @dev The proof of intent and balance public settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_INTENT` bundle
+struct RenegadeSettledIntentBundle {
+    /// @dev The private intent authorization payload with signature attached
+    RenegadeSettledIntentAuthBundle auth;
+    /// @dev The calldata bundle containing a proof of output balance validity
+    OutputBalanceBundle outputBalanceBundle;
+    /// @dev The statement of intent and balance public settlement
+    IntentAndBalancePublicSettlementStatement settlementStatement;
+    /// @dev The proof of intent and balance public settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+}
+
+// -----------
+// | Library |
+// -----------
+
+/// @title Private Intent Private Balance Bundle Library
+/// @author Renegade Eng
+/// @notice Library for decoding, computing commitments, and extracting values from private intent, private balance
+/// bundles.
+library PrivateIntentPrivateBalanceBundleLib {
+    using BN254 for BN254.ScalarField;
+    using IntentPublicShareLib for IntentPublicShare;
+    using IntentPreMatchShareLib for IntentPreMatchShare;
+    using PostMatchBalanceShareLib for PostMatchBalanceShare;
+    using SignatureWithNonceLib for SignatureWithNonce;
+    using SettlementContextLib for SettlementContext;
+    using DarkpoolStateLib for DarkpoolState;
+    using PublicInputsLib for IntentAndBalanceValidityStatementFirstFill;
+    using PublicInputsLib for IntentAndBalanceValidityStatement;
+    using PublicInputsLib for NewOutputBalanceValidityStatement;
+    using PublicInputsLib for OutputBalanceValidityStatement;
+    using PublicInputsLib for IntentAndBalancePublicSettlementStatement;
+    using SettlementObligationLib for SettlementObligation;
+    using FeeRateLib for FeeRate;
+    using FeeTakeLib for FeeTake;
+    using OutputBalanceBundleLib for OutputBalanceBundle;
+
+    // ----------
+    // | Decode |
+    // ----------
+
+    /// @notice Decode a renegade settled private intent settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledIntentBundleDataFirstFill(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledIntentFirstFillBundle memory bundleData)
+    {
+        bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledIntentFirstFillBundle));
+    }
+
+    /// @notice Decode a renegade settled private intent settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledIntentBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledIntentBundle memory bundleData)
+    {
+        bool validType = !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledIntentBundle));
+    }
+
+    // ---------------------------
+    // | Commitments Computation |
+    // ---------------------------
+
+    /// @notice Compute the full commitment to the updated intent for a renegade settled private intent bundle
+    /// on its first fill
+    /// @dev The circuit proves the validity of the private share commitment, so we must:
+    /// 1. Compute the updated public share which results from applying the settlement to the leaked `amountIn` share.
+    /// 2. Compute the full commitment to the updated intent from the private commitment and public shares.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        RenegadeSettledIntentFirstFillBundle memory bundleData,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+        IntentAndBalancePublicSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // 1. Compute the updated public share of the amount in field
+        BN254.ScalarField newAmountInShare = settlementStatement.amountPublicShare;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementStatement.settlementObligation.amountIn);
+        newAmountInShare = newAmountInShare.sub(settlementAmount);
+
+        // 2. Create the full updated intent public share
+        IntentPublicShare memory newIntentPublicShare =
+            authStatement.intentPublicShare.toFullPublicShare(newAmountInShare);
+        uint256[] memory publicShares = newIntentPublicShare.scalarSerialize();
+
+        // 3. Compute the full commitment to the updated intent
+        newIntentCommitment = CommitmentLib.computeCommitmentWithPublicShares(
+            authStatement.intentPrivateShareCommitment, publicShares, hasher
+        );
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a renegade settled private intent bundle
+    /// on its first fill
+    /// @dev The circuit proves the validity of a commitment to all fields of the balance which don't change in the
+    /// match,
+    /// so we must:
+    /// 1. Compute the updated public shares of the balance
+    /// 2. Compute the full commitment to the updated balance from the partial commitment and public shares.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledIntentFirstFillBundle memory bundleData,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+        IntentAndBalancePublicSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // 1. Compute the updated public shares of the balance
+        // The fees don't update for the input balance, so we leave them as is
+        PostMatchBalanceShare memory newInBalancePublicShares = settlementStatement.inBalancePublicShares;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementStatement.settlementObligation.amountIn);
+        newInBalancePublicShares.amount = newInBalancePublicShares.amount.sub(settlementAmount);
+
+        // 2. Resume the partial commitment with updated shares
+        uint256[] memory remainingShares = newInBalancePublicShares.scalarSerialize();
+        newBalanceCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.balancePartialCommitment, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a renegade settled private intent bundle
+    /// on its subsequent fill
+    /// @dev The partial commitment computed in the circuit is a commitment to all shares except the public share of the
+    /// `amountIn` field, which is updated in a match settlement. We must therefore apply the settlement to the
+    /// `amountIn` public share and resume the commitment.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        RenegadeSettledIntentBundle memory bundleData,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        IntentAndBalancePublicSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // Compute the updated public share of the amount in field
+        BN254.ScalarField newAmountInShare = settlementStatement.amountPublicShare;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementStatement.settlementObligation.amountIn);
+        newAmountInShare = newAmountInShare.sub(settlementAmount);
+
+        // Resume the partial commitment with updated shares
+        uint256[] memory remainingShares = new uint256[](1);
+        remainingShares[0] = BN254.ScalarField.unwrap(newAmountInShare);
+        newIntentCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.newIntentPartialCommitment, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a renegade settled private intent bundle
+    /// on its subsequent fill
+    /// @dev The partial commitment computed in the circuit is a commitment to all shares except the public share of the
+    /// `amount` field, which is updated in a match settlement. We must therefore apply the settlement to the
+    /// `amount` public share and resume the commitment.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledIntentBundle memory bundleData,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        IntentAndBalancePublicSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // Compute the updated public shares of the balance
+        PostMatchBalanceShare memory newInBalancePublicShares = settlementStatement.inBalancePublicShares;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(settlementStatement.settlementObligation.amountIn);
+        newInBalancePublicShares.amount = newInBalancePublicShares.amount.sub(settlementAmount);
+
+        // Resume the partial commitment with updated shares
+        uint256[] memory remainingShares = newInBalancePublicShares.scalarSerialize();
+        newBalanceCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.balancePartialCommitment, hasher);
+    }
+
+    // ------------------------
+    // | Intent Authorization |
+    // ------------------------
+
+    /// @notice Authorize the intent and capitalizing balance for a Renegade settled private intent bundle on its first
+    /// fill
+    /// @param bundleData The bundle to check validity for
+    /// @param settlementContext The settlement context to check validity for
+    /// @param vkeys The contract storing the verification keys
+    /// @param state The state to use for verification
+    function authorizeIntent(
+        RenegadeSettledIntentFirstFillBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        RenegadeSettledIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
+
+        // Validate the Merkle root used to authorize the input balance
+        // TODO: Allow for dynamic Merkle depth
+        if (authBundle.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
+            revert IDarkpool.InvalidMerkleDepthRequested();
+        }
+        state.assertRootInHistory(authBundle.statement.merkleRoot);
+
+        // Verify the intent signature
+        verifyIntentSignature(authBundle, state);
+
+        // Push the validity proof to the settlement context
+        pushValidityProof(
+            authBundle.statement.statementSerialize(),
+            authBundle.validityProof,
+            bundleData.settlementProof,
+            vkeys.intentAndBalanceFirstFillValidityKeys(),
+            vkeys.intentAndBalanceSettlement0LinkingKey(),
+            bundleData.authSettlementLinkingProof,
+            settlementContext
+        );
+    }
+
+    /// @notice Authorize the intent and capitalizing balance for a Renegade settled private intent bundle on its
+    /// subsequent fill
+    /// @dev Note that we don't need to verify the owner signature here. The presence of the intent in the Merkle tree
+    /// implies that the owner's signature has already been verified (in a previous fill). So in this case, we need only
+    /// verify the proof attached to the bundle.
+    /// @param bundleData The bundle to authorize
+    /// @param settlementContext The settlement context to authorize the intent for
+    /// @param vkeys The contract storing the verification keys
+    /// @param state The state to use for authorization
+    function authorizeIntent(
+        RenegadeSettledIntentBundle memory bundleData,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Validate the Merkle roots used for the input balance and intent
+        // TODO: Allow for dynamic Merkle depth
+        if (bundleData.auth.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
+            revert IDarkpool.InvalidMerkleDepthRequested();
+        }
+        state.assertRootInHistory(bundleData.auth.statement.intentMerkleRoot);
+        state.assertRootInHistory(bundleData.auth.statement.balanceMerkleRoot);
+
+        // Push a validity proof to the settlement context
+        pushValidityProof(
+            bundleData.auth.statement.statementSerialize(),
+            bundleData.auth.validityProof,
+            bundleData.settlementProof,
+            vkeys.intentAndBalanceValidityKeys(),
+            vkeys.intentAndBalanceSettlement0LinkingKey(),
+            bundleData.authSettlementLinkingProof,
+            settlementContext
+        );
+    }
+
+    /// @notice Verify the signature on the intent authorization bundle for a first fill
+    /// @param bundleData The bundle to check validity for
+    /// @param state The state to use for verification
+    function verifyIntentSignature(
+        RenegadeSettledIntentAuthBundleFirstFill memory bundleData,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Verify the owner signature and spend the nonce
+        bytes32 digest = PrivateIntentPrivateBalanceAuthBundleLib.getOwnerSignatureDigest(bundleData);
+        address signer = bundleData.statement.oneTimeAuthorizingAddress;
+
+        bool valid = bundleData.ownerSignature.verifyPrehashed(signer, digest);
+        if (!valid) revert IDarkpoolV2.InvalidOwnerSignature();
+        state.spendNonce(bundleData.ownerSignature.nonce);
+    }
+
+    // --------------------------------
+    // | Output Balance Authorization |
+    // --------------------------------
+
+    /// @notice Authorize the output balance for a Renegade settled private intent bundle
+    /// @dev The output balance receives the obligation's output amount
+    /// @dev A settlement *may* create a new output balance, or it may use an existing balance. These two cases
+    /// correspond to the helpers below
+    /// @param outputBalanceBundle The output balance's authorization bundle
+    /// @param settlementProof The settlement proof; included here to proof-link the output balance authorization into
+    /// the settlement proof
+    /// @param settlementContext The settlement context to authorize the output balance for
+    /// @param vkeys The verification keys to use for authorization
+    /// @param state The state to use for authorization
+    function authorizeOutputBalance(
+        OutputBalanceBundle memory outputBalanceBundle,
+        PlonkProof memory settlementProof,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        if (outputBalanceBundle.bundleType == OutputBalanceBundleType.NEW_BALANCE) {
+            authorizeNewOutputBalance(outputBalanceBundle, settlementProof, settlementContext, vkeys);
+        } else if (outputBalanceBundle.bundleType == OutputBalanceBundleType.EXISTING_BALANCE) {
+            authorizeExistingOutputBalance(outputBalanceBundle, settlementProof, settlementContext, vkeys, state);
+        } else {
+            revert IDarkpoolV2.InvalidOutputBalanceBundleType();
+        }
+    }
+
+    /// @notice Authorize a new output balance for a Renegade settled private intent bundle
+    /// @dev A new output balance is created as part of the settlement
+    /// @param bundle The output balance's authorization bundle
+    /// @param settlementProof The settlement proof; included here to proof-link the output balance authorization into
+    /// the settlement proof
+    /// @param settlementContext The settlement context to authorize the output balance for
+    /// @param vkeys The verification keys to use for authorization
+    function authorizeNewOutputBalance(
+        OutputBalanceBundle memory bundle,
+        PlonkProof memory settlementProof,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys
+    )
+        internal
+    {
+        NewBalanceBundle memory newBalanceBundle = bundle.decodeNewBalanceBundle();
+        pushValidityProof(
+            newBalanceBundle.statement.statementSerialize(),
+            bundle.proof,
+            settlementProof,
+            vkeys.newOutputBalanceValidityKeys(),
+            // We use the first party's link group layout for this linking argument regardless of the party ID
+            // because in this settlement ring, the settlement proof is per-party, and only has link groups for one
+            // output balance.
+            vkeys.outputBalanceSettlement0LinkingKey(),
+            bundle.settlementLinkingProof,
+            settlementContext
+        );
+    }
+
+    /// @notice Authorize an existing output balance for a Renegade settled private intent bundle
+    /// @dev An existing output balance is used as part of the settlement
+    /// @param bundle The output balance's authorization bundle
+    /// @param settlementProof The settlement proof; included here to proof-link the output balance authorization into
+    /// the settlement proof
+    /// @param settlementContext The settlement context to authorize the output balance for
+    /// @param vkeys The verification keys to use for authorization
+    /// @param state The state to use for authorization
+    function authorizeExistingOutputBalance(
+        OutputBalanceBundle memory bundle,
+        PlonkProof memory settlementProof,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        ExistingBalanceBundle memory existingBalanceBundle = bundle.decodeExistingBalanceBundle();
+
+        // Validate the Merkle root used for the output balance
+        // TODO: Allow for dynamic Merkle depth
+        if (existingBalanceBundle.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
+            revert IDarkpool.InvalidMerkleDepthRequested();
+        }
+        state.assertRootInHistory(existingBalanceBundle.statement.merkleRoot);
+
+        // Push the validity proof to the settlement context alongside the proof linking argument
+        pushValidityProof(
+            existingBalanceBundle.statement.statementSerialize(),
+            bundle.proof,
+            settlementProof,
+            vkeys.outputBalanceValidityKeys(),
+            // We use the first party's link group layout for this linking argument regardless of the party ID
+            // because in this settlement ring, the settlement proof is per-party, and only has link groups for one
+            // output balance.
+            vkeys.outputBalanceSettlement0LinkingKey(),
+            bundle.settlementLinkingProof,
+            settlementContext
+        );
+    }
+
+    // -----------------
+    // | State Updates |
+    // -----------------
+
+    /// @notice Execute the state updates for a bundle on its first fill
+    /// @param bundle The settlement bundle to execute the state updates for
+    /// @param state The state to use for the state updates
+    /// @param settlementContext The settlement context to which we append post-execution updates.
+    /// @param hasher The hasher contract
+    /// TODO: Update state for output balances
+    function executeStateUpdatesFirstFill(
+        RenegadeSettledIntentFirstFillBundle memory bundle,
+        DarkpoolState storage state,
+        SettlementContext memory settlementContext,
+        IHasher hasher
+    )
+        internal
+    {
+        // 1. Nullify the balance state
+        BN254.ScalarField nullifier = bundle.auth.statement.oldBalanceNullifier;
+        state.spendNullifier(nullifier);
+
+        // 2. Insert commitments to the updated intent and balance into the Merkle tree
+        uint256 merkleDepth = bundle.auth.merkleDepth;
+        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(bundle, hasher);
+        BN254.ScalarField newBalanceCommitment = computeFullBalanceCommitment(bundle, hasher);
+        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+
+        // 3. Allocate transfers to settle the fees due from the obligation
+        _allocateTransfers(bundle.settlementStatement, state, settlementContext);
+
+        // 4. Emit recovery IDs for the intent and balance
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundle.auth.statement;
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+    }
+
+    /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill
+    /// @param bundleData The bundle data to execute the state updates for
+    /// @param state The darkpool state containing all storage references
+    /// @param settlementContext The settlement context to which we append post-execution updates.
+    /// @param hasher The hasher to use for hashing
+    /// TODO: Update state for output balances
+    function executeStateUpdates(
+        RenegadeSettledIntentBundle memory bundleData,
+        DarkpoolState storage state,
+        SettlementContext memory settlementContext,
+        IHasher hasher
+    )
+        internal
+    {
+        // 1. Nullify both the balance and intent states
+        BN254.ScalarField balanceNullifier = bundleData.auth.statement.oldBalanceNullifier;
+        BN254.ScalarField intentNullifier = bundleData.auth.statement.oldIntentNullifier;
+        state.spendNullifier(balanceNullifier);
+        state.spendNullifier(intentNullifier);
+
+        // 2. Insert commitments to the updated intent and balance into the Merkle tree
+        uint256 merkleDepth = bundleData.auth.merkleDepth;
+        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(bundleData, hasher);
+        BN254.ScalarField newBalanceCommitment = computeFullBalanceCommitment(bundleData, hasher);
+        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+
+        // 3. Allocate transfers to settle the fees due from the obligation
+        _allocateTransfers(bundleData.settlementStatement, state, settlementContext);
+
+        // 4. Emit recovery IDs for the intent and balance
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+    }
+
+    // -------------------
+    // | Validity Proofs |
+    // -------------------
+
+    /// @notice Push a validity proof to the settlement context
+    /// @dev This method also pushes a proof linking argument between the validity proof and the settlement proof
+    /// @param publicInputs The public inputs to the validity proof
+    /// @param validityProof The validity proof to push
+    /// @param settlementProof The settlement proof to push
+    /// @param validityVKey The verification key to use for the validity proof
+    /// @param linkingVKey The verification key to use for the proof linking argument
+    /// @param linkingProof The linking proof between the validity and settlement proofs
+    /// @param settlementContext The settlement context to push to
+    function pushValidityProof(
+        BN254.ScalarField[] memory publicInputs,
+        PlonkProof memory validityProof,
+        PlonkProof memory settlementProof,
+        VerificationKey memory validityVKey,
+        ProofLinkingVK memory linkingVKey,
+        LinkingProof memory linkingProof,
+        SettlementContext memory settlementContext
+    )
+        internal
+        pure
+    {
+        settlementContext.pushProof(publicInputs, validityProof, validityVKey);
+        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
+            wireComm0: validityProof.wireComms[0],
+            wireComm1: settlementProof.wireComms[0],
+            proof: linkingProof,
+            vk: linkingVKey
+        });
+        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
+    }
+
+    // ---------------------
+    // | Settlement Proofs |
+    // ---------------------
+
+    /// @notice Push a settlement proof to the settlement context
+    /// @param obligation The obligation to validate. The statement has a copy of this obligation, which must match the
+    /// value passed in here.
+    /// @param statement The settlement statement
+    /// @param proof The settlement proof to push
+    /// @param vkeys The verification keys contract
+    /// @param settlementContext The settlement context to push to
+    function verifySettlement(
+        SettlementObligation memory obligation,
+        IntentAndBalancePublicSettlementStatement memory statement,
+        PlonkProof memory proof,
+        IVkeys vkeys,
+        SettlementContext memory settlementContext
+    )
+        internal
+        view
+    {
+        // The obligation in the settlement statement must match the one from the obligation bundle
+        bool obligationMatches = obligation.isEqualTo(statement.settlementObligation);
+        if (!obligationMatches) revert IDarkpoolV2.InvalidObligation();
+
+        // Push the settlement proof to the settlement context
+        BN254.ScalarField[] memory publicInputs = statement.statementSerialize();
+        VerificationKey memory vk = vkeys.intentAndBalancePublicSettlementKeys();
+        settlementContext.pushProof(publicInputs, proof, vk);
+    }
+
+    // -------------
+    // | Transfers |
+    // -------------
+
+    /// @notice Allocate the transfers to settle the obligation
+    /// @dev We transfer fees out of the balance immediately. This is done to avoid the need to update the balance later
+    /// to pay fees. It leaks no extra privacy, because the settlement obligation in this case is known.
+    /// @param settlementStatement The settlement statement to allocate the transfers for
+    /// @param state The darkpool state containing all storage references
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    function _allocateTransfers(
+        IntentAndBalancePublicSettlementStatement memory settlementStatement,
+        DarkpoolState storage state,
+        SettlementContext memory settlementContext
+    )
+        internal
+        view
+    {
+        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) = _computeFeeTakes(settlementStatement, state);
+
+        // Add withdrawal transfers for the fees
+        SimpleTransfer memory relayerWithdrawal = relayerFeeTake.buildWithdrawalTransfer();
+        SimpleTransfer memory protocolWithdrawal = protocolFeeTake.buildWithdrawalTransfer();
+        settlementContext.pushWithdrawal(relayerWithdrawal);
+        settlementContext.pushWithdrawal(protocolWithdrawal);
+    }
+
+    /// @notice Compute the fee takes for the match
+    /// @param settlementStatement The settlement statement to compute the fee takes for
+    /// @param state The darkpool state containing all storage references
+    /// @return relayerFeeTake The relayer fee take
+    /// @return protocolFeeTake The protocol fee take
+    function _computeFeeTakes(
+        IntentAndBalancePublicSettlementStatement memory settlementStatement,
+        DarkpoolState storage state
+    )
+        internal
+        view
+        returns (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake)
+    {
+        SettlementObligation memory obligation = settlementStatement.settlementObligation;
+
+        // First compute the fee rates
+        FeeRate memory relayerFeeRate =
+            FeeRate({ rate: settlementStatement.relayerFee, recipient: settlementStatement.relayerFeeRecipient });
+        FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
+
+        // Then multiply the rates with the receive amount
+        uint256 receiveAmount = obligation.amountOut;
+        address receiveToken = obligation.outputToken;
+        relayerFeeTake = relayerFeeRate.computeFeeTake(receiveToken, receiveAmount);
+        protocolFeeTake = protocolFeeRate.computeFeeTake(receiveToken, receiveAmount);
+    }
+}

--- a/src/darkpool/v2/types/settlement/OutputBalanceBundle.sol
+++ b/src/darkpool/v2/types/settlement/OutputBalanceBundle.sol
@@ -39,6 +39,8 @@ enum OutputBalanceBundleType {
 
 /// @notice The verification data for an existing balance bundle
 struct ExistingBalanceBundle {
+    /// @dev The Merkle depth of the balance
+    uint256 merkleDepth;
     /// @dev The statement for the balance validity proof
     OutputBalanceValidityStatement statement;
 }
@@ -55,33 +57,6 @@ struct NewBalanceBundle {
 library OutputBalanceBundleLib {
     using PublicInputsLib for OutputBalanceValidityStatement;
     using PublicInputsLib for NewOutputBalanceValidityStatement;
-
-    /// @notice Extract the public keys and verification key for an output balance bundle
-    /// @param bundle The output balance bundle to extract the public keys and verification key for
-    /// @param vkeys The contract storing the verification keys
-    /// @return publicInputs The public inputs for the output balance validity proof
-    /// @return vk The verification key for the output balance validity proof
-    function getStatementAndVerificationKey(
-        OutputBalanceBundle memory bundle,
-        IVkeys vkeys
-    )
-        internal
-        view
-        returns (BN254.ScalarField[] memory publicInputs, VerificationKey memory vk)
-    {
-        if (bundle.bundleType == OutputBalanceBundleType.EXISTING_BALANCE) {
-            ExistingBalanceBundle memory existingBalanceBundle =
-                OutputBalanceBundleLib.decodeExistingBalanceBundle(bundle);
-            publicInputs = existingBalanceBundle.statement.statementSerialize();
-            vk = vkeys.outputBalanceValidityKeys();
-        } else if (bundle.bundleType == OutputBalanceBundleType.NEW_BALANCE) {
-            NewBalanceBundle memory newBalanceBundle = OutputBalanceBundleLib.decodeNewBalanceBundle(bundle);
-            publicInputs = newBalanceBundle.statement.statementSerialize();
-            vk = vkeys.newOutputBalanceValidityVkeys();
-        } else {
-            revert IDarkpoolV2.InvalidOutputBalanceBundleType();
-        }
-    }
 
     /// @notice Decode an existing balance bundle
     /// @param bundle The output balance bundle to decode

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/FullMatchTests.t.sol
@@ -5,14 +5,14 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 
-import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { ObligationBundle, ObligationType, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
-    RenegadeSettledIntentBundle,
     RenegadeSettledIntentFirstFillBundle,
-    SettlementBundleLib
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+    RenegadeSettledIntentBundle,
+    PrivateIntentPrivateBalanceBundleLib
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
 import { RenegadeSettledPrivateIntentTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
@@ -26,8 +26,8 @@ import { ExpectedDifferences } from "../SettlementTestUtils.sol";
 
 contract FullMatchTests is RenegadeSettledPrivateIntentTestUtils {
     using ObligationLib for ObligationBundle;
-    using SettlementBundleLib for RenegadeSettledIntentBundle;
-    using SettlementBundleLib for RenegadeSettledIntentFirstFillBundle;
+    using PrivateIntentPrivateBalanceBundleLib for RenegadeSettledIntentBundle;
+    using PrivateIntentPrivateBalanceBundleLib for RenegadeSettledIntentFirstFillBundle;
     using FixedPointLib for FixedPoint;
     using MerkleTreeLib for MerkleTreeLib.MerkleTree;
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
@@ -3,12 +3,9 @@ pragma solidity ^0.8.24;
 
 /* solhint-disable func-name-mixedcase */
 
-import {
-    PartyId,
-    SettlementBundle,
-    SettlementBundleLib,
-    RenegadeSettledIntentFirstFillBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { PartyId, SettlementBundle, SettlementBundleLib } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { RenegadeSettledIntentFirstFillBundle } from
+    "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     SignatureWithNonce, RenegadeSettledIntentAuthBundleFirstFill
@@ -22,8 +19,6 @@ import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
 import { RenegadeSettledPrivateIntentTestUtils } from "./Utils.sol";
 
 contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivateIntentTestUtils {
-    using SettlementBundleLib for RenegadeSettledIntentFirstFillBundle;
-
     function setUp() public virtual override {
         super.setUp();
         // Mint max amounts of the base and quote tokens to the darkpool to capitalize fee payments

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/Utils.sol
@@ -3,21 +3,23 @@ pragma solidity ^0.8.24;
 
 import { Vm } from "forge-std/Vm.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
-import { DarkpoolV2TestUtils } from "../../DarkpoolV2TestUtils.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
-import {
-    SettlementBundle,
-    SettlementBundleType,
-    RenegadeSettledIntentFirstFillBundle,
-    RenegadeSettledIntentBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { ObligationBundle, ObligationType, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     SignatureWithNonce,
     RenegadeSettledIntentAuthBundleFirstFill,
     RenegadeSettledIntentAuthBundle
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
-import { OutputBalanceBundle, OutputBalanceBundleType } from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
+import {
+    RenegadeSettledIntentFirstFillBundle,
+    RenegadeSettledIntentBundle
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
+import {
+    OutputBalanceBundle,
+    OutputBalanceBundleType,
+    ExistingBalanceBundle
+} from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
@@ -151,9 +153,11 @@ contract RenegadeSettledPrivateIntentTestUtils is SettlementTestUtils {
             recoveryId: randomScalar()
         });
 
+        ExistingBalanceBundle memory existingBalanceBundle =
+            ExistingBalanceBundle({ merkleDepth: DarkpoolConstants.DEFAULT_MERKLE_DEPTH, statement: statement });
         return OutputBalanceBundle({
             bundleType: OutputBalanceBundleType.EXISTING_BALANCE,
-            data: abi.encode(statement),
+            data: abi.encode(existingBalanceBundle),
             proof: createDummyProof(),
             settlementLinkingProof: createDummyLinkingProof()
         });


### PR DESCRIPTION
### Purpose
This PR factors the ring 2 implementation into a settlement library that better encapsulates the ring 2 validation behavior.

We can re-use this verification logic in the external match settlement paths.

I removed some unnecessary statement elements from the new output balance proof. We're likely to verify the output balance creation in-circuit. 

### Todo
- Add output balance state updates

### Testing
- [x] All tests pass
