### PR TITLE
darkpoolv2: settlement: Break out ring 3 validation into library

### DIFF
--- a/src/darkpool/v2/interfaces/ISettlementTypes.sol
+++ b/src/darkpool/v2/interfaces/ISettlementTypes.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.24;
 /* solhint-disable use-natspec */
 
 import { SettlementBundle, SettlementBundleType, PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { PublicIntentPublicBalanceBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    PublicIntentPublicBalanceBundle,
     RenegadeSettledPrivateFirstFillBundle,
     RenegadeSettledPrivateFillBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+} from "darkpoolv2-lib/settlement/bundles/RenegadeSettledPrivateFillLib.sol";
 import {
     PrivateIntentPublicBalanceFirstFillBundle,
     PrivateIntentPublicBalanceBundle

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
@@ -1,34 +1,20 @@
 // SPDX-License-Identifier: Apache
 pragma solidity ^0.8.24;
 
-import { BN254 } from "solidity-bn254/BN254.sol";
+import { PartyId, SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    PartyId,
-    SettlementBundle,
-    SettlementBundleLib,
     RenegadeSettledPrivateFirstFillBundle,
     RenegadeSettledPrivateFillBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+} from "darkpoolv2-lib/settlement/bundles/RenegadeSettledPrivateFillLib.sol";
 import {
-    ObligationBundle,
-    ObligationLib,
-    PrivateObligationBundle
+    ObligationBundle, ObligationLib, PrivateObligationBundle
 } from "darkpoolv2-types/settlement/ObligationBundle.sol";
-import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
-import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { DarkpoolState } from "darkpoolv2-lib/DarkpoolState.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
-import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
-import {
-    IntentAndBalanceValidityStatementFirstFill,
-    IntentAndBalanceValidityStatement
-} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
-
-import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
-
-import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
-
-import { RenegadeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/RenegadeSettledPrivateIntent.sol";
+import { RenegadeSettledPrivateFillLib as RenegadeSettledPrivateFillBundleLib } from
+    "darkpoolv2-lib/settlement/bundles/RenegadeSettledPrivateFillLib.sol";
 
 /// @title Renegade Settled Private Fill Library
 /// @author Renegade Eng
@@ -40,15 +26,8 @@ import { RenegadeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/Reneg
 /// In particular, intent authorization is the exact same, and state updates are the same except that we pull
 /// shares from a different statement type.
 library RenegadeSettledPrivateFillLib {
-    using SignatureWithNonceLib for SignatureWithNonce;
     using ObligationLib for ObligationBundle;
-    using SettlementBundleLib for SettlementBundle;
-    using SettlementBundleLib for RenegadeSettledPrivateFirstFillBundle;
-    using SettlementBundleLib for RenegadeSettledPrivateFillBundle;
-    using SettlementContextLib for SettlementContext;
-    using DarkpoolStateLib for DarkpoolState;
-    using PublicInputsLib for IntentAndBalanceValidityStatementFirstFill;
-    using PublicInputsLib for IntentAndBalanceValidityStatement;
+    using RenegadeSettledPrivateFillBundleLib for SettlementBundle;
 
     // --- Errors --- //
 
@@ -106,20 +85,12 @@ library RenegadeSettledPrivateFillLib {
             settlementBundle.decodeRenegadeSettledPrivateFirstFillBundle();
         PrivateObligationBundle memory obligation = obligationBundle.decodePrivateObligation();
 
-        // 1. Validate the intent authorization
-        // Uses the same logic as the `RENEGADE_SETTLED_INTENT` bundle
-        // TODO: Add settlement library here
-        // RenegadeSettledPrivateIntentLib.authorizeIntent(
-        //     bundleData.auth, settlementContext, vkeys, state
-        // );
-
-        // 2. Validate the obligation constraints
-        validateObligationConstraintsFirstFill(
-            partyId, obligationBundle, settlementBundle, settlementContext, vkeys, state
+        // 1. Authorize the intent and input balance
+        RenegadeSettledPrivateFillBundleLib.authorizeAndUpdateIntentAndBalance(
+            partyId, bundleData, obligation, settlementContext, vkeys, hasher, state
         );
 
-        // 3. Execute state updates
-        executeStateUpdatesFirstFill(partyId, obligation, bundleData, state, hasher);
+        // TODO: Output balance updates
     }
 
     /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill
@@ -144,150 +115,11 @@ library RenegadeSettledPrivateFillLib {
         RenegadeSettledPrivateFillBundle memory bundleData = settlementBundle.decodeRenegadeSettledPrivateBundle();
         PrivateObligationBundle memory obligation = obligationBundle.decodePrivateObligation();
 
-        // 1. Validate the intent authorization
-        // Uses the same logic as the `RENEGADE_SETTLED_INTENT` bundle
-        // TODO: Add settlement library here
-        // RenegadeSettledPrivateIntentLib.authorizeIntent(bundleData.auth, settlementContext, vkeys, state);
+        // 1. Authorize the intent and input balance
+        RenegadeSettledPrivateFillBundleLib.authorizeAndUpdateIntentAndBalance(
+            partyId, bundleData, obligation, settlementContext, vkeys, hasher, state
+        );
 
-        // 2. Validate the obligation constraints
-        validateObligationConstraints(partyId, obligationBundle, settlementBundle, settlementContext, vkeys, state);
-
-        // 3. Execute state updates
-        executeStateUpdates(partyId, obligation, bundleData, state, hasher);
-    }
-
-    // --------------------------
-    // | Obligation Constraints |
-    // --------------------------
-
-    /// @notice Validate the obligation constraints for a renegade settled private fill bundle on the first fill
-    /// @param partyId The party ID to validate the obligation for
-    /// @param obligationBundle The obligation bundle to validate
-    /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    /// @param state The darkpool state containing all storage references
-    /// @dev The obligation constraints are validated in the settlement proofs. So, we only need to proof-link the
-    /// validation proof into the obligation bundle's settlement proof.
-    function validateObligationConstraintsFirstFill(
-        PartyId partyId,
-        ObligationBundle calldata obligationBundle,
-        SettlementBundle calldata settlementBundle,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys,
-        DarkpoolState storage state
-    )
-        internal {
-        // TODO: Proof link into the obligation bundle's settlement proof
-    }
-
-    /// @notice Validate the obligation constraints for a renegade settled private fill bundle
-    /// @param partyId The party ID to validate the obligation for
-    /// @param obligationBundle The obligation bundle to validate
-    /// @param settlementBundle The settlement bundle to validate
-    /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
-    /// @param state The darkpool state containing all storage references
-    /// @dev The obligation constraints are validated in the settlement proofs. So, we only need to proof-link the
-    /// validation proof into the obligation bundle's settlement proof.
-    function validateObligationConstraints(
-        PartyId partyId,
-        ObligationBundle calldata obligationBundle,
-        SettlementBundle calldata settlementBundle,
-        SettlementContext memory settlementContext,
-        IVkeys vkeys,
-        DarkpoolState storage state
-    )
-        internal {
-        // TODO: Proof link into the obligation bundle's settlement proof
-    }
-
-    // -----------------
-    // | State Updates |
-    // -----------------
-
-    /// @notice Execute the state updates necessary to settle the bundle for a first fill
-    /// @param partyId The party ID to execute the settlement bundle for
-    /// @param obligation The obligation to execute the state updates for
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing
-    /// @dev On the first fill, no intent state needs to be nullified, however the balance state must be.
-    /// @dev Note: For private fills, commitment computation happens in the obligation bundle proof
-    function executeStateUpdatesFirstFill(
-        PartyId partyId,
-        PrivateObligationBundle memory obligation,
-        RenegadeSettledPrivateFirstFillBundle memory bundleData,
-        DarkpoolState storage state,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Nullify the balance state
-        BN254.ScalarField balanceNullifier = bundleData.auth.statement.oldBalanceNullifier;
-        state.spendNullifier(balanceNullifier);
-
-        // 2. Insert commitments to the updated balance and intent into the Merkle tree
-        BN254.ScalarField newIntentAmountPublicShare;
-        PostMatchBalanceShare memory newBalanceShares;
-        if (partyId == PartyId.PARTY_0) {
-            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare0;
-            newBalanceShares = obligation.statement.newOutBalancePublicShares0;
-        } else if (partyId == PartyId.PARTY_1) {
-            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare1;
-            newBalanceShares = obligation.statement.newOutBalancePublicShares1;
-        }
-
-        BN254.ScalarField newBalanceCommitment = bundleData.computeFullBalanceCommitment(newBalanceShares, hasher);
-        BN254.ScalarField newIntentCommitment =
-            bundleData.computeFullIntentCommitment(newIntentAmountPublicShare, hasher);
-
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
-        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
-    }
-
-    /// @notice Execute the state updates necessary to settle the bundle for a subsequent fill
-    /// @param partyId The party ID to execute the settlement bundle for
-    /// @param obligation The obligation to execute the state updates for
-    /// @param bundleData The bundle data to execute the state updates for
-    /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing
-    /// @dev Note: For private fills, commitment computation happens in the obligation bundle proof
-    function executeStateUpdates(
-        PartyId partyId,
-        PrivateObligationBundle memory obligation,
-        RenegadeSettledPrivateFillBundle memory bundleData,
-        DarkpoolState storage state,
-        IHasher hasher
-    )
-        internal
-    {
-        // 1. Nullify the balance and intent states
-        BN254.ScalarField balanceNullifier = bundleData.auth.statement.oldBalanceNullifier;
-        BN254.ScalarField intentNullifier = bundleData.auth.statement.oldIntentNullifier;
-        state.spendNullifier(balanceNullifier);
-        state.spendNullifier(intentNullifier);
-
-        // 2. Insert commitments to the updated balance and intent into the Merkle tree
-        BN254.ScalarField newIntentAmountPublicShare;
-        PostMatchBalanceShare memory newBalanceShares;
-        if (partyId == PartyId.PARTY_0) {
-            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare0;
-            newBalanceShares = obligation.statement.newInBalancePublicShares0;
-        } else if (partyId == PartyId.PARTY_1) {
-            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare1;
-            newBalanceShares = obligation.statement.newInBalancePublicShares1;
-        }
-
-        // Compute the commitments to the updated balance and intent
-        BN254.ScalarField newBalanceCommitment = bundleData.computeFullBalanceCommitment(newBalanceShares, hasher);
-        BN254.ScalarField newIntentCommitment =
-            bundleData.computeFullIntentCommitment(newIntentAmountPublicShare, hasher);
-
-        // Insert at the configured depth
-        uint256 merkleDepth = bundleData.auth.merkleDepth;
-        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
-        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+        // TODO: Output balance updates
     }
 }

--- a/src/darkpool/v2/libraries/settlement/bundles/RenegadeSettledPrivateFillLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/RenegadeSettledPrivateFillLib.sol
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import {
+    IntentAndBalanceValidityStatementFirstFill,
+    IntentAndBalanceValidityStatement
+} from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
+import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
+import { PartyId } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { LinkingProof, ProofLinkingVK } from "renegade-lib/verifier/Types.sol";
+import {
+    RenegadeSettledIntentAuthBundleFirstFill,
+    RenegadeSettledIntentAuthBundle
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { PostMatchBalanceShare, PostMatchBalanceShareLib } from "darkpoolv2-types/Balance.sol";
+import {
+    IntentPublicShare,
+    IntentPublicShareLib,
+    IntentPreMatchShare,
+    IntentPreMatchShareLib
+} from "darkpoolv2-types/Intent.sol";
+import { CommitmentLib } from "darkpoolv2-lib/Commitments.sol";
+import { PrivateObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
+import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
+import { PrivateIntentPrivateBalanceBundleLib } from
+    "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_INTENT` bundle on the first fill
+/// @dev Note that this is the same as the `RENEGADE_SETTLED_INTENT` bundle, but without the settlement statement and
+/// proof
+/// These proofs are attached to the obligation bundle, as the proof unifies the two settlement bundles
+struct RenegadeSettledPrivateFirstFillBundle {
+    /// @dev The private intent authorization payload with signature attached
+    RenegadeSettledIntentAuthBundleFirstFill auth;
+    /// @dev The proof linking argument between the validity proof and the settlement proof
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @notice The settlement bundle data for a `RENEGADE_SETTLED_PRIVATE_FILL` bundle on subsequent fills
+/// @dev Note that this is the same as the `RENEGADE_SETTLED_INTENT` bundle, but without the settlement statement and
+/// proof
+/// These proofs are attached to the obligation bundle, as the proof unifies the two settlement bundles
+struct RenegadeSettledPrivateFillBundle {
+    /// @dev The private intent authorization payload with signature attached
+    RenegadeSettledIntentAuthBundle auth;
+    /// @dev The proof linking argument between the validity proof and the settlement proof
+    LinkingProof authSettlementLinkingProof;
+}
+
+/// @title Renegade Settled Private Fill Library
+/// @author Renegade Eng
+/// @notice Library for validating renegade settled private fills
+/// @dev A renegade settled private fill is a private intent with a private (darkpool) balance where
+/// the settlement obligation itself is private.
+library RenegadeSettledPrivateFillLib {
+    using PublicInputsLib for IntentAndBalanceValidityStatementFirstFill;
+    using PublicInputsLib for IntentAndBalanceValidityStatement;
+    using DarkpoolStateLib for DarkpoolState;
+    using IntentPreMatchShareLib for IntentPreMatchShare;
+    using IntentPublicShareLib for IntentPublicShare;
+    using PostMatchBalanceShareLib for PostMatchBalanceShare;
+
+    // ----------
+    // | Decode |
+    // ----------
+
+    /// @notice Decode a renegade settled private fill settlement bundle for a first fill
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledPrivateFirstFillBundle(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledPrivateFirstFillBundle memory bundleData)
+    {
+        bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFirstFillBundle));
+    }
+
+    /// @notice Decode a renegade settled private fill settlement bundle
+    /// @param bundle The settlement bundle to decode
+    /// @return bundleData The decoded bundle data
+    function decodeRenegadeSettledPrivateBundle(SettlementBundle calldata bundle)
+        internal
+        pure
+        returns (RenegadeSettledPrivateFillBundle memory bundleData)
+    {
+        bool validType = !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
+        require(validType, IDarkpoolV2.InvalidSettlementBundleType());
+        bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFillBundle));
+    }
+
+    // ----------------------------------
+    // | Intent & Input Balance Updates |
+    // ----------------------------------
+
+    /// @notice Authorize and update the intent and input balance for a renegade settled private fill on the first fill
+    /// @param partyId The party ID to authorize and update
+    /// @param bundleData The bundle to authorize and update
+    /// @param obligationBundle The obligation bundle to authorize and update
+    /// @param settlementContext The settlement context to authorize and update
+    /// @param vkeys The contract storing the verification keys
+    /// @param hasher The hasher to use for hashing
+    /// @param state The state to use for authorization and update
+    function authorizeAndUpdateIntentAndBalance(
+        PartyId partyId,
+        RenegadeSettledPrivateFirstFillBundle memory bundleData,
+        PrivateObligationBundle memory obligationBundle,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Validate the Merkle root used to authorize the input balance
+        // TODO: Allow for dynamic Merkle depth
+        if (bundleData.auth.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
+            revert IDarkpool.InvalidMerkleDepthRequested();
+        }
+        state.assertRootInHistory(bundleData.auth.statement.merkleRoot);
+
+        // Verify that the owner has signed the intent
+        PrivateIntentPrivateBalanceBundleLib._verifyIntentSignature(bundleData.auth, state);
+
+        // Push the validity proof to the settlement context
+        ProofLinkingVK memory proofLinkingVkey = _getIntentAndBalanceProofLinkingVkey(partyId, vkeys);
+        PrivateIntentPrivateBalanceBundleLib.pushValidityProof(
+            bundleData.auth.statement.statementSerialize(),
+            bundleData.auth.validityProof,
+            obligationBundle.proof,
+            vkeys.intentAndBalanceFirstFillValidityKeys(),
+            proofLinkingVkey,
+            bundleData.authSettlementLinkingProof,
+            settlementContext
+        );
+
+        // Execute state updates for the input balance and intent
+        _updateIntentAndBalance(partyId, bundleData, obligationBundle, state, hasher);
+    }
+
+    /// @notice Authorize and update the intent and input balance for a renegade settled private fill on a subsequent
+    /// fill
+    /// @param partyId The party ID to authorize and update
+    /// @param bundleData The bundle to authorize and update
+    /// @param obligationBundle The obligation bundle to authorize and update
+    /// @param settlementContext The settlement context to authorize and update
+    /// @param vkeys The contract storing the verification keys
+    /// @param hasher The hasher to use for hashing
+    /// @param state The state to use for authorization and update
+    function authorizeAndUpdateIntentAndBalance(
+        PartyId partyId,
+        RenegadeSettledPrivateFillBundle memory bundleData,
+        PrivateObligationBundle memory obligationBundle,
+        SettlementContext memory settlementContext,
+        IVkeys vkeys,
+        IHasher hasher,
+        DarkpoolState storage state
+    )
+        internal
+    {
+        // Validate the Merkle roots used for the input balance and intent
+        // TODO: Allow for dynamic Merkle depth
+        if (bundleData.auth.merkleDepth != DarkpoolConstants.DEFAULT_MERKLE_DEPTH) {
+            revert IDarkpool.InvalidMerkleDepthRequested();
+        }
+        state.assertRootInHistory(bundleData.auth.statement.intentMerkleRoot);
+        state.assertRootInHistory(bundleData.auth.statement.balanceMerkleRoot);
+
+        // Push a validity proof to the settlement context
+        ProofLinkingVK memory proofLinkingVkey = _getIntentAndBalanceProofLinkingVkey(partyId, vkeys);
+        PrivateIntentPrivateBalanceBundleLib.pushValidityProof(
+            bundleData.auth.statement.statementSerialize(),
+            bundleData.auth.validityProof,
+            obligationBundle.proof,
+            vkeys.intentAndBalanceValidityKeys(),
+            proofLinkingVkey,
+            bundleData.authSettlementLinkingProof,
+            settlementContext
+        );
+
+        // Rotate the intent and balance state elements to their updated versions
+        _updateIntentAndBalance(partyId, bundleData, obligationBundle, state, hasher);
+    }
+
+    /// @notice Update the intent and input balance after authorization on the first fill
+    /// @param partyId The party ID to update the intent and input balance for
+    /// @param bundleData The bundle data to update
+    /// @param obligation The obligation to update
+    /// @param state The state to use for the update
+    /// @param hasher The hasher to use for hashing
+    function _updateIntentAndBalance(
+        PartyId partyId,
+        RenegadeSettledPrivateFirstFillBundle memory bundleData,
+        PrivateObligationBundle memory obligation,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        // 1. Nullify the balance state
+        BN254.ScalarField balanceNullifier = bundleData.auth.statement.oldBalanceNullifier;
+        state.spendNullifier(balanceNullifier);
+
+        // 2. Insert commitments to the updated balance and intent into the Merkle tree
+        BN254.ScalarField newIntentAmountPublicShare;
+        PostMatchBalanceShare memory newBalanceShares;
+        if (partyId == PartyId.PARTY_0) {
+            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare0;
+            newBalanceShares = obligation.statement.newOutBalancePublicShares0;
+        } else if (partyId == PartyId.PARTY_1) {
+            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare1;
+            newBalanceShares = obligation.statement.newOutBalancePublicShares1;
+        }
+
+        BN254.ScalarField newBalanceCommitment = computeFullBalanceCommitment(bundleData, newBalanceShares, hasher);
+        BN254.ScalarField newIntentCommitment =
+            computeFullIntentCommitment(bundleData, newIntentAmountPublicShare, hasher);
+
+        uint256 merkleDepth = bundleData.auth.merkleDepth;
+        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+    }
+
+    /// @notice Update the intent and input balance after authorization on a subsequent fill
+    /// @param partyId The party ID to update the intent and input balance for
+    /// @param bundleData The bundle data to update
+    /// @param obligation The obligation to update
+    /// @param state The state to use for the update
+    /// @param hasher The hasher to use for the update
+    function _updateIntentAndBalance(
+        PartyId partyId,
+        RenegadeSettledPrivateFillBundle memory bundleData,
+        PrivateObligationBundle memory obligation,
+        DarkpoolState storage state,
+        IHasher hasher
+    )
+        internal
+    {
+        // 1. Nullify the balance and intent states
+        BN254.ScalarField balanceNullifier = bundleData.auth.statement.oldBalanceNullifier;
+        BN254.ScalarField intentNullifier = bundleData.auth.statement.oldIntentNullifier;
+        state.spendNullifier(balanceNullifier);
+        state.spendNullifier(intentNullifier);
+
+        // 2. Insert commitments to the updated balance and intent into the Merkle tree
+        BN254.ScalarField newIntentAmountPublicShare;
+        PostMatchBalanceShare memory newBalanceShares;
+        if (partyId == PartyId.PARTY_0) {
+            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare0;
+            newBalanceShares = obligation.statement.newInBalancePublicShares0;
+        } else if (partyId == PartyId.PARTY_1) {
+            newIntentAmountPublicShare = obligation.statement.newAmountPublicShare1;
+            newBalanceShares = obligation.statement.newInBalancePublicShares1;
+        }
+
+        // Compute the commitments to the updated balance and intent
+        BN254.ScalarField newBalanceCommitment = computeFullBalanceCommitment(bundleData, newBalanceShares, hasher);
+        BN254.ScalarField newIntentCommitment =
+            computeFullIntentCommitment(bundleData, newIntentAmountPublicShare, hasher);
+
+        // Insert at the configured depth
+        uint256 merkleDepth = bundleData.auth.merkleDepth;
+        state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+        state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+    }
+
+    // --------------------------
+    // | Commitment Computation |
+    // --------------------------
+
+    /// @notice Compute the full commitment to the updated intent for a renegade settled private fill bundle
+    /// on its first fill
+    /// @dev Unlike the `computeFullIntentCommitment` methods above, private fills require updating the intent shares
+    /// in-circuit; to avoid leaking the pre- and post-update shares and thereby the fill. So we need not update the
+    /// shares here, we need only resume the partial commitment.
+    /// @dev We also take the updated intent amount public share as an argument here because the settlement proof
+    /// computes updated intent amount public shares for both parties. It's simpler to rely on a higher level method to
+    /// extract the correct party's shares.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newIntentAmountPublicShare The updated intent amount public share
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    /// TODO: Compute this correctly
+    function computeFullIntentCommitment(
+        RenegadeSettledPrivateFirstFillBundle memory bundleData,
+        BN254.ScalarField newIntentAmountPublicShare,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+
+        // Create a full intent share from the pre-match share and the updated amount public share
+        IntentPublicShare memory newIntentPublicShare =
+            authStatement.intentPublicShare.toFullPublicShare(newIntentAmountPublicShare);
+        uint256[] memory publicShares = newIntentPublicShare.scalarSerialize();
+
+        // Compute the full commitment to the updated intent
+        newIntentCommitment = CommitmentLib.computeCommitmentWithPublicShares(
+            authStatement.intentPrivateShareCommitment, publicShares, hasher
+        );
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a renegade settled private fill bundle
+    /// on its first fill
+    /// @dev Unlike the `computeFullBalanceCommitment` methods above, private fills require updating the shares
+    /// in-circuit; to avoid leaking the pre- and post-update shares and thereby the fill. So we need not update the
+    /// shares here, we need only resume the partial commitment.
+    /// @dev We also take the updated balance shares as an argument here because the settlement proof computes updated
+    /// shares for both parties. It's simpler to rely on a higher level method to extract the correct party's shares.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newBalancePublicShares The updated balance public shares
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledPrivateFirstFillBundle memory bundleData,
+        PostMatchBalanceShare memory newBalancePublicShares,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        // Resume the partial commitment with the updated shares
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+        uint256[] memory remainingShares = newBalancePublicShares.scalarSerialize();
+        newBalanceCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.balancePartialCommitment, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated intent for a renegade settled private fill bundle
+    /// on its subsequent fill
+    /// @dev As with the first fill implementation for private fill bundles; the shares are pre-updated in the circuit,
+    /// so we only need to resume the partial commitment.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newIntentAmountPublicShare The updated intent amount public share
+    /// @param hasher The hasher to use for hashing
+    /// @return newIntentCommitment The full commitment to the updated intent
+    function computeFullIntentCommitment(
+        RenegadeSettledPrivateFillBundle memory bundleData,
+        BN254.ScalarField newIntentAmountPublicShare,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newIntentCommitment)
+    {
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        uint256[] memory remainingShares = new uint256[](1);
+        remainingShares[0] = BN254.ScalarField.unwrap(newIntentAmountPublicShare);
+        newIntentCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.newIntentPartialCommitment, hasher);
+    }
+
+    /// @notice Compute the full commitment to the updated balance for a renegade settled private fill bundle
+    /// on its subsequent fill
+    /// @dev As with the first fill implementation for private fill bundles; the shares are pre-updated in the circuit,
+    /// so we only need to resume the partial commitment.
+    /// @param bundleData The bundle data to compute the commitment for
+    /// @param newBalancePublicShares The updated balance public shares
+    /// @param hasher The hasher to use for hashing
+    /// @return newBalanceCommitment The full commitment to the updated balance
+    function computeFullBalanceCommitment(
+        RenegadeSettledPrivateFillBundle memory bundleData,
+        PostMatchBalanceShare memory newBalancePublicShares,
+        IHasher hasher
+    )
+        internal
+        view
+        returns (BN254.ScalarField newBalanceCommitment)
+    {
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        uint256[] memory remainingShares = newBalancePublicShares.scalarSerialize();
+        newBalanceCommitment =
+            CommitmentLib.computeResumableCommitment(remainingShares, authStatement.balancePartialCommitment, hasher);
+    }
+
+    // --- Helpers --- //
+
+    /// @notice Get the proof linking vkey for a Renegade settled private fill bundle based on the party ID
+    /// @param partyId The party ID to get the proof linking vkey for
+    /// @param vkeys The verification keys to use for the proof linking
+    /// @return proofLinkingVkey The proof linking vkey
+    function _getIntentAndBalanceProofLinkingVkey(
+        PartyId partyId,
+        IVkeys vkeys
+    )
+        internal
+        view
+        returns (ProofLinkingVK memory proofLinkingVkey)
+    {
+        if (partyId == PartyId.PARTY_0) {
+            proofLinkingVkey = vkeys.intentAndBalanceSettlement0LinkingKey();
+        } else {
+            proofLinkingVkey = vkeys.intentAndBalanceSettlement1LinkingKey();
+        }
+    }
+}

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -125,6 +125,7 @@ struct RenegadeSettledIntentAuthBundleFirstFill {
     /// under the previous, now leaked, one time key. This authorizes the intent to be capitalized by
     /// the balance which the owner (hidden) has deposited in the darkpool. This signature also
     /// authorizes the one time key to be rotated to the new one time key.
+    /// TODO: Move this to an in-circuit verification
     SignatureWithNonce ownerSignature;
     /// @dev The statement for the proof intent and balance validity
     IntentAndBalanceValidityStatementFirstFill statement;

--- a/src/libraries/merkle/MerkleTree.sol
+++ b/src/libraries/merkle/MerkleTree.sol
@@ -142,11 +142,11 @@ library MerkleTreeLib {
         // `subtreeFilled` maintains whether the subtree rooted at the current node is full
         // This is initially true, as the current node is the leaf being inserted
         bool subtreeFilled = true;
-        for (uint256 height = 0; height < tree.config.depth; ++height) {
+        uint256 depth = tree.config.depth;
+        for (uint256 height = 0; height < depth; ++height) {
             // Compute the insertion coordinates at the current height
             uint256 idxAtHeight = idx >> height;
-            uint256 idxBit = idxAtHeight & 1;
-            bool isRightChild = idxBit == 1;
+            bool isRightChild = (idxAtHeight & 1) == 1;
 
             // If the subtree is full, we need to switch the sibling path entry at this height
             if (subtreeFilled) {
@@ -164,9 +164,9 @@ library MerkleTreeLib {
             subtreeFilled = isRightChild && subtreeFilled;
 
             // Emit an event for indexers to track the opening of the current insertion
-            uint256 siblingIdx = isRightChild ? idxAtHeight - 1 : idxAtHeight + 1;
-            uint8 depth = uint8(tree.config.depth - height);
-            emit MerkleOpeningNode(depth, uint128(siblingIdx), sisterLeaves[height]);
+            emit MerkleOpeningNode(
+                uint8(depth - height), uint128(isRightChild ? idxAtHeight - 1 : idxAtHeight + 1), sisterLeaves[height]
+            );
         }
 
         // Log the updates to the Merkle tree after an insertion

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/FullMatchTests.t.sol
@@ -15,8 +15,8 @@ import {
 import {
     RenegadeSettledPrivateFillBundle,
     RenegadeSettledPrivateFirstFillBundle,
-    SettlementBundleLib
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+    RenegadeSettledPrivateFillLib
+} from "darkpoolv2-lib/settlement/bundles/RenegadeSettledPrivateFillLib.sol";
 import { RenegadeSettledPrivateFillTestUtils } from "./Utils.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { VerifierCore } from "renegade-lib/verifier/VerifierCore.sol";
@@ -27,8 +27,8 @@ import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 
 contract FullMatchTests is RenegadeSettledPrivateFillTestUtils {
     using ObligationLib for ObligationBundle;
-    using SettlementBundleLib for RenegadeSettledPrivateFillBundle;
-    using SettlementBundleLib for RenegadeSettledPrivateFirstFillBundle;
+    using RenegadeSettledPrivateFillLib for RenegadeSettledPrivateFirstFillBundle;
+    using RenegadeSettledPrivateFillLib for RenegadeSettledPrivateFillBundle;
     using FixedPointLib for FixedPoint;
     using MerkleTreeLib for MerkleTreeLib.MerkleTree;
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
@@ -3,12 +3,11 @@ pragma solidity ^0.8.24;
 
 /* solhint-disable func-name-mixedcase */
 
+import { PartyId, SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    PartyId,
-    SettlementBundle,
-    SettlementBundleLib,
-    RenegadeSettledPrivateFirstFillBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+    RenegadeSettledPrivateFirstFillBundle,
+    RenegadeSettledPrivateFillLib
+} from "darkpoolv2-lib/settlement/bundles/RenegadeSettledPrivateFillLib.sol";
 import { ObligationBundle, ObligationType } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import {
     SignatureWithNonce, RenegadeSettledIntentAuthBundleFirstFill
@@ -21,8 +20,6 @@ import { IDarkpool } from "darkpoolv1-interfaces/IDarkpool.sol";
 import { RenegadeSettledPrivateFillTestUtils } from "./Utils.sol";
 
 contract RenegadeSettledPrivateFillAuthorizationTest is RenegadeSettledPrivateFillTestUtils {
-    using SettlementBundleLib for RenegadeSettledPrivateFirstFillBundle;
-
     // -----------
     // | Helpers |
     // -----------

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
@@ -4,12 +4,11 @@ pragma solidity ^0.8.24;
 import { Vm } from "forge-std/Vm.sol";
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { DarkpoolV2TestUtils } from "../../DarkpoolV2TestUtils.sol";
+import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import {
-    SettlementBundle,
-    SettlementBundleType,
     RenegadeSettledPrivateFirstFillBundle,
     RenegadeSettledPrivateFillBundle
-} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+} from "darkpoolv2-lib/settlement/bundles/RenegadeSettledPrivateFillLib.sol";
 import {
     ObligationBundle,
     ObligationType,
@@ -191,7 +190,8 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
             statement: validityStatement,
             validityProof: createDummyProof()
         });
-        RenegadeSettledPrivateFirstFillBundle memory bundleData = RenegadeSettledPrivateFirstFillBundle({ auth: auth });
+        RenegadeSettledPrivateFirstFillBundle memory bundleData =
+            RenegadeSettledPrivateFirstFillBundle({ auth: auth, authSettlementLinkingProof: createDummyLinkingProof() });
 
         // Encode the bundle
         return SettlementBundle({
@@ -215,7 +215,8 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
             statement: validityStatement,
             validityProof: createDummyProof()
         });
-        RenegadeSettledPrivateFillBundle memory bundleData = RenegadeSettledPrivateFillBundle({ auth: auth });
+        RenegadeSettledPrivateFillBundle memory bundleData =
+            RenegadeSettledPrivateFillBundle({ auth: auth, authSettlementLinkingProof: createDummyLinkingProof() });
 
         // Encode the bundle
         return SettlementBundle({


### PR DESCRIPTION
### Purpose
This PR breaks out the ring 3 validation logic into a separate library. This will be useful for sharing logic between standard and external match paths.

### Todo
- Output balance validation and updates

### Testing
- [x] All tests pass