### PR TITLE
darkpoolv2: settlement: external-match: add bounded settlement path to ring 2

### DIFF
--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -24,6 +24,7 @@ import {
     IntentOnlyBoundedSettlementStatement,
     IntentOnlyPublicSettlementStatement,
     IntentAndBalancePublicSettlementStatement,
+    IntentAndBalanceBoundedSettlementStatement,
     IntentAndBalancePrivateSettlementStatement
 } from "./Settlement.sol";
 
@@ -360,6 +361,49 @@ library PublicInputsLib {
         // Add the relayer fee and recipient
         publicInputs[11] = BN254.ScalarField.wrap(statement.relayerFee.repr);
         publicInputs[12] = BN254.ScalarField.wrap(uint256(uint160(statement.relayerFeeRecipient)));
+    }
+
+    /// @notice Serialize the public inputs for a proof of intent and balance bounded settlement
+    /// @param statement The statement to serialize
+    /// @return publicInputs The serialized public inputs
+    /// @dev NOTE: This is a temporary placeholder implementation until the circuits are completed.
+    /// The actual circuit public inputs format may differ from this serialization.
+    function statementSerialize(IntentAndBalanceBoundedSettlementStatement memory statement)
+        internal
+        pure
+        returns (BN254.ScalarField[] memory publicInputs)
+    {
+        uint256 nPublicInputs = 16;
+        publicInputs = new BN254.ScalarField[](nPublicInputs);
+
+        // Add the bounded match result fields
+        publicInputs[0] = BN254.ScalarField.wrap(uint256(uint160(statement.boundedMatchResult.internalPartyInputToken)));
+        publicInputs[1] =
+            BN254.ScalarField.wrap(uint256(uint160(statement.boundedMatchResult.internalPartyOutputToken)));
+        publicInputs[2] = BN254.ScalarField.wrap(statement.boundedMatchResult.price.repr);
+        publicInputs[3] = BN254.ScalarField.wrap(statement.boundedMatchResult.minInternalPartyAmountIn);
+        publicInputs[4] = BN254.ScalarField.wrap(statement.boundedMatchResult.maxInternalPartyAmountIn);
+        publicInputs[5] = BN254.ScalarField.wrap(statement.boundedMatchResult.blockDeadline);
+
+        // Add the leaked pre-update amount public share of the intent
+        publicInputs[6] = statement.amountPublicShare;
+
+        // Add the input balance public shares
+        publicInputs[7] = statement.inBalancePublicShares.relayerFeeBalance;
+        publicInputs[8] = statement.inBalancePublicShares.protocolFeeBalance;
+        publicInputs[9] = statement.inBalancePublicShares.amount;
+
+        // Add the output balance public shares
+        publicInputs[10] = statement.outBalancePublicShares.relayerFeeBalance;
+        publicInputs[11] = statement.outBalancePublicShares.protocolFeeBalance;
+        publicInputs[12] = statement.outBalancePublicShares.amount;
+
+        // Add the fee rates
+        publicInputs[13] = BN254.ScalarField.wrap(statement.externalRelayerFeeRate.repr);
+        publicInputs[14] = BN254.ScalarField.wrap(statement.internalRelayerFeeRate.repr);
+
+        // Add the relayer fee address
+        publicInputs[15] = BN254.ScalarField.wrap(uint256(uint160(statement.relayerFeeAddress)));
     }
 
     /// @notice Serialize the public inputs for a proof of intent and balance validity

--- a/src/darkpool/v2/libraries/public_inputs/Settlement.sol
+++ b/src/darkpool/v2/libraries/public_inputs/Settlement.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
-import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
 import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
+import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
 
 // --- Settlement Statements --- //
 // Settlement proofs verify that:
@@ -71,6 +71,28 @@ struct IntentAndBalancePublicSettlementStatement {
     FixedPoint relayerFee;
     /// @dev The recipient of the relayer fee
     address relayerFeeRecipient;
+}
+
+/// @notice A statement for a proof of intent and balance bounded settlement
+/// @dev The statement type for `INTENT AND BALANCE BOUNDED SETTLEMENT`
+/// @dev Similar to public settlement but with bounded match result instead of exact obligation
+struct IntentAndBalanceBoundedSettlementStatement {
+    /// @dev The bounded match result that the intent must be able to capitalize
+    BoundedMatchResult boundedMatchResult;
+    /// @dev The leaked pre-update amount public share of the intent
+    /// @dev Because this circuit represents a public settlement, we leak the public
+    /// share and allow the contracts to update it on-chain.
+    BN254.ScalarField amountPublicShare;
+    /// @dev The updated public shares of the post-match balance fields for the input balance
+    PostMatchBalanceShare inBalancePublicShares;
+    /// @dev The updated public shares of the post-match balance fields for the output balance
+    PostMatchBalanceShare outBalancePublicShares;
+    /// @dev The relayer fee rate charged to the external party
+    FixedPoint externalRelayerFeeRate;
+    /// @dev The relayer fee rate charged to the internal party
+    FixedPoint internalRelayerFeeRate;
+    /// @dev The address at which the relayer receives their fee
+    address relayerFeeAddress;
 }
 
 /// @notice A statement for a proof of intent and balance private settlement

--- a/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
@@ -20,6 +20,7 @@ import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settle
 import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
 import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol";
+import { RenegadeSettledPrivateIntentLib } from "./RenegadeSettledPrivateIntent.sol";
 import { DarkpoolState } from "darkpoolv2-lib/DarkpoolState.sol";
 import { SettlementLib } from "./SettlementLib.sol";
 import { SettlementVerification } from "./SettlementVerification.sol";
@@ -96,14 +97,9 @@ library ExternalSettlementLib {
         uint256 numDeposits = SettlementBundleLib.getNumDeposits(internalPartySettlementBundle) + 1;
         uint256 numWithdrawals = SettlementBundleLib.getNumWithdrawals(internalPartySettlementBundle) + 1;
         uint256 proofCapacity = SettlementBundleLib.getNumProofs(internalPartySettlementBundle);
+        uint256 proofLinkingCapacity = SettlementBundleLib.getNumProofLinkingArguments(internalPartySettlementBundle);
 
-        return
-            SettlementContextLib.newContext(
-                numDeposits,
-                numWithdrawals,
-                proofCapacity,
-                0 /* proof linking capacity */
-            );
+        return SettlementContextLib.newContext(numDeposits, numWithdrawals, proofCapacity, proofLinkingCapacity);
     }
 
     /// @notice Allocate transfers to settle an external party's obligation into the settlement context
@@ -160,6 +156,10 @@ library ExternalSettlementLib {
             );
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
             NativeSettledPrivateIntentLib.executeBoundedMatch(
+                matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, hasher, vkeys, state
+            );
+        } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT) {
+            RenegadeSettledPrivateIntentLib.executeBoundedMatch(
                 matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, hasher, vkeys, state
             );
         } else {

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -182,7 +182,7 @@ library RenegadeSettledPrivateIntentLib {
     /// @param state The darkpool state containing all storage references
     /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
     /// The balance constraint is implicitly checked by transferring into the darkpool.
-    function executeBounded(
+    function executeBoundedMatch(
         BoundedMatchResultBundle calldata matchBundle,
         SettlementObligation memory obligation,
         SettlementBundle calldata settlementBundle,

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateIntent.sol
@@ -7,6 +7,11 @@ import {
     RenegadeSettledIntentBundle,
     PrivateIntentPrivateBalanceBundleLib
 } from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
+import {
+    RenegadeSettledIntentBoundedFirstFillBundle,
+    RenegadeSettledIntentBoundedBundle,
+    PrivateIntentPrivateBalanceBoundedLib
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol";
 import { OutputBalanceBundle, OutputBalanceBundleLib } from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
 import { ObligationBundle, ObligationLib } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
@@ -14,6 +19,7 @@ import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.so
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
 
 /// @title Renegade Settled Private Intent Library
 /// @author Renegade Eng
@@ -24,6 +30,8 @@ library RenegadeSettledPrivateIntentLib {
     using PrivateIntentPrivateBalanceBundleLib for SettlementBundle;
     using PrivateIntentPrivateBalanceBundleLib for RenegadeSettledIntentFirstFillBundle;
     using PrivateIntentPrivateBalanceBundleLib for RenegadeSettledIntentBundle;
+    using PrivateIntentPrivateBalanceBoundedLib for RenegadeSettledIntentBoundedFirstFillBundle;
+    using PrivateIntentPrivateBalanceBoundedLib for RenegadeSettledIntentBoundedBundle;
     using SettlementContextLib for SettlementContext;
     using DarkpoolStateLib for DarkpoolState;
     using ObligationLib for ObligationBundle;
@@ -153,6 +161,136 @@ library RenegadeSettledPrivateIntentLib {
 
         // 3. Validate the output balance validity
         PrivateIntentPrivateBalanceBundleLib.authorizeAndUpdateOutputBalance(
+            netReceiveAmount,
+            bundle.settlementStatement,
+            bundle.outputBalanceBundle,
+            bundle.settlementProof,
+            settlementContext,
+            vkeys,
+            hasher,
+            state
+        );
+    }
+
+    /// @notice Execute a renegade settled private intent bundle with bounded settlement
+    /// @param matchBundle The bounded match result bundle to execute the settlement bundle for
+    /// @param obligation The settlement obligation derived from the bounded match result
+    /// @param settlementBundle The settlement bundle to execute
+    /// @param settlementContext The settlement context to which we append post-execution updates.
+    /// @param hasher The hasher to use for hashing
+    /// @param vkeys The contract storing the verification keys
+    /// @param state The darkpool state containing all storage references
+    /// @dev As in the natively-settled public intent case, no balance obligation constraints are checked here.
+    /// The balance constraint is implicitly checked by transferring into the darkpool.
+    function executeBounded(
+        BoundedMatchResultBundle calldata matchBundle,
+        SettlementObligation memory obligation,
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        IHasher hasher,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        if (settlementBundle.isFirstFill) {
+            executeBoundedFirstFill(matchBundle, obligation, settlementBundle, settlementContext, hasher, vkeys, state);
+        } else {
+            executeBoundedSubsequentFill(
+                matchBundle, obligation, settlementBundle, settlementContext, hasher, vkeys, state
+            );
+        }
+    }
+
+    /// @notice Execute the state updates necessary to settle the bundle for a first fill with bounded settlement
+    /// @param matchBundle The bounded match result bundle to execute the settlement bundle for
+    /// @param obligation The settlement obligation derived from the bounded match result
+    /// @param settlementBundle The settlement bundle to execute
+    /// @param settlementContext The settlement context to which we append post-execution updates.
+    /// @param hasher The hasher to use for hashing
+    /// @param vkeys The contract storing the verification keys
+    /// @param state The darkpool state containing all storage references
+    function executeBoundedFirstFill(
+        BoundedMatchResultBundle calldata matchBundle,
+        SettlementObligation memory obligation,
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        IHasher hasher,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Decode the bundle data
+        RenegadeSettledIntentBoundedFirstFillBundle memory bundle =
+            PrivateIntentPrivateBalanceBoundedLib.decodeRenegadeSettledIntentBundleDataFirstFill(settlementBundle);
+
+        // 1. Validate the bounded match result settlement
+        // The methods below may modify the memory state of the statement, so we append the proof first
+        PrivateIntentPrivateBalanceBoundedLib.verifySettlement(
+            matchBundle.permit.matchResult, bundle.settlementStatement, bundle.settlementProof, vkeys, settlementContext
+        );
+
+        // Pay fees to the relayer and protocol, and compute the trader's receive amount net of fees
+        uint256 netReceiveAmount = PrivateIntentPrivateBalanceBoundedLib.applyFees(
+            bundle.settlementStatement, obligation, state, settlementContext
+        );
+
+        // 2. Validate the intent and input (capitalizing) balance authorization
+        bundle.authorizeAndUpdateIntentAndBalance(obligation.amountIn, settlementContext, vkeys, hasher, state);
+
+        // 3. Validate the output balance validity
+        PrivateIntentPrivateBalanceBoundedLib.authorizeAndUpdateOutputBalance(
+            netReceiveAmount,
+            bundle.settlementStatement,
+            bundle.outputBalanceBundle,
+            bundle.settlementProof,
+            settlementContext,
+            vkeys,
+            hasher,
+            state
+        );
+    }
+
+    /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill with bounded settlement
+    /// @param matchBundle The bounded match result bundle to execute the settlement bundle for
+    /// @param obligation The settlement obligation derived from the bounded match result
+    /// @param settlementBundle The settlement bundle to execute
+    /// @param settlementContext The settlement context to which we append post-execution updates.
+    /// @param hasher The hasher to use for hashing
+    /// @param vkeys The contract storing the verification keys
+    /// @param state The darkpool state containing all storage references
+    function executeBoundedSubsequentFill(
+        BoundedMatchResultBundle calldata matchBundle,
+        SettlementObligation memory obligation,
+        SettlementBundle calldata settlementBundle,
+        SettlementContext memory settlementContext,
+        IHasher hasher,
+        IVkeys vkeys,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Decode the bundle data
+        RenegadeSettledIntentBoundedBundle memory bundle =
+            PrivateIntentPrivateBalanceBoundedLib.decodeRenegadeSettledIntentBundleData(settlementBundle);
+
+        // 1. Validate the obligation settlement
+        // The methods below may modify the memory state of the statement, so we append the proof first
+        PrivateIntentPrivateBalanceBoundedLib.verifySettlement(
+            matchBundle.permit.matchResult, bundle.settlementStatement, bundle.settlementProof, vkeys, settlementContext
+        );
+
+        // Pay fees to the relayer and protocol, and compute the trader's receive amount net of fees
+        uint256 netReceiveAmount = PrivateIntentPrivateBalanceBoundedLib.applyFees(
+            bundle.settlementStatement, obligation, state, settlementContext
+        );
+
+        // 2. Validate the intent and input (capitalizing) balance authorization
+        bundle.authorizeAndUpdateIntentAndBalance(obligation.amountIn, settlementContext, vkeys, hasher, state);
+
+        // 3. Validate the output balance validity
+        PrivateIntentPrivateBalanceBoundedLib.authorizeAndUpdateOutputBalance(
             netReceiveAmount,
             bundle.settlementStatement,
             bundle.outputBalanceBundle,

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol
@@ -1,0 +1,863 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import {
+    PlonkProof,
+    LinkingProof,
+    VerificationKey,
+    ProofLinkingInstance,
+    ProofLinkingVK
+} from "renegade-lib/verifier/Types.sol";
+
+import { CommitmentLib } from "darkpoolv2-lib/Commitments.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { FeeRate, FeeRateLib, FeeTake, FeeTakeLib } from "darkpoolv2-types/Fee.sol";
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import {
+    RenegadeSettledIntentAuthBundleFirstFill,
+    RenegadeSettledIntentAuthBundle,
+    SignatureWithNonce,
+    SignatureWithNonceLib,
+    PrivateIntentPrivateBalanceAuthBundleLib
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import {
+    OutputBalanceBundle,
+    OutputBalanceBundleLib,
+    NewBalanceBundle,
+    ExistingBalanceBundle,
+    OutputBalanceBundleType
+} from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
+import { IntentAndBalanceBoundedSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
+import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
+import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    IntentAndBalanceValidityStatementFirstFill,
+    IntentAndBalanceValidityStatement,
+    NewOutputBalanceValidityStatement,
+    OutputBalanceValidityStatement
+} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import {
+    IntentPublicShare,
+    IntentPublicShareLib,
+    IntentPreMatchShare,
+    IntentPreMatchShareLib
+} from "darkpoolv2-types/Intent.sol";
+import { PostMatchBalanceShare, PostMatchBalanceShareLib } from "darkpoolv2-types/Balance.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
+import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
+
+// ----------------
+// | Bundle Types |
+// ----------------
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_PRIVATE_INTENT` bundle on the first fill
+/// with bounded settlement (min/max amount constraints)
+struct RenegadeSettledIntentBoundedFirstFillBundle {
+    /// @dev The private intent authorization payload with signature attached
+    RenegadeSettledIntentAuthBundleFirstFill auth;
+    /// @dev The calldata bundle containing a proof of output balance validity
+    OutputBalanceBundle outputBalanceBundle;
+    /// @dev The statement of intent and balance public settlement
+    IntentAndBalanceBoundedSettlementStatement settlementStatement;
+    /// @dev The proof of intent and balance public settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+    // TODO: Add bounded settlement specific fields (min/max amounts, bounded match result, etc.)
+}
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_INTENT` bundle with bounded settlement
+struct RenegadeSettledIntentBoundedBundle {
+    /// @dev The private intent authorization payload with signature attached
+    RenegadeSettledIntentAuthBundle auth;
+    /// @dev The calldata bundle containing a proof of output balance validity
+    OutputBalanceBundle outputBalanceBundle;
+    /// @dev The statement of intent and balance public settlement
+    IntentAndBalanceBoundedSettlementStatement settlementStatement;
+    /// @dev The proof of intent and balance public settlement
+    PlonkProof settlementProof;
+    /// @dev The proof linking the authorization and settlement proofs
+    LinkingProof authSettlementLinkingProof;
+    // TODO: Add bounded settlement specific fields (min/max amounts, bounded match result, etc.)
+}
+
+// -----------
+// | Library |
+// -----------
+
+/// @title Private Intent Private Balance Bounded Settlement Library
+/// @author Renegade Eng
+/// @notice Library for decoding, computing commitments, and extracting values from private intent, private balance
+/// bundles using bounded settlement (with min/max amount constraints).
+library PrivateIntentPrivateBalanceBoundedLib {
+    using BN254 for BN254.ScalarField;
+    using IntentPublicShareLib for IntentPublicShare;
+    using IntentPreMatchShareLib for IntentPreMatchShare;
+    using PostMatchBalanceShareLib for PostMatchBalanceShare;
+    using SignatureWithNonceLib for SignatureWithNonce;
+    using SettlementContextLib for SettlementContext;
+    using DarkpoolStateLib for DarkpoolState;
+    using PublicInputsLib for IntentAndBalanceValidityStatementFirstFill;
+    using PublicInputsLib for IntentAndBalanceValidityStatement;
+    using PublicInputsLib for NewOutputBalanceValidityStatement;
+    using PublicInputsLib for OutputBalanceValidityStatement;
+    using PublicInputsLib for IntentAndBalanceBoundedSettlementStatement;
+    using SettlementObligationLib for SettlementObligation;
+    using BoundedMatchResultLib for BoundedMatchResult;
+    using FeeRateLib for FeeRate;
+    using FeeTakeLib for FeeTake;
+    using OutputBalanceBundleLib for OutputBalanceBundle;
+
+    // ----------
+    // | Decode |
+    // ----------
+
+    /// @notice Decode a Renegade settled private intent settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledIntentBundleDataFirstFill(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledIntentBoundedFirstFillBundle memory bundleData)
+    {
+        bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledIntentBoundedFirstFillBundle));
+    }
+
+    /// @notice Decode a Renegade settled private intent settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledIntentBundleData(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledIntentBoundedBundle memory bundleData)
+    {
+        bool validType = !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledIntentBoundedBundle));
+    }
+
+    // ----------------------------------
+    // | Intent & Input Balance Updates |
+    // ----------------------------------
+
+    /// @notice Authorize and update the intent and capitalizing balance for a Renegade settled private intent bundle on
+    /// its first fill
+    /// @param bundleData The bundle to check validity for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param settlementContext The settlement context to check validity for
+    /// @param vkeys The contract storing the verification keys
+    /// @param hasher The hasher contract
+    /// @param state The state to use for verification
+    function authorizeAndUpdateIntentAndBalance(
+        RenegadeSettledIntentBoundedFirstFillBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        RenegadeSettledIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
+
+        // Validate the Merkle root used to authorize the input balance
+        state.assertRootInHistory(authBundle.statement.merkleRoot);
+
+        // Verify the intent signature
+        _verifyIntentSignature(authBundle, state);
+
+        // Push the validity proof to the settlement context
+        pushValidityProof(
+            authBundle.statement.statementSerialize(),
+            authBundle.validityProof,
+            bundleData.settlementProof,
+            vkeys.intentAndBalanceFirstFillValidityKeys(),
+            vkeys.intentAndBalanceSettlement0LinkingKey(),
+            bundleData.authSettlementLinkingProof,
+            settlementContext
+        );
+
+        // Rotate the intent and balance state elements to their updated versions
+        _updateIntentAndBalance(bundleData, internalPartyAmountIn, state, hasher);
+    }
+
+    /// @notice Authorize and update the intent and capitalizing balance for a Renegade settled private intent bundle on
+    /// subsequent fill
+    /// @dev Note that we don't need to verify the owner signature here. The presence of the intent in the Merkle tree
+    /// implies that the owner's signature has already been verified (in a previous fill). So in this case, we need only
+    /// verify the proof attached to the bundle.
+    /// @param bundleData The bundle to authorize
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param settlementContext The settlement context to authorize the intent for
+    /// @param vkeys The contract storing the verification keys
+    /// @param hasher The hasher contract
+    /// @param state The state to use for authorization
+    function authorizeAndUpdateIntentAndBalance(
+        RenegadeSettledIntentBoundedBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Validate the Merkle roots used for the input balance and intent
+        state.assertRootInHistory(bundleData.auth.statement.intentMerkleRoot);
+        state.assertRootInHistory(bundleData.auth.statement.balanceMerkleRoot);
+
+        // Push a validity proof to the settlement context
+        pushValidityProof(
+            bundleData.auth.statement.statementSerialize(),
+            bundleData.auth.validityProof,
+            bundleData.settlementProof,
+            vkeys.intentAndBalanceValidityKeys(),
+            vkeys.intentAndBalanceSettlement0LinkingKey(),
+            bundleData.authSettlementLinkingProof,
+            settlementContext
+        );
+
+        // Rotate the intent and balance state elements to their updated versions
+        _updateIntentAndBalance(bundleData, internalPartyAmountIn, state, hasher);
+    }
+
+    /// @notice Update the intent and input balance on the first fill after authorization
+    /// @param bundle The bundle to update the intent for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param state The state to use for the update
+    /// @param hasher The hasher contract
+    function _updateIntentAndBalance(
+        RenegadeSettledIntentBoundedFirstFillBundle memory bundle,
+        uint256 internalPartyAmountIn,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        // 1. Nullify the balance state
+        BN254.ScalarField nullifier = bundle.auth.statement.oldBalanceNullifier;
+        state.spendNullifier(nullifier);
+
+        // 2. Insert commitments to the updated intent and balance into the Merkle tree
+        uint256 merkleDepth = bundle.auth.merkleDepth;
+        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(bundle, internalPartyAmountIn, hasher);
+        BN254.ScalarField newBalanceCommitment = computeFullBalanceCommitment(bundle, internalPartyAmountIn, hasher);
+        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+
+        // 3. Emit recovery IDs for the intent and balance
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundle.auth.statement;
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+    }
+
+    /// @notice Update the intent and input balance on a subsequent fill
+    /// @param bundle The bundle to update the intent for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param state The state to use for the update
+    /// @param hasher The hasher contract
+    function _updateIntentAndBalance(
+        RenegadeSettledIntentBoundedBundle memory bundle,
+        uint256 internalPartyAmountIn,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        // 1. Nullify both the balance and intent states
+        BN254.ScalarField balanceNullifier = bundle.auth.statement.oldBalanceNullifier;
+        BN254.ScalarField intentNullifier = bundle.auth.statement.oldIntentNullifier;
+        state.spendNullifier(balanceNullifier);
+        state.spendNullifier(intentNullifier);
+
+        // 2. Insert commitments to the updated intent and balance into the Merkle tree
+        uint256 merkleDepth = bundle.auth.merkleDepth;
+        BN254.ScalarField newIntentCommitment = computeFullIntentCommitment(bundle, internalPartyAmountIn, hasher);
+        BN254.ScalarField newBalanceCommitment = computeFullBalanceCommitment(bundle, internalPartyAmountIn, hasher);
+        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+
+        // 3. Emit recovery IDs for the intent and balance
+        IntentAndBalanceValidityStatement memory authStatement = bundle.auth.statement;
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+    }
+
+    /// @notice Verify the signature on the intent authorization bundle for a first fill
+    /// @param bundleData The bundle to check validity for
+    /// @param state The state to use for verification
+    function _verifyIntentSignature(
+        RenegadeSettledIntentAuthBundleFirstFill memory bundleData,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Verify the owner signature and spend the nonce
+        bytes32 digest = PrivateIntentPrivateBalanceAuthBundleLib.getOwnerSignatureDigest(bundleData);
+        address signer = bundleData.statement.oneTimeAuthorizingAddress;
+
+        bool valid = bundleData.ownerSignature.verifyPrehashed(signer, digest);
+        if (!valid) revert IDarkpoolV2.InvalidOwnerSignature();
+        state.spendNonce(bundleData.ownerSignature.nonce);
+    }
+
+    // --------------------------------
+    // | Output Balance Authorization |
+    // --------------------------------
+
+    /// @notice Authorize and update the output balance for a Renegade settled private intent bundle
+    /// @dev The output balance receives the obligation's output amount
+    /// @dev A settlement *may* create a new output balance, or it may use an existing balance. These two cases
+    /// correspond to the helpers below
+    /// @param netReceiveAmount The net receive amount of the trader after fees have been applied
+    /// @param settlementStatement The settlement statement to use for the update
+    /// @param outputBalanceBundle The output balance's authorization bundle
+    /// @param settlementProof The settlement proof; included here to proof-link the output balance authorization into
+    /// the settlement proof
+    /// @param settlementContext The settlement context to authorize the output balance for
+    /// @param vkeys The verification keys to use for authorization
+    /// @param hasher The hasher contract
+    /// @param state The state to use for authorization
+    function authorizeAndUpdateOutputBalance(
+        uint256 netReceiveAmount,
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        OutputBalanceBundle memory outputBalanceBundle,
+        PlonkProof memory settlementProof,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        if (outputBalanceBundle.bundleType == OutputBalanceBundleType.NEW_BALANCE) {
+            _authorizeAndUpdateNewOutputBalance(
+                netReceiveAmount,
+                outputBalanceBundle,
+                settlementStatement,
+                settlementProof,
+                settlementContext,
+                vkeys,
+                hasher,
+                state
+            );
+        } else if (outputBalanceBundle.bundleType == OutputBalanceBundleType.EXISTING_BALANCE) {
+            _authorizeAndUpdateExistingOutputBalance(
+                netReceiveAmount,
+                outputBalanceBundle,
+                settlementStatement,
+                settlementProof,
+                settlementContext,
+                vkeys,
+                hasher,
+                state
+            );
+        } else {
+            revert IDarkpoolV2.InvalidOutputBalanceBundleType();
+        }
+    }
+
+    /// @notice Authorize a new output balance for a Renegade settled private intent bundle
+    /// @dev A new output balance is created as part of the settlement
+    /// @param netReceiveAmount The net receive amount of the trader after fees have been applied
+    /// @param bundle The output balance's authorization bundle
+    /// @param settlementStatement The settlement statement to use for the update
+    /// @param settlementProof The settlement proof; included here to proof-link the output balance authorization into
+    /// the settlement proof
+    /// @param settlementContext The settlement context to authorize the output balance for
+    /// @param vkeys The verification keys to use for authorization
+    /// @param hasher The hasher contract
+    /// @param state The state to use for the update
+    function _authorizeAndUpdateNewOutputBalance(
+        uint256 netReceiveAmount,
+        OutputBalanceBundle memory bundle,
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        PlonkProof memory settlementProof,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Verify the output balance validity proof
+        NewBalanceBundle memory newBalanceBundle = bundle.decodeNewBalanceBundle();
+        pushValidityProof(
+            newBalanceBundle.statement.statementSerialize(),
+            bundle.proof,
+            settlementProof,
+            vkeys.newOutputBalanceValidityKeys(),
+            // We use the first party's link group layout for this linking argument regardless of the party ID
+            // because in this settlement ring, the settlement proof is per-party, and only has link groups for one
+            // output balance.
+            vkeys.outputBalanceSettlement0LinkingKey(),
+            bundle.settlementLinkingProof,
+            settlementContext
+        );
+
+        // Update the output balance's contract state
+        _updateNewOutputBalance(netReceiveAmount, newBalanceBundle, bundle, settlementStatement, hasher, state);
+    }
+
+    /// @notice Authorize an existing output balance for a Renegade settled private intent bundle
+    /// @dev An existing output balance is used as part of the settlement
+    /// @param netReceiveAmount The net receive amount of the trader after fees have been applied
+    /// @param bundle The output balance's authorization bundle
+    /// @param settlementStatement The settlement statement to use for the update
+    /// @param settlementProof The settlement proof; included here to proof-link the output balance authorization into
+    /// the settlement proof
+    /// @param settlementContext The settlement context to authorize the output balance for
+    /// @param vkeys The verification keys to use for authorization
+    /// @param hasher The hasher contract
+    /// @param state The state to use for authorization
+    function _authorizeAndUpdateExistingOutputBalance(
+        uint256 netReceiveAmount,
+        OutputBalanceBundle memory bundle,
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        PlonkProof memory settlementProof,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        ExistingBalanceBundle memory existingBalanceBundle = bundle.decodeExistingBalanceBundle();
+
+        // Validate the Merkle root used for the output balance
+        state.assertRootInHistory(existingBalanceBundle.statement.merkleRoot);
+
+        // Push the validity proof to the settlement context alongside the proof linking argument
+        pushValidityProof(
+            existingBalanceBundle.statement.statementSerialize(),
+            bundle.proof,
+            settlementProof,
+            vkeys.outputBalanceValidityKeys(),
+            // We use the first party's link group layout for this linking argument regardless of the party ID
+            // because in this settlement ring, the settlement proof is per-party, and only has link groups for one
+            // output balance.
+            vkeys.outputBalanceSettlement0LinkingKey(),
+            bundle.settlementLinkingProof,
+            settlementContext
+        );
+
+        // Update the output balance's contract state
+        _updateExistingOutputBalance(
+            netReceiveAmount, existingBalanceBundle, bundle, settlementStatement, hasher, state
+        );
+    }
+
+    /// @notice Update a new output balance's contract state
+    /// @param netReceiveAmount The net receive amount of the trader after fees have been applied
+    /// @param bundle The new balance bundle
+    /// @param outputBalanceBundle The output balance's authorization bundle
+    /// @param settlementStatement The settlement statement to use for the update
+    /// @param hasher The hasher contract
+    /// @param state The state to use for the update
+    function _updateNewOutputBalance(
+        uint256 netReceiveAmount,
+        NewBalanceBundle memory bundle,
+        OutputBalanceBundle memory outputBalanceBundle,
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Compute the commitment to the output balance after the settlement is applied
+        // Fees are already paid directly as ERC20 transfers for this settlement bundle type, so we only need to update
+        // the balance's `amount` share.
+        BN254.ScalarField newBalanceCommitment =
+            computeFullNewOutputBalanceCommitment(netReceiveAmount, bundle, settlementStatement, hasher);
+        state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, newBalanceCommitment, hasher);
+
+        // Emit a recovery ID for the output balance
+        BN254.ScalarField recoveryId = bundle.statement.recoveryId;
+        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+    }
+
+    /// @notice Update an existing output balance's contract state
+    /// @param netReceiveAmount The net receive amount of the trader after fees have been applied
+    /// @param bundle The existing balance bundle
+    /// @param outputBalanceBundle The output balance's authorization bundle
+    /// @param settlementStatement The settlement statement to use for the update
+    /// @param hasher The hasher contract
+    /// @param state The state to use for the update
+    function _updateExistingOutputBalance(
+        uint256 netReceiveAmount,
+        ExistingBalanceBundle memory bundle,
+        OutputBalanceBundle memory outputBalanceBundle,
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Nullify the previous version of the balance
+        state.spendNullifier(bundle.statement.oldBalanceNullifier);
+
+        // Compute the commitment to the output balance after the settlement is applied
+        // Fees are already paid directly as ERC20 transfers for this settlement bundle type, so we only need to update
+        // the balance's `amount` share.
+        BN254.ScalarField newBalanceCommitment =
+            computeFullExistingOutputBalanceCommitment(netReceiveAmount, bundle, settlementStatement, hasher);
+        state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, newBalanceCommitment, hasher);
+
+        // Emit a recovery ID for the output balance
+        BN254.ScalarField recoveryId = bundle.statement.recoveryId;
+        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+    }
+
+    // ---------------------------
+    // | Commitments Computation |
+    // ---------------------------
+
+    /// @notice Compute the full commitment to the updated intent for a Renegade settled private intent bundle
+    /// on its first fill
+    /// @dev The circuit proves the validity of the private share commitment, so we must:
+    /// 1. Compute the updated public share which results from applying the settlement to the leaked `amountIn` share.
+    /// 2. Compute the full commitment to the updated intent from the private commitment and public shares.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        RenegadeSettledIntentBoundedFirstFillBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // 1. Compute the updated public share of the amount in field
+        BN254.ScalarField newAmountInShare = settlementStatement.amountPublicShare;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
+        newAmountInShare = newAmountInShare.sub(settlementAmount);
+
+        // 2. Create the full updated intent public share
+        IntentPublicShare memory newIntentPublicShare =
+            authStatement.intentPublicShare.toFullPublicShare(newAmountInShare);
+        uint256[] memory publicShares = newIntentPublicShare.scalarSerialize();
+
+        // 3. Compute the full commitment to the updated intent
+        newIntentCommitment = CommitmentLib.computeCommitmentWithPublicShares(
+            authStatement.intentPrivateShareCommitment, publicShares, hasher
+        );
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a Renegade settled private intent bundle
+    /// on its first fill
+    /// @dev The circuit proves the validity of a commitment to all fields of the balance which don't change in the
+    /// match,
+    /// so we must:
+    /// 1. Compute the updated public shares of the balance
+    /// 2. Compute the full commitment to the updated balance from the partial commitment and public shares.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledIntentBoundedFirstFillBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // 1. Compute the updated public shares of the balance
+        // The fees don't update for the input balance, so we leave them as is
+        PostMatchBalanceShare memory newInBalancePublicShares = settlementStatement.inBalancePublicShares;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
+        newInBalancePublicShares.amount = newInBalancePublicShares.amount.sub(settlementAmount);
+
+        // 2. Resume the partial commitment with updated shares
+        uint256[] memory remainingShares = newInBalancePublicShares.scalarSerialize();
+        newBalanceCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.balancePartialCommitment, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a Renegade settled private intent bundle
+    /// on its subsequent fill
+    /// @dev The partial commitment computed in the circuit is a commitment to all shares except the public share of the
+    /// `amountIn` field, which is updated in a match settlement. We must therefore apply the settlement to the
+    /// `amountIn` public share and resume the commitment.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        RenegadeSettledIntentBoundedBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // Compute the updated public share of the amount in field
+        BN254.ScalarField newAmountInShare = settlementStatement.amountPublicShare;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
+        newAmountInShare = newAmountInShare.sub(settlementAmount);
+
+        // Resume the partial commitment with updated shares
+        uint256[] memory remainingShares = new uint256[](1);
+        remainingShares[0] = BN254.ScalarField.unwrap(newAmountInShare);
+        newIntentCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.newIntentPartialCommitment, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a Renegade settled private intent bundle
+    /// on its subsequent fill
+    /// @dev The partial commitment computed in the circuit is a commitment to all shares except the public share of the
+    /// `amount` field, which is updated in a match settlement. We must therefore apply the settlement to the
+    /// `amount` public share and resume the commitment.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param internalPartyAmountIn The internal party's input amount (determined at runtime)
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledIntentBoundedBundle memory bundleData,
+        uint256 internalPartyAmountIn,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement = bundleData.settlementStatement;
+
+        // Compute the updated public shares of the balance
+        PostMatchBalanceShare memory newInBalancePublicShares = settlementStatement.inBalancePublicShares;
+        BN254.ScalarField settlementAmount = BN254.ScalarField.wrap(internalPartyAmountIn);
+        newInBalancePublicShares.amount = newInBalancePublicShares.amount.sub(settlementAmount);
+
+        // Resume the partial commitment with updated shares
+        uint256[] memory remainingShares = newInBalancePublicShares.scalarSerialize();
+        newBalanceCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.balancePartialCommitment, hasher);
+    }
+
+    /// @notice Compute the full commitment to a new output balance for a Renegade settled private intent
+    /// bundle; after updating the balance's amount share to reflect the settlement
+    /// @param netReceiveAmount The net receive amount of the trader after fees have been applied
+    /// @param bundle The output balance's authorization bundle
+    /// @param settlementStatement The settlement statement to use for the update
+    /// @param hasher The hasher contract
+    /// @return newBalanceCommitment The full commitment to the new output balance
+    function computeFullNewOutputBalanceCommitment(
+        uint256 netReceiveAmount,
+        NewBalanceBundle memory bundle,
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        PostMatchBalanceShare memory newBalancePublicShares = settlementStatement.outBalancePublicShares;
+        BN254.ScalarField netReceiveAmountScalar = BN254.ScalarField.wrap(netReceiveAmount);
+        newBalancePublicShares.amount = newBalancePublicShares.amount.add(netReceiveAmountScalar);
+
+        uint256[] memory remainingShares = newBalancePublicShares.scalarSerialize();
+        newBalanceCommitment = CommitmentLib.computeResumableCommitment(
+            remainingShares, bundle.statement.newBalancePartialCommitment, hasher
+        );
+    }
+
+    /// @notice Compute the full commitment to an existing output balance for a Renegade settled private intent
+    /// bundle; after updating the balance's amount share to reflect the settlement
+    /// @param netReceiveAmount The net receive amount of the trader after fees have been applied
+    /// @param bundle The output balance's authorization bundle
+    /// @param settlementStatement The settlement statement to use for the update
+    /// @param hasher The hasher contract
+    /// @return newBalanceCommitment The full commitment to the existing output balance
+    function computeFullExistingOutputBalanceCommitment(
+        uint256 netReceiveAmount,
+        ExistingBalanceBundle memory bundle,
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        PostMatchBalanceShare memory newBalancePublicShares = settlementStatement.outBalancePublicShares;
+        BN254.ScalarField netReceiveAmountScalar = BN254.ScalarField.wrap(netReceiveAmount);
+        newBalancePublicShares.amount = newBalancePublicShares.amount.add(netReceiveAmountScalar);
+
+        uint256[] memory remainingShares = newBalancePublicShares.scalarSerialize();
+        newBalanceCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, bundle.statement.newPartialCommitment, hasher);
+    }
+
+    // -------------------
+    // | Validity Proofs |
+    // -------------------
+
+    /// @notice Push a validity proof to the settlement context
+    /// @dev This method also pushes a proof linking argument between the validity proof and the settlement proof
+    /// @param publicInputs The public inputs to the validity proof
+    /// @param validityProof The validity proof to push
+    /// @param settlementProof The settlement proof to push
+    /// @param validityVKey The verification key to use for the validity proof
+    /// @param linkingVKey The verification key to use for the proof linking argument
+    /// @param linkingProof The linking proof between the validity and settlement proofs
+    /// @param settlementContext The settlement context to push to
+    function pushValidityProof(
+        BN254.ScalarField[] memory publicInputs,
+        PlonkProof memory validityProof,
+        PlonkProof memory settlementProof,
+        VerificationKey memory validityVKey,
+        ProofLinkingVK memory linkingVKey,
+        LinkingProof memory linkingProof,
+        SettlementContext memory settlementContext
+    )
+        internal
+        pure
+    {
+        settlementContext.pushProof(publicInputs, validityProof, validityVKey);
+        ProofLinkingInstance memory proofLinkingArgument = ProofLinkingInstance({
+            wireComm0: validityProof.wireComms[0],
+            wireComm1: settlementProof.wireComms[0],
+            proof: linkingProof,
+            vk: linkingVKey
+        });
+        settlementContext.pushProofLinkingArgument(proofLinkingArgument);
+    }
+
+    // ---------------------
+    // | Settlement Proofs |
+    // ---------------------
+
+    /// @notice Push a settlement proof to the settlement context
+    /// @param boundedMatchResult The bounded match result to validate. The statement has a copy of this bounded match
+    /// result, which must match the value passed in here.
+    /// @param statement The settlement statement
+    /// @param proof The settlement proof to push
+    /// @param vkeys The verification keys contract
+    /// @param settlementContext The settlement context to push to
+    function verifySettlement(
+        BoundedMatchResult memory boundedMatchResult,
+        IntentAndBalanceBoundedSettlementStatement memory statement,
+        PlonkProof memory proof,
+        IVkeys vkeys,
+        SettlementContext memory settlementContext
+    )
+        internal
+        view
+    {
+        // The bounded match result in the settlement statement must match the one from the bounded match result bundle
+        bool matchResultMatches = boundedMatchResult.isEqualTo(statement.boundedMatchResult);
+        if (!matchResultMatches) revert IDarkpoolV2.InvalidBoundedMatchResult();
+
+        // Push the settlement proof to the settlement context
+        BN254.ScalarField[] memory publicInputs = statement.statementSerialize();
+        VerificationKey memory vk = vkeys.intentAndBalancePublicSettlementKeys();
+        settlementContext.pushProof(publicInputs, proof, vk);
+    }
+
+    // -------------
+    // | Transfers |
+    // -------------
+
+    /// @notice Apply fees to an obligation and allocate transfers to settle the fees
+    /// @param settlementStatement The settlement statement to apply the fees to
+    /// @param obligation The obligation to apply the fees to
+    /// @param state The darkpool state containing all storage references
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @return traderNetReceiveAmount The net receive amount after fees
+    function applyFees(
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        SettlementObligation memory obligation,
+        DarkpoolState storage state,
+        SettlementContext memory settlementContext
+    )
+        internal
+        view
+        returns (uint256 traderNetReceiveAmount)
+    {
+        // Transfer fees to the relayer and protocol collection wallets
+        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) =
+            _addFeeTransfers(settlementStatement, obligation, state, settlementContext);
+
+        // Calculate the net receive amount after fees
+        uint256 totalFee = relayerFeeTake.fee + protocolFeeTake.fee;
+        traderNetReceiveAmount = obligation.amountOut - totalFee;
+    }
+
+    /// @notice Allocate the transfers to settle the obligation
+    /// @dev We transfer fees out of the balance immediately. This is done to avoid the need to update the balance later
+    /// to pay fees. It leaks no extra privacy, because the settlement obligation in this case is known.
+    /// @param settlementStatement The settlement statement to allocate the transfers for
+    /// @param obligation The obligation to allocate the transfers for
+    /// @param state The darkpool state containing all storage references
+    /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @return relayerFeeTake The relayer fee take
+    /// @return protocolFeeTake The protocol fee take
+    function _addFeeTransfers(
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        SettlementObligation memory obligation,
+        DarkpoolState storage state,
+        SettlementContext memory settlementContext
+    )
+        internal
+        view
+        returns (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake)
+    {
+        (relayerFeeTake, protocolFeeTake) = _computeFeeTakes(settlementStatement, obligation, state);
+
+        // Add withdrawal transfers for the fees
+        SimpleTransfer memory relayerWithdrawal = relayerFeeTake.buildWithdrawalTransfer();
+        SimpleTransfer memory protocolWithdrawal = protocolFeeTake.buildWithdrawalTransfer();
+        settlementContext.pushWithdrawal(relayerWithdrawal);
+        settlementContext.pushWithdrawal(protocolWithdrawal);
+    }
+
+    /// @notice Compute the fee takes for the match
+    /// @param settlementStatement The settlement statement to compute the fee takes for
+    /// @param obligation The obligation to compute the fee takes for
+    /// @param state The darkpool state containing all storage references
+    /// @return relayerFeeTake The relayer fee take
+    /// @return protocolFeeTake The protocol fee take
+    function _computeFeeTakes(
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement,
+        SettlementObligation memory obligation,
+        DarkpoolState storage state
+    )
+        internal
+        view
+        returns (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake)
+    {
+        // First compute the fee rates
+        FeeRate memory relayerFeeRate = FeeRate({
+            rate: settlementStatement.internalRelayerFeeRate, recipient: settlementStatement.relayerFeeAddress
+        });
+        FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
+
+        // Then multiply the rates with the receive amount
+        uint256 receiveAmount = obligation.amountOut;
+        address receiveToken = obligation.outputToken;
+        relayerFeeTake = relayerFeeRate.computeFeeTake(receiveToken, receiveAmount);
+        protocolFeeTake = protocolFeeRate.computeFeeTake(receiveToken, receiveAmount);
+    }
+}

--- a/test/darkpool/v2/settlement/external-match/renegade-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/external-match/renegade-settled-private-intents/FullMatchTests.t.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/* solhint-disable func-name-mixedcase */
+
+import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
+import { FeeTake } from "darkpoolv2-types/Fee.sol";
+import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+
+import { BalanceSnapshots, ExpectedDifferences } from "../../SettlementTestUtils.sol";
+import { RenegadeSettledBoundedPrivateIntentTestUtils } from "./Utils.sol";
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+
+contract FullMatchTests is RenegadeSettledBoundedPrivateIntentTestUtils {
+    using FixedPointLib for FixedPoint;
+
+    function setUp() public virtual override {
+        super.setUp();
+        // Mint max amounts of the base and quote tokens to the darkpool to capitalize fee payments
+        uint256 maxAmt = 2 ** DarkpoolConstants.AMOUNT_BITS - 1;
+        baseToken.mint(address(darkpool), maxAmt);
+        quoteToken.mint(address(darkpool), maxAmt);
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @dev Create match data for a simulated trade
+    function _createMatchData(bool isFirstFill)
+        internal
+        returns (
+            SettlementObligation memory internalPartyObligation,
+            SettlementObligation memory externalPartyObligation,
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
+        )
+    {
+        // Create obligations for the trade
+        FixedPoint memory price;
+        (internalPartyObligation, externalPartyObligation, price) = createTradeObligations();
+
+        // Create bounded match result and bundle
+        BoundedMatchResult memory matchResult = createBoundedMatchResultForObligation(internalPartyObligation, price);
+        matchBundle = createBoundedMatchResultBundleWithSigners(matchResult, executor.privateKey);
+
+        // Create the internal party settlement bundle
+        internalPartySettlementBundle = createRenegadeSettledBoundedBundle(isFirstFill, matchResult, oneTimeOwner);
+
+        // Capitalize the parties for their obligations
+        // For renegade-settled, internal party's capital is in darkpool (private balances)
+        // External party uses normal EOA balances
+        capitalizeExternalParty(externalPartyObligation);
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    // --- Valid Test Cases --- //
+
+    /// @notice Test a basic bounded match settlement with first fill
+    function test_boundedMatch_firstFill() public {
+        // Create match data for first fill
+        (
+            SettlementObligation memory internalPartyObligation,
+            SettlementObligation memory externalPartyObligation,
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
+        ) =
+            _createMatchData(
+                true /* isFirstFill */
+            );
+
+        // Choose a trade size and build the actual obligations that will be used in settlement
+        (uint256 externalPartyAmountIn,) =
+            randomExternalPartyAmountIn(externalPartyObligation, matchBundle.permit.matchResult.price);
+        address recipient = externalParty.addr;
+        (SettlementObligation memory actualExternalObligation, SettlementObligation memory actualInternalObligation) =
+            buildObligationsFromMatchResult(matchBundle.permit.matchResult, externalPartyAmountIn);
+
+        // Compute fees that will be deducted from internal party's output
+        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) = computeMatchFees(actualInternalObligation);
+        uint256 totalFee = relayerFeeTake.fee + protocolFeeTake.fee;
+
+        // Set up expected differences accounting for fees
+        // Internal party: No ERC20 changes (uses darkpool private balances)
+        // External party: Normal ERC20 deposits/withdrawals
+        // Darkpool: Loses internal party's input, gains external party's input minus fees
+        ExpectedDifferences memory expectedDifferences = createEmptyExpectedDifferences();
+        expectedDifferences.party0BaseChange = 0; // Internal party uses darkpool balances
+        expectedDifferences.party0QuoteChange = 0; // Internal party uses darkpool balances
+        expectedDifferences.party1BaseChange = int256(actualExternalObligation.amountOut);
+        expectedDifferences.party1QuoteChange = -int256(actualExternalObligation.amountIn);
+        expectedDifferences.relayerFeeBaseChange = 0;
+        expectedDifferences.relayerFeeQuoteChange = int256(relayerFeeTake.fee);
+        expectedDifferences.protocolFeeBaseChange = 0;
+        expectedDifferences.protocolFeeQuoteChange = int256(protocolFeeTake.fee);
+        expectedDifferences.darkpoolBaseChange = -int256(actualInternalObligation.amountIn); // Input token sent to
+        // external party
+        expectedDifferences.darkpoolQuoteChange = int256(actualExternalObligation.amountIn) - int256(totalFee); // Received
+        // from external party minus fees
+
+        // Check balances before and after settlement
+        BalanceSnapshots memory preMatch = _captureBalances();
+        vm.prank(externalParty.addr);
+        darkpool.settleExternalMatch(externalPartyAmountIn, recipient, matchBundle, internalPartySettlementBundle);
+        BalanceSnapshots memory postMatch = _captureBalances();
+        _verifyBalanceChanges(preMatch, postMatch, expectedDifferences);
+    }
+
+    /// @notice Test a bounded match settlement with subsequent fill
+    function test_boundedMatch_subsequentFill() public {
+        // Create match data for subsequent fill
+        (
+            SettlementObligation memory internalPartyObligation,
+            SettlementObligation memory externalPartyObligation,
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
+        ) =
+            _createMatchData(
+                false /* isFirstFill */
+            );
+
+        // Choose a trade size and build the actual obligations that will be used in settlement
+        (uint256 externalPartyAmountIn,) =
+            randomExternalPartyAmountIn(externalPartyObligation, matchBundle.permit.matchResult.price);
+        address recipient = externalParty.addr;
+        (SettlementObligation memory actualExternalObligation, SettlementObligation memory actualInternalObligation) =
+            buildObligationsFromMatchResult(matchBundle.permit.matchResult, externalPartyAmountIn);
+
+        // Compute fees that will be deducted from internal party's output
+        (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) = computeMatchFees(actualInternalObligation);
+        uint256 totalFee = relayerFeeTake.fee + protocolFeeTake.fee;
+
+        // Set up expected differences accounting for fees
+        // Darkpool: Loses internal party's input, gains external party's input minus fees
+        ExpectedDifferences memory expectedDifferences = createEmptyExpectedDifferences();
+        expectedDifferences.party0BaseChange = 0; // Internal party uses darkpool balances
+        expectedDifferences.party0QuoteChange = 0; // Internal party uses darkpool balances
+        expectedDifferences.party1BaseChange = int256(actualExternalObligation.amountOut);
+        expectedDifferences.party1QuoteChange = -int256(actualExternalObligation.amountIn);
+        expectedDifferences.relayerFeeBaseChange = 0;
+        expectedDifferences.relayerFeeQuoteChange = int256(relayerFeeTake.fee);
+        expectedDifferences.protocolFeeBaseChange = 0;
+        expectedDifferences.protocolFeeQuoteChange = int256(protocolFeeTake.fee);
+        expectedDifferences.darkpoolBaseChange = -int256(actualInternalObligation.amountIn); // Input token sent to
+        // external party
+        expectedDifferences.darkpoolQuoteChange = int256(actualExternalObligation.amountIn) - int256(totalFee); // Received
+        // from external party minus fees
+
+        // Check balances before and after settlement
+        BalanceSnapshots memory preMatch = _captureBalances();
+        vm.prank(externalParty.addr);
+        darkpool.settleExternalMatch(externalPartyAmountIn, recipient, matchBundle, internalPartySettlementBundle);
+        BalanceSnapshots memory postMatch = _captureBalances();
+        _verifyBalanceChanges(preMatch, postMatch, expectedDifferences);
+    }
+}
+

--- a/test/darkpool/v2/settlement/external-match/renegade-settled-private-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/renegade-settled-private-intents/Utils.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { Vm } from "forge-std/Vm.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import {
+    SignatureWithNonce,
+    RenegadeSettledIntentAuthBundleFirstFill,
+    RenegadeSettledIntentAuthBundle
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import {
+    RenegadeSettledIntentBoundedFirstFillBundle,
+    RenegadeSettledIntentBoundedBundle
+} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol";
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { IntentAndBalanceBoundedSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
+import {
+    IntentAndBalanceValidityStatementFirstFill,
+    IntentAndBalanceValidityStatement,
+    OutputBalanceValidityStatement
+} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import { IntentPreMatchShare } from "darkpoolv2-types/Intent.sol";
+import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import {
+    OutputBalanceBundle,
+    OutputBalanceBundleType,
+    ExistingBalanceBundle
+} from "darkpoolv2-types/settlement/OutputBalanceBundle.sol";
+import { ExternalMatchTestUtils } from "../Utils.sol";
+
+contract RenegadeSettledBoundedPrivateIntentTestUtils is ExternalMatchTestUtils {
+    using BoundedMatchResultLib for BoundedMatchResult;
+    using FixedPointLib for FixedPoint;
+    using DarkpoolStateLib for DarkpoolState;
+
+    // ---------
+    // | Utils |
+    // ---------
+
+    // --- Signatures --- //
+
+    /// @dev Sign the owner signature digest for a renegade settled private intent
+    /// @dev The signature is over intentAndAuthorizingAddressCommitment which combines
+    /// the intent commitment and the new one-time key hash
+    function createOwnerSignature(
+        BN254.ScalarField intentAndAuthorizingAddressCommitment,
+        uint256 signerPrivateKey
+    )
+        internal
+        returns (SignatureWithNonce memory)
+    {
+        // Hash the intent and authorizing address commitment with a random nonce
+        // This matches getOwnerSignatureDigest which hashes the single commitment
+        uint256 nonce = randomUint();
+        uint256 commitment = BN254.ScalarField.unwrap(intentAndAuthorizingAddressCommitment);
+        bytes32 digest = EfficientHashLib.hash(commitment);
+        bytes32 signatureDigest = EfficientHashLib.hash(digest, bytes32(nonce));
+
+        // Sign with the private key
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, signatureDigest);
+        return SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
+    }
+
+    // --- Bounded Settlement Statement --- //
+
+    /// @dev Create a bounded settlement statement for a given bounded match result
+    /// @param matchResult The bounded match result to create the statement for
+    /// @return statement The bounded settlement statement
+    function createBoundedSettlementStatement(BoundedMatchResult memory matchResult)
+        internal
+        returns (IntentAndBalanceBoundedSettlementStatement memory statement)
+    {
+        PostMatchBalanceShare memory inBalancePublicShares = PostMatchBalanceShare({
+            relayerFeeBalance: randomScalar(), protocolFeeBalance: randomScalar(), amount: randomScalar()
+        });
+
+        PostMatchBalanceShare memory outBalancePublicShares = PostMatchBalanceShare({
+            relayerFeeBalance: randomScalar(), protocolFeeBalance: randomScalar(), amount: randomScalar()
+        });
+
+        statement = IntentAndBalanceBoundedSettlementStatement({
+            boundedMatchResult: matchResult,
+            amountPublicShare: randomScalar(),
+            inBalancePublicShares: inBalancePublicShares,
+            outBalancePublicShares: outBalancePublicShares,
+            externalRelayerFeeRate: relayerFeeRateFixedPoint,
+            internalRelayerFeeRate: relayerFeeRateFixedPoint,
+            relayerFeeAddress: relayerFeeAddr
+        });
+    }
+
+    // --- Dummy Data --- //
+
+    /// @dev Create a dummy intent and balance validity statement (first fill)
+    function createSampleStatementFirstFill() internal returns (IntentAndBalanceValidityStatementFirstFill memory) {
+        IntentPreMatchShare memory intentPublicShare = IntentPreMatchShare({
+            inToken: randomScalar(), outToken: randomScalar(), owner: randomScalar(), minPrice: randomScalar()
+        });
+
+        BN254.ScalarField merkleRoot = darkpoolState.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+        return IntentAndBalanceValidityStatementFirstFill({
+            merkleRoot: merkleRoot,
+            intentAndAuthorizingAddressCommitment: randomScalar(),
+            intentPublicShare: intentPublicShare,
+            intentPrivateShareCommitment: randomScalar(),
+            intentRecoveryId: randomScalar(),
+            balancePartialCommitment: randomPartialCommitment(),
+            newOneTimeAddressPublicShare: randomScalar(),
+            oldBalanceNullifier: randomScalar(),
+            balanceRecoveryId: randomScalar(),
+            oneTimeAuthorizingAddress: oneTimeOwner.addr
+        });
+    }
+
+    /// @dev Create a dummy intent and balance validity statement (subsequent fill)
+    function createSampleStatement() internal returns (IntentAndBalanceValidityStatement memory) {
+        BN254.ScalarField merkleRoot = darkpoolState.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+        return IntentAndBalanceValidityStatement({
+            intentMerkleRoot: merkleRoot,
+            oldIntentNullifier: randomScalar(),
+            newIntentPartialCommitment: randomPartialCommitment(),
+            intentRecoveryId: randomScalar(),
+            balanceMerkleRoot: merkleRoot,
+            oldBalanceNullifier: randomScalar(),
+            balancePartialCommitment: randomPartialCommitment(),
+            balanceRecoveryId: randomScalar()
+        });
+    }
+
+    /// @dev Create a sample output balance bundle
+    function createSampleOutputBalanceBundle() internal returns (OutputBalanceBundle memory) {
+        BN254.ScalarField merkleRoot = darkpoolState.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+        OutputBalanceValidityStatement memory statement = OutputBalanceValidityStatement({
+            merkleRoot: merkleRoot,
+            oldBalanceNullifier: randomScalar(),
+            newPartialCommitment: randomPartialCommitment(),
+            recoveryId: randomScalar()
+        });
+
+        ExistingBalanceBundle memory existingBalanceBundle = ExistingBalanceBundle({ statement: statement });
+        return OutputBalanceBundle({
+            merkleDepth: DarkpoolConstants.DEFAULT_MERKLE_DEPTH,
+            bundleType: OutputBalanceBundleType.EXISTING_BALANCE,
+            data: abi.encode(existingBalanceBundle),
+            proof: createDummyProof(),
+            settlementLinkingProof: createDummyLinkingProof()
+        });
+    }
+
+    // --- Renegade Settled Bounded Bundle --- //
+
+    /// @dev Create a complete renegade settled bounded private intent settlement bundle
+    function createRenegadeSettledBoundedBundle(
+        bool isFirstFill,
+        BoundedMatchResult memory matchResult,
+        Vm.Wallet memory owner
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
+        if (isFirstFill) {
+            return createRenegadeSettledBoundedBundleFirstFill(merkleDepth, matchResult, owner);
+        } else {
+            return createRenegadeSettledBoundedBundleSubsequent(merkleDepth, matchResult);
+        }
+    }
+
+    /// @dev Create a renegade settled bounded private intent settlement bundle for first fill
+    function createRenegadeSettledBoundedBundleFirstFill(
+        uint256 merkleDepth,
+        BoundedMatchResult memory matchResult,
+        Vm.Wallet memory oneTimeKey
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        // Create the validity statement
+        IntentAndBalanceValidityStatementFirstFill memory validityStatement = createSampleStatementFirstFill();
+        validityStatement.oneTimeAuthorizingAddress = oneTimeKey.addr;
+
+        // Sign the owner signature digest
+        // The signature is over intentAndAuthorizingAddressCommitment which combines
+        // the intent commitment and the new one-time key hash
+        SignatureWithNonce memory ownerSignature =
+            createOwnerSignature(validityStatement.intentAndAuthorizingAddressCommitment, oneTimeKey.privateKey);
+
+        // Create auth bundle
+        RenegadeSettledIntentAuthBundleFirstFill memory auth = RenegadeSettledIntentAuthBundleFirstFill({
+            merkleDepth: merkleDepth,
+            ownerSignature: ownerSignature,
+            statement: validityStatement,
+            validityProof: createDummyProof()
+        });
+
+        // Create bounded settlement statement
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement =
+            createBoundedSettlementStatement(matchResult);
+
+        // Create output balance bundle
+        OutputBalanceBundle memory outputBalanceBundle = createSampleOutputBalanceBundle();
+
+        // Create the bundle data
+        RenegadeSettledIntentBoundedFirstFillBundle memory bundleData = RenegadeSettledIntentBoundedFirstFillBundle({
+            auth: auth,
+            outputBalanceBundle: outputBalanceBundle,
+            settlementStatement: settlementStatement,
+            settlementProof: createDummyProof(),
+            authSettlementLinkingProof: createDummyLinkingProof()
+        });
+
+        // Encode and return the settlement bundle
+        return SettlementBundle({
+            isFirstFill: true, bundleType: SettlementBundleType.RENEGADE_SETTLED_INTENT, data: abi.encode(bundleData)
+        });
+    }
+
+    /// @dev Create a renegade settled bounded private intent settlement bundle for subsequent fills
+    function createRenegadeSettledBoundedBundleSubsequent(
+        uint256 merkleDepth,
+        BoundedMatchResult memory matchResult
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        // Get the actual Merkle root from the test state (must be in history for subsequent fills)
+        BN254.ScalarField merkleRoot = darkpoolState.getMerkleRoot(merkleDepth);
+
+        // Create the validity statement
+        IntentAndBalanceValidityStatement memory validityStatement = createSampleStatement();
+
+        // Create auth bundle (no signature needed for subsequent fills)
+        RenegadeSettledIntentAuthBundle memory auth = RenegadeSettledIntentAuthBundle({
+            merkleDepth: merkleDepth, statement: validityStatement, validityProof: createDummyProof()
+        });
+
+        // Create bounded settlement statement
+        IntentAndBalanceBoundedSettlementStatement memory settlementStatement =
+            createBoundedSettlementStatement(matchResult);
+
+        // Create output balance bundle
+        OutputBalanceBundle memory outputBalanceBundle = createSampleOutputBalanceBundle();
+
+        // Create the bundle data
+        RenegadeSettledIntentBoundedBundle memory bundleData = RenegadeSettledIntentBoundedBundle({
+            auth: auth,
+            outputBalanceBundle: outputBalanceBundle,
+            settlementStatement: settlementStatement,
+            settlementProof: createDummyProof(),
+            authSettlementLinkingProof: createDummyLinkingProof()
+        });
+
+        // Encode and return the settlement bundle
+        return SettlementBundle({
+            isFirstFill: false, bundleType: SettlementBundleType.RENEGADE_SETTLED_INTENT, data: abi.encode(bundleData)
+        });
+    }
+}
+


### PR DESCRIPTION
### Purpose

This PR adds bounded settlement paths to ring 2 intents.
We share code between the two settlement paths by using specific fields in function parameters rather than path-specific bundle and statement types. If we want fewer parameters we can break up functions like we do in ring 1 settlement.

### Todo

- Add match tests for ring 2 bounded settlement

### Testing

- [x] All existing tests pass