### PR TITLE
darkpoolv2: settlement: add `ExternalSettlementLib` and make bundle handlers public

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -39,6 +39,7 @@ import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { ExternalSettlementLib } from "darkpoolv2-lib/settlement/ExternalSettlementLib.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { StateUpdatesLib } from "darkpoolv2-lib/StateUpdatesLib.sol";
 
@@ -269,7 +270,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     )
         public
     {
-        SettlementLib.settleExternalMatch(
+        ExternalSettlementLib.settleExternalMatch(
             _state,
             hasher,
             verifier,

--- a/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import { IPermit2 } from "permit2-lib/interfaces/IPermit2.sol";
+import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
+import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+
+import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
+import { BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import {
+    SettlementBundle,
+    SettlementBundleType,
+    SettlementBundleLib
+} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
+import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol";
+import { DarkpoolState } from "darkpoolv2-lib/DarkpoolState.sol";
+import { SettlementLib } from "./SettlementLib.sol";
+import { SettlementVerification } from "./SettlementVerification.sol";
+
+/// @title ExternalSettlementLib
+/// @author Renegade Eng
+/// @notice Library for external settlement operations
+library ExternalSettlementLib {
+    using SettlementBundleLib for SettlementBundle;
+    using SettlementContextLib for SettlementContext;
+    using SettlementObligationLib for SettlementObligation;
+
+    /// @notice Settle a trade with an external party who decides the trade size
+    /// @param state The darkpool state containing all storage references
+    /// @param hasher The hasher to use for hashing commitments
+    /// @param verifier The verifier to use for verification
+    /// @param weth The WETH9 contract instance
+    /// @param permit2 The permit2 contract instance
+    /// @param vkeys The contract storing the verification keys
+    /// @param externalPartyAmountIn The input amount for the trade
+    /// @param recipient The recipient of the withdrawal
+    /// @param matchBundle The bounded match result bundle
+    /// @param internalPartySettlementBundle The settlement bundle for the internal party
+    function settleExternalMatch(
+        DarkpoolState storage state,
+        IHasher hasher,
+        IVerifier verifier,
+        IWETH9 weth,
+        IPermit2 permit2,
+        IVkeys vkeys,
+        uint256 externalPartyAmountIn,
+        address recipient,
+        BoundedMatchResultBundle calldata matchBundle,
+        SettlementBundle calldata internalPartySettlementBundle
+    )
+        external
+    {
+        // Allocate a settlement context
+        SettlementContext memory settlementContext = allocateExternalSettlementContext(internalPartySettlementBundle);
+
+        // Build settlement obligations from the bounded match result and external party amount in
+        (SettlementObligation memory externalObligation, SettlementObligation memory internalObligation) =
+            BoundedMatchResultLib.buildObligations(matchBundle.permit.matchResult, externalPartyAmountIn);
+
+        // Validate and authorize the settlement bundles
+        executeExternalSettlementBundle(
+            matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, hasher, vkeys, state
+        );
+
+        // Allocate transfers for external party
+        // Authorization is implied by virtue of the external party being the one settling
+        allocateExternalMatchSettlementTransfers(recipient, externalObligation, settlementContext);
+
+        // Execute the transfers necessary for settlement
+        // The helpers above will push transfers to the settlement context if necessary
+        SettlementLib.executeTransfers(settlementContext, weth, permit2);
+
+        // Verify the proofs necessary for settlement
+        // The helpers above will push proofs to the settlement context if necessary
+        SettlementVerification.verifySettlementProofs(settlementContext, verifier);
+    }
+
+    // --- Allocation --- //
+
+    /// @notice Allocate a settlement context for an external match
+    /// @dev The number of transfers and proofs for the external party is known: (1 deposit + 1 withdrawal + 0 proofs)
+    /// @param internalPartySettlementBundle The settlement bundle for the internal party
+    /// @return The allocated settlement context
+    function allocateExternalSettlementContext(SettlementBundle calldata internalPartySettlementBundle)
+        internal
+        pure
+        returns (SettlementContext memory)
+    {
+        uint256 numDeposits = SettlementBundleLib.getNumDeposits(internalPartySettlementBundle) + 1;
+        uint256 numWithdrawals = SettlementBundleLib.getNumWithdrawals(internalPartySettlementBundle) + 1;
+        uint256 proofCapacity = SettlementBundleLib.getNumProofs(internalPartySettlementBundle);
+
+        return
+            SettlementContextLib.newContext(
+                numDeposits,
+                numWithdrawals,
+                proofCapacity,
+                0 /* proof linking capacity */
+            );
+    }
+
+    /// @notice Allocate transfers to settle an external party's obligation into the settlement context
+    /// @dev TODO: Implement fee computation and withdrawal transfers for relayer/protocol fees, and use recipient
+    /// parameter for withdrawal
+    /// @param recipient The recipient of the withdrawal
+    /// @param externalObligation The external party's settlement obligation to settle
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    function allocateExternalMatchSettlementTransfers(
+        address recipient,
+        SettlementObligation memory externalObligation,
+        SettlementContext memory settlementContext
+    )
+        internal
+        view
+    {
+        address owner = msg.sender;
+
+        // Deposit the input token into the darkpool
+        SimpleTransfer memory deposit = externalObligation.buildERC20ApprovalDeposit(owner);
+        settlementContext.pushDeposit(deposit);
+
+        // Withdraw the output token from the darkpool
+        uint256 totalFee = 0;
+        SimpleTransfer memory withdrawal = externalObligation.buildWithdrawalTransfer(recipient, totalFee);
+        settlementContext.pushWithdrawal(withdrawal);
+    }
+
+    // --- Settlement Bundle Validation --- //
+
+    /// @notice Execute an external settlement bundle
+    /// @param matchBundle The bounded match result authorization bundle to validate
+    /// @param internalObligation The settlement obligation to validate
+    /// @param internalPartySettlementBundle The settlement bundle for the internal party
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param hasher The hasher to use for hashing
+    /// @param vkeys The contract storing the verification keys
+    /// @param state The darkpool state containing all storage references
+    function executeExternalSettlementBundle(
+        BoundedMatchResultBundle calldata matchBundle,
+        SettlementObligation memory internalObligation,
+        SettlementBundle calldata internalPartySettlementBundle,
+        SettlementContext memory settlementContext,
+        IHasher hasher,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        SettlementBundleType bundleType = internalPartySettlementBundle.bundleType;
+        if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT) {
+            NativeSettledPublicIntentLib.executeBoundedMatch(
+                matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, state
+            );
+        } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
+            NativeSettledPrivateIntentLib.executeBoundedMatch(
+                matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, hasher, vkeys, state
+            );
+        } else {
+            // TODO: Add support for other settlement bundle types
+            revert IDarkpoolV2.InvalidSettlementBundleType();
+        }
+    }
+}

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
@@ -10,7 +10,9 @@ import {
     RenegadeSettledPrivateFillBundle
 } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    ObligationBundle, ObligationLib, PrivateObligationBundle
+    ObligationBundle,
+    ObligationLib,
+    PrivateObligationBundle
 } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
@@ -173,8 +175,7 @@ library RenegadeSettledPrivateFillLib {
         IVkeys vkeys,
         DarkpoolState storage state
     )
-        internal
-    {
+        internal {
         // TODO: Proof link into the obligation bundle's settlement proof
     }
 
@@ -195,8 +196,7 @@ library RenegadeSettledPrivateFillLib {
         IVkeys vkeys,
         DarkpoolState storage state
     )
-        internal
-    {
+        internal {
         // TODO: Proof link into the obligation bundle's settlement proof
     }
 

--- a/src/darkpool/v2/libraries/settlement/SettlementVerification.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementVerification.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { OpeningElements } from "renegade-lib/verifier/Types.sol";
+import { ProofLinkingCore } from "renegade-lib/verifier/ProofLinking.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+
+/// @title SettlementVerification
+/// @author Renegade Eng
+/// @notice Library for verifying settlement proofs
+/// @dev Separated from SettlementLib to reduce bytecode size via delegatecall
+library SettlementVerification {
+    using SettlementContextLib for SettlementContext;
+
+    /// @notice Verify the proofs necessary for settlement
+    /// @param settlementContext The settlement context to verify the proofs from
+    /// @param verifier The verifier to use for verification
+    function verifySettlementProofs(SettlementContext memory settlementContext, IVerifier verifier) public view {
+        if (settlementContext.numProofs() == 0) {
+            return;
+        }
+
+        // Create the extra commitment opening elements implied by the proof linking relation
+        OpeningElements memory linkOpenings =
+            ProofLinkingCore.createOpeningElements(settlementContext.proofLinkingArguments.instances);
+
+        // Call the core verifier
+        bool valid = verifier.batchVerify(
+            settlementContext.verifications.proofs,
+            settlementContext.verifications.publicInputs,
+            settlementContext.verifications.vks,
+            linkOpenings
+        );
+
+        if (!valid) {
+            revert IDarkpoolV2.SettlementVerificationFailed();
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

This PR makes two changes to lower the bytecode size of `SettlementLib`.

1. Breaks external settlement methods out of `SettlementLib` into `ExternalSettlementLib`
2. Breaks `verifySettlementProofs` out of `SettlementLib` into `SettlementVerification`

| Approach | SettlementLib | ExternalSettlementLib | SettlementVerificationLib |
|----------|---------------|----------------------|-----------------------------|
| Baseline | 30,791 | - | - |
| SettlementVerificationLib | 29,151 | - | 6,572 |
| ExternalSettlementLib | 27,316 | 20,079 | - |
| SettlementVerificationLib + ExternalSettlementLib | 25,183 | 18,494 | 6,572 |

Still not quite under 24kb but will revisit after finishing up external match for ring 2.