### PR TITLE
darkpoolv2: settlement: Introduce SettlementContracts type

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -25,6 +25,7 @@ import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
 import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.sol";
 import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import {
     DepositProofBundle,
     NewBalanceDepositProofBundle,
@@ -174,6 +175,11 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         return _state.getProtocolFeeRate(asset0, asset1).rate;
     }
 
+    /// @inheritdoc IDarkpoolV2
+    function getDefaultProtocolFee() public view returns (FixedPoint memory) {
+        return _state.getDefaultProtocolFeeRate();
+    }
+
     // -----------------
     // | State Updates |
     // -----------------
@@ -248,17 +254,10 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     )
         public
     {
-        SettlementLib.settleMatch(
-            _state,
-            hasher,
-            verifier,
-            weth,
-            permit2,
-            vkeys,
-            obligationBundle,
-            party0SettlementBundle,
-            party1SettlementBundle
-        );
+        SettlementContracts memory contracts =
+            SettlementContracts({ hasher: hasher, verifier: verifier, weth: weth, permit2: permit2, vkeys: vkeys });
+
+        SettlementLib.settleMatch(_state, contracts, obligationBundle, party0SettlementBundle, party1SettlementBundle);
     }
 
     /// @inheritdoc IDarkpoolV2
@@ -270,17 +269,11 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     )
         public
     {
+        SettlementContracts memory contracts =
+            SettlementContracts({ hasher: hasher, verifier: verifier, weth: weth, permit2: permit2, vkeys: vkeys });
+
         ExternalSettlementLib.settleExternalMatch(
-            _state,
-            hasher,
-            verifier,
-            weth,
-            permit2,
-            vkeys,
-            externalPartyAmountIn,
-            recipient,
-            matchBundle,
-            internalPartySettlementBundle
+            _state, contracts, externalPartyAmountIn, recipient, matchBundle, internalPartySettlementBundle
         );
     }
 }

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -87,6 +87,8 @@ interface IDarkpoolV2 {
     error InvalidBoundedMatchResult();
     /// @notice Thrown when the protocol fee rates used in settlement do not match
     error InvalidProtocolFeeRates();
+    /// @notice Thrown when the protocol fee does not match the expected value
+    error InvalidProtocolFee();
 
     // --- Events --- //
 
@@ -155,6 +157,10 @@ interface IDarkpoolV2 {
     /// @param asset1 The second asset in the trading pair
     /// @return The protocol fee rate for the asset pair
     function getProtocolFee(address asset0, address asset1) external view returns (FixedPoint memory);
+
+    /// @notice Get the default protocol fee rate
+    /// @return The default protocol fee rate
+    function getDefaultProtocolFee() external view returns (FixedPoint memory);
 
     /// @notice Get the amount remaining for an open public intent
     /// @param intentHash The hash of the intent

--- a/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
@@ -21,6 +21,7 @@ import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 import { NativeSettledPublicIntentLib } from "./NativeSettledPublicIntent.sol";
 import { NativeSettledPrivateIntentLib } from "./NativeSettledPrivateIntent.sol";
 import { RenegadeSettledPrivateIntentLib } from "./RenegadeSettledPrivateIntent.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { DarkpoolState } from "darkpoolv2-lib/DarkpoolState.sol";
 import { SettlementLib } from "./SettlementLib.sol";
 import { SettlementVerification } from "./SettlementVerification.sol";
@@ -35,22 +36,14 @@ library ExternalSettlementLib {
 
     /// @notice Settle a trade with an external party who decides the trade size
     /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing commitments
-    /// @param verifier The verifier to use for verification
-    /// @param weth The WETH9 contract instance
-    /// @param permit2 The permit2 contract instance
-    /// @param vkeys The contract storing the verification keys
+    /// @param contracts The contract references needed for settlement
     /// @param externalPartyAmountIn The input amount for the trade
     /// @param recipient The recipient of the withdrawal
     /// @param matchBundle The bounded match result bundle
     /// @param internalPartySettlementBundle The settlement bundle for the internal party
     function settleExternalMatch(
         DarkpoolState storage state,
-        IHasher hasher,
-        IVerifier verifier,
-        IWETH9 weth,
-        IPermit2 permit2,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         uint256 externalPartyAmountIn,
         address recipient,
         BoundedMatchResultBundle calldata matchBundle,
@@ -67,7 +60,7 @@ library ExternalSettlementLib {
 
         // Validate and authorize the settlement bundles
         executeExternalSettlementBundle(
-            matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, hasher, vkeys, state
+            matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, contracts, state
         );
 
         // Allocate transfers for external party
@@ -76,11 +69,11 @@ library ExternalSettlementLib {
 
         // Execute the transfers necessary for settlement
         // The helpers above will push transfers to the settlement context if necessary
-        SettlementLib.executeTransfers(settlementContext, weth, permit2);
+        SettlementLib.executeTransfers(settlementContext, contracts);
 
         // Verify the proofs necessary for settlement
         // The helpers above will push proofs to the settlement context if necessary
-        SettlementVerification.verifySettlementProofs(settlementContext, verifier);
+        SettlementVerification.verifySettlementProofs(settlementContext, contracts.verifier);
     }
 
     // --- Allocation --- //
@@ -135,16 +128,14 @@ library ExternalSettlementLib {
     /// @param internalObligation The settlement obligation to validate
     /// @param internalPartySettlementBundle The settlement bundle for the internal party
     /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param hasher The hasher to use for hashing
-    /// @param vkeys The contract storing the verification keys
+    /// @param contracts The contract references needed for settlement
     /// @param state The darkpool state containing all storage references
     function executeExternalSettlementBundle(
         BoundedMatchResultBundle calldata matchBundle,
         SettlementObligation memory internalObligation,
         SettlementBundle calldata internalPartySettlementBundle,
         SettlementContext memory settlementContext,
-        IHasher hasher,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         DarkpoolState storage state
     )
         internal
@@ -156,7 +147,7 @@ library ExternalSettlementLib {
             );
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
             NativeSettledPrivateIntentLib.executeBoundedMatch(
-                matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, hasher, vkeys, state
+                matchBundle, internalObligation, internalPartySettlementBundle, settlementContext, contracts, state
             );
         } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT) {
             RenegadeSettledPrivateIntentLib.executeBoundedMatch(

--- a/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
+++ b/src/darkpool/v2/libraries/settlement/RenegadeSettledPrivateFill.sol
@@ -13,6 +13,7 @@ import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext
 import { DarkpoolState } from "darkpoolv2-lib/DarkpoolState.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { RenegadeSettledPrivateFillLib as RenegadeSettledPrivateFillBundleLib } from
     "darkpoolv2-lib/settlement/bundles/RenegadeSettledPrivateFillLib.sol";
 
@@ -41,24 +42,22 @@ library RenegadeSettledPrivateFillLib {
     /// @param obligationBundle The obligation bundle to execute
     /// @param settlementBundle The settlement bundle to execute
     /// @param settlementContext The settlement context to which we append post-execution updates.
-    /// @param hasher The hasher to use for hashing
-    /// @param vkeys The contract storing the verification keys
+    /// @param contracts The contract references needed for settlement
     /// @param state The darkpool state containing all storage references
     function execute(
         PartyId partyId,
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
-        IHasher hasher,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         DarkpoolState storage state
     )
         internal
     {
         if (settlementBundle.isFirstFill) {
-            executeFirstFill(partyId, obligationBundle, settlementBundle, settlementContext, hasher, vkeys, state);
+            executeFirstFill(partyId, obligationBundle, settlementBundle, settlementContext, contracts, state);
         } else {
-            executeSubsequentFill(partyId, obligationBundle, settlementBundle, settlementContext, hasher, vkeys, state);
+            executeSubsequentFill(partyId, obligationBundle, settlementBundle, settlementContext, contracts, state);
         }
     }
 
@@ -67,16 +66,14 @@ library RenegadeSettledPrivateFillLib {
     /// @param obligationBundle The obligation bundle to execute
     /// @param settlementBundle The settlement bundle to execute
     /// @param settlementContext The settlement context to which we append post-execution updates.
-    /// @param hasher The hasher to use for hashing
-    /// @param vkeys The contract storing the verification keys
+    /// @param contracts The contract references needed for settlement
     /// @param state The darkpool state containing all storage references
     function executeFirstFill(
         PartyId partyId,
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
-        IHasher hasher,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         DarkpoolState storage state
     )
         internal
@@ -87,12 +84,12 @@ library RenegadeSettledPrivateFillLib {
 
         // 1. Authorize the intent and input balance
         RenegadeSettledPrivateFillBundleLib.authorizeAndUpdateIntentAndBalance(
-            partyId, bundleData, obligation, settlementContext, vkeys, hasher, state
+            partyId, bundleData, obligation, settlementContext, contracts, state
         );
 
         // 2. Validate the output balance validity
         RenegadeSettledPrivateFillBundleLib.authorizeAndUpdateOutputBalance(
-            partyId, bundleData.outputBalanceBundle, obligation, settlementContext, vkeys, hasher, state
+            partyId, bundleData.outputBalanceBundle, obligation, settlementContext, contracts, state
         );
     }
 
@@ -101,16 +98,14 @@ library RenegadeSettledPrivateFillLib {
     /// @param obligationBundle The obligation bundle to execute
     /// @param settlementBundle The settlement bundle to execute
     /// @param settlementContext The settlement context to which we append post-execution updates.
-    /// @param hasher The hasher to use for hashing
-    /// @param vkeys The contract storing the verification keys
+    /// @param contracts The contract references needed for settlement
     /// @param state The darkpool state containing all storage references
     function executeSubsequentFill(
         PartyId partyId,
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
-        IHasher hasher,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         DarkpoolState storage state
     )
         internal
@@ -120,12 +115,12 @@ library RenegadeSettledPrivateFillLib {
 
         // 1. Authorize the intent and input balance
         RenegadeSettledPrivateFillBundleLib.authorizeAndUpdateIntentAndBalance(
-            partyId, bundleData, obligation, settlementContext, vkeys, hasher, state
+            partyId, bundleData, obligation, settlementContext, contracts, state
         );
 
         // 2. Validate the output balance validity
         RenegadeSettledPrivateFillBundleLib.authorizeAndUpdateOutputBalance(
-            partyId, bundleData.outputBalanceBundle, obligation, settlementContext, vkeys, hasher, state
+            partyId, bundleData.outputBalanceBundle, obligation, settlementContext, contracts, state
         );
     }
 }

--- a/src/darkpool/v2/libraries/settlement/SettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/SettlementLib.sol
@@ -9,9 +9,10 @@ import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { VerificationKey } from "renegade-lib/verifier/Types.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
-import { DarkpoolState } from "darkpoolv2-lib/DarkpoolState.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { ExternalTransferLib } from "darkpoolv2-lib/TransferLib.sol";
 import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
 import { IntentAndBalancePrivateSettlementStatement } from "darkpoolv2-lib/public_inputs/Settlement.sol";
@@ -40,6 +41,15 @@ import { RenegadeSettledPrivateIntentLib } from "./RenegadeSettledPrivateIntent.
 import { RenegadeSettledPrivateFillLib } from "./RenegadeSettledPrivateFill.sol";
 import { SettlementVerification } from "./SettlementVerification.sol";
 
+/// @notice Contract references needed for settlement operations
+struct SettlementContracts {
+    IHasher hasher;
+    IVerifier verifier;
+    IWETH9 weth;
+    IPermit2 permit2;
+    IVkeys vkeys;
+}
+
 /// @title SettlementLib
 /// @author Renegade Eng
 /// @notice Library for settlement operations
@@ -51,26 +61,20 @@ library SettlementLib {
     using SettlementTransfersLib for SettlementTransfers;
     using ProofLinkingListLib for ProofLinkingList;
     using PublicInputsLib for IntentAndBalancePrivateSettlementStatement;
+    using DarkpoolStateLib for DarkpoolState;
+    using FixedPointLib for FixedPoint;
 
     // --- Entry Point --- //
 
     /// @notice Settle a match between two parties
     /// @param state The darkpool state containing all storage references
-    /// @param hasher The hasher to use for hashing commitments
-    /// @param verifier The verifier to use for verification
-    /// @param weth The WETH9 contract instance
-    /// @param permit2 The permit2 contract instance
-    /// @param vkeys The contract storing the verification keys
+    /// @param contracts The contract references needed for settlement
     /// @param obligationBundle The obligation bundle for the trade
     /// @param party0SettlementBundle The settlement bundle for the first party
     /// @param party1SettlementBundle The settlement bundle for the second party
     function settleMatch(
         DarkpoolState storage state,
-        IHasher hasher,
-        IVerifier verifier,
-        IWETH9 weth,
-        IPermit2 permit2,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata party0SettlementBundle,
         SettlementBundle calldata party1SettlementBundle
@@ -82,21 +86,21 @@ library SettlementLib {
             allocateSettlementContext(party0SettlementBundle, party1SettlementBundle);
 
         // 2. Validate that the settlement obligations are compatible with one another
-        validateObligationBundle(obligationBundle, settlementContext, vkeys);
+        validateObligationBundle(obligationBundle, settlementContext, state, contracts);
 
         // 3. Validate and authorize the settlement bundles
         executeSettlementBundle(
-            PartyId.PARTY_0, obligationBundle, party0SettlementBundle, settlementContext, hasher, vkeys, state
+            PartyId.PARTY_0, obligationBundle, party0SettlementBundle, settlementContext, contracts, state
         );
         executeSettlementBundle(
-            PartyId.PARTY_1, obligationBundle, party1SettlementBundle, settlementContext, hasher, vkeys, state
+            PartyId.PARTY_1, obligationBundle, party1SettlementBundle, settlementContext, contracts, state
         );
 
         // 4. Execute the transfers necessary for settlement
-        executeTransfers(settlementContext, weth, permit2);
+        executeTransfers(settlementContext, contracts);
 
         // 5. Verify the proofs necessary for settlement
-        SettlementVerification.verifySettlementProofs(settlementContext, verifier);
+        SettlementVerification.verifySettlementProofs(settlementContext, contracts.verifier);
     }
 
     // --- Allocation --- //
@@ -134,11 +138,13 @@ library SettlementLib {
     /// @notice Validate an obligation bundle
     /// @param obligationBundle The obligation bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param vkeys The contract storing the verification keys
+    /// @param state The darkpool state containing all storage references
+    /// @param contracts The contract references needed for settlement
     function validateObligationBundle(
         ObligationBundle calldata obligationBundle,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        DarkpoolState storage state,
+        SettlementContracts memory contracts
     )
         internal
         view
@@ -147,7 +153,7 @@ library SettlementLib {
             // Validate a public obligation bundle
             validatePublicObligationBundle(obligationBundle);
         } else if (obligationBundle.obligationType == ObligationType.PRIVATE) {
-            validatePrivateObligationBundle(obligationBundle, settlementContext, vkeys);
+            validatePrivateObligationBundle(obligationBundle, settlementContext, state, contracts.vkeys);
         } else {
             revert IDarkpoolV2.InvalidSettlementBundleType();
         }
@@ -183,10 +189,12 @@ library SettlementLib {
     /// @notice Validate a private obligation bundle
     /// @param obligationBundle The obligation bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
+    /// @param state The darkpool state containing all storage references
     /// @param vkeys The contract storing the verification keys
     function validatePrivateObligationBundle(
         ObligationBundle calldata obligationBundle,
         SettlementContext memory settlementContext,
+        DarkpoolState storage state,
         IVkeys vkeys
     )
         internal
@@ -194,6 +202,16 @@ library SettlementLib {
     {
         // Decode the obligations
         PrivateObligationBundle memory obligation = obligationBundle.decodePrivateObligation();
+
+        // Validate relayer fees
+        DarkpoolConstants.validateFeeRate(obligation.statement.relayerFee0);
+        DarkpoolConstants.validateFeeRate(obligation.statement.relayerFee1);
+
+        // The protocol fee must match
+        FixedPoint memory defaultProtocolFeeRate = state.getDefaultProtocolFeeRate();
+        if (obligation.statement.protocolFee.repr != defaultProtocolFeeRate.repr) {
+            revert IDarkpoolV2.InvalidProtocolFee();
+        }
 
         // Append the settlement proof to the context for verification
         BN254.ScalarField[] memory publicInputs = obligation.statement.statementSerialize();
@@ -208,8 +226,7 @@ library SettlementLib {
     /// @param obligationBundle The obligation bundle for the trade
     /// @param settlementBundle The settlement bundle to validate
     /// @param settlementContext The settlement context to which we append post-validation updates.
-    /// @param hasher The hasher to use for hashing commitments
-    /// @param vkeys The contract storing the verification keys
+    /// @param contracts The contract references needed for settlement
     /// @param state The darkpool state containing all storage references
     /// @dev This function validates and executes the settlement bundle based on the bundle type
     /// @dev See the library files in this directory for type-specific execution & validation logic.
@@ -218,8 +235,7 @@ library SettlementLib {
         ObligationBundle calldata obligationBundle,
         SettlementBundle calldata settlementBundle,
         SettlementContext memory settlementContext,
-        IHasher hasher,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         DarkpoolState storage state
     )
         internal
@@ -229,15 +245,15 @@ library SettlementLib {
             NativeSettledPublicIntentLib.execute(partyId, obligationBundle, settlementBundle, settlementContext, state);
         } else if (bundleType == SettlementBundleType.NATIVELY_SETTLED_PRIVATE_INTENT) {
             NativeSettledPrivateIntentLib.execute(
-                partyId, obligationBundle, settlementBundle, settlementContext, hasher, vkeys, state
+                partyId, obligationBundle, settlementBundle, settlementContext, contracts, state
             );
         } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_INTENT) {
             RenegadeSettledPrivateIntentLib.execute(
-                partyId, obligationBundle, settlementBundle, settlementContext, hasher, vkeys, state
+                partyId, obligationBundle, settlementBundle, settlementContext, contracts, state
             );
         } else if (bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL) {
             RenegadeSettledPrivateFillLib.execute(
-                partyId, obligationBundle, settlementBundle, settlementContext, hasher, vkeys, state
+                partyId, obligationBundle, settlementBundle, settlementContext, contracts, state
             );
         } else {
             revert IDarkpoolV2.InvalidSettlementBundleType();
@@ -248,20 +264,24 @@ library SettlementLib {
 
     /// @notice Execute the transfers necessary for settlement
     /// @param settlementContext The settlement context to execute the transfers from
-    /// @param weth The WETH9 contract instance
-    /// @param permit2 The permit2 contract instance
-    function executeTransfers(SettlementContext memory settlementContext, IWETH9 weth, IPermit2 permit2) internal {
+    /// @param contracts The contract references needed for settlement
+    function executeTransfers(
+        SettlementContext memory settlementContext,
+        SettlementContracts memory contracts
+    )
+        internal
+    {
         // First, execute the deposits
         // We execute deposits first to ensure the darkpool is capitalized for withdrawals
         for (uint256 i = 0; i < settlementContext.transfers.numDeposits(); ++i) {
             SimpleTransfer memory deposit = settlementContext.transfers.deposits.transfers[i];
-            ExternalTransferLib.executeTransfer(deposit, weth, permit2);
+            ExternalTransferLib.executeTransfer(deposit, contracts.weth, contracts.permit2);
         }
 
         // Second, execute the withdrawals
         for (uint256 i = 0; i < settlementContext.transfers.numWithdrawals(); ++i) {
             SimpleTransfer memory withdrawal = settlementContext.transfers.withdrawals.transfers[i];
-            ExternalTransferLib.executeTransfer(withdrawal, weth, permit2);
+            ExternalTransferLib.executeTransfer(withdrawal, contracts.weth, contracts.permit2);
         }
     }
 }

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
@@ -27,6 +27,7 @@ import { PrivateIntentAuthBundle, PrivateIntentAuthBundleFirstFill } from "darkp
 import { PublicInputsLib } from "darkpoolv2-lib/public_inputs/PublicInputsLib.sol";
 import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlement/SettlementBundle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
 import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
@@ -408,36 +409,36 @@ library PrivateIntentPublicBalanceBundleLib {
     /// @notice Push the validity proof to the context and validate merkle depth
     /// @param bundleData The bundle containing the validity proof
     /// @param settlementContext The context to push to
-    /// @param vkeys The verification keys contract
+    /// @param contracts The contract references needed for settlement
     function pushValidityProof(
         PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        SettlementContracts memory contracts
     )
         internal
         view
     {
         BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
-        VerificationKey memory vk = vkeys.intentOnlyFirstFillValidityKeys();
+        VerificationKey memory vk = contracts.vkeys.intentOnlyFirstFillValidityKeys();
         _pushValidityProofInner(publicInputs, bundleData.auth.validityProof, vk, settlementContext);
     }
 
     /// @notice Push the validity proof to the context and validate merkle depth
     /// @param bundleData The bundle containing the validity proof
     /// @param settlementContext The context to push to
-    /// @param vkeys The verification keys contract
+    /// @param contracts The contract references needed for settlement
     /// @param state The darkpool state for root validation
     function pushValidityProof(
         PrivateIntentPublicBalanceBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         DarkpoolState storage state
     )
         internal
         view
     {
         BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
-        VerificationKey memory vk = vkeys.intentOnlyValidityKeys();
+        VerificationKey memory vk = contracts.vkeys.intentOnlyValidityKeys();
         _pushValidityProofInner(publicInputs, bundleData.auth.validityProof, vk, settlementContext);
         state.assertRootInHistory(bundleData.auth.statement.merkleRoot);
     }
@@ -445,36 +446,36 @@ library PrivateIntentPublicBalanceBundleLib {
     /// @notice Push the validity proof to the context and validate merkle depth
     /// @param bundleData The bundle containing the validity proof
     /// @param settlementContext The context to push to
-    /// @param vkeys The verification keys contract
+    /// @param contracts The contract references needed for settlement
     function pushValidityProof(
         PrivateIntentPublicBalanceBoundedFirstFillBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        SettlementContracts memory contracts
     )
         internal
         view
     {
         BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
-        VerificationKey memory vk = vkeys.intentOnlyFirstFillValidityKeys();
+        VerificationKey memory vk = contracts.vkeys.intentOnlyFirstFillValidityKeys();
         _pushValidityProofInner(publicInputs, bundleData.auth.validityProof, vk, settlementContext);
     }
 
     /// @notice Push the validity proof to the context and validate merkle depth
     /// @param bundleData The bundle containing the validity proof
     /// @param settlementContext The context to push to
-    /// @param vkeys The verification keys contract
+    /// @param contracts The contract references needed for settlement
     /// @param state The darkpool state for root validation
     function pushValidityProof(
         PrivateIntentPublicBalanceBoundedBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys,
+        SettlementContracts memory contracts,
         DarkpoolState storage state
     )
         internal
         view
     {
         BN254.ScalarField[] memory publicInputs = bundleData.auth.statement.statementSerialize();
-        VerificationKey memory vk = vkeys.intentOnlyValidityKeys();
+        VerificationKey memory vk = contracts.vkeys.intentOnlyValidityKeys();
         _pushValidityProofInner(publicInputs, bundleData.auth.validityProof, vk, settlementContext);
         state.assertRootInHistory(bundleData.auth.statement.merkleRoot);
     }
@@ -503,11 +504,11 @@ library PrivateIntentPublicBalanceBundleLib {
     /// @notice Push the settlement proof and proof linking argument to the context
     /// @param bundleData The bundle containing proofs
     /// @param settlementContext The context to push to
-    /// @param vkeys The verification keys contract
+    /// @param contracts The contract references needed for settlement
     function pushSettlementProofs(
         PrivateIntentPublicBalanceFirstFillBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        SettlementContracts memory contracts
     )
         internal
         view
@@ -518,18 +519,18 @@ library PrivateIntentPublicBalanceBundleLib {
             bundleData.auth.validityProof,
             bundleData.authSettlementLinkingProof,
             settlementContext,
-            vkeys
+            contracts
         );
     }
 
     /// @notice Push the settlement proof and proof linking argument to the context
     /// @param bundleData The bundle containing proofs
     /// @param settlementContext The context to push to
-    /// @param vkeys The verification keys contract
+    /// @param contracts The contract references needed for settlement
     function pushSettlementProofs(
         PrivateIntentPublicBalanceBundle memory bundleData,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        SettlementContracts memory contracts
     )
         internal
         view
@@ -540,7 +541,7 @@ library PrivateIntentPublicBalanceBundleLib {
             bundleData.auth.validityProof,
             bundleData.authSettlementLinkingProof,
             settlementContext,
-            vkeys
+            contracts
         );
     }
 
@@ -576,21 +577,21 @@ library PrivateIntentPublicBalanceBundleLib {
     /// @param validityProof The validity proof (for proof linking)
     /// @param authSettlementLinkingProof The proof linking the auth and settlement proofs
     /// @param settlementContext The context to push to
-    /// @param vkeys The verification keys contract
+    /// @param contracts The contract references needed for settlement
     function _pushSettlementProofsInner(
         IntentOnlyPublicSettlementStatement memory settlementStatement,
         PlonkProof memory settlementProof,
         PlonkProof memory validityProof,
         LinkingProof memory authSettlementLinkingProof,
         SettlementContext memory settlementContext,
-        IVkeys vkeys
+        SettlementContracts memory contracts
     )
         private
         view
     {
         // Push the settlement proof
         BN254.ScalarField[] memory publicInputs = settlementStatement.statementSerialize();
-        VerificationKey memory vk = vkeys.intentOnlyPublicSettlementKeys();
+        VerificationKey memory vk = contracts.vkeys.intentOnlyPublicSettlementKeys();
         settlementContext.pushProof(publicInputs, settlementProof, vk);
 
         // Push the proof linking argument
@@ -598,7 +599,7 @@ library PrivateIntentPublicBalanceBundleLib {
             wireComm0: validityProof.wireComms[0],
             wireComm1: settlementProof.wireComms[0],
             proof: authSettlementLinkingProof,
-            vk: vkeys.intentOnlySettlementLinkingKey()
+            vk: contracts.vkeys.intentOnlySettlementLinkingKey()
         });
         settlementContext.pushProofLinkingArgument(proofLinkingArgument);
     }

--- a/test/darkpool/v2/DarkpoolV2TestBase.sol
+++ b/test/darkpool/v2/DarkpoolV2TestBase.sol
@@ -26,6 +26,8 @@ import { IGasSponsor } from "darkpoolv1-interfaces/IGasSponsor.sol";
 
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { TestVerifierV2 } from "test-contracts/TestVerifierV2.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { DarkpoolV2 } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
 // solhint-disable-next-line max-states-count
 contract DarkpoolV2TestBase is TestUtils {
@@ -262,5 +264,23 @@ contract DarkpoolV2TestBase is TestUtils {
     function etherQuoteBalances(address addr) public view returns (uint256 etherAmt, uint256 quoteAmt) {
         etherAmt = addr.balance;
         quoteAmt = quoteToken.balanceOf(addr);
+    }
+
+    /// @notice Create a SettlementContracts struct from the test's contract instances
+    /// @param verifier The verifier to use (if not provided, uses the darkpool's verifier)
+    function getSettlementContracts(IVerifier verifier) public view returns (SettlementContracts memory contracts) {
+        contracts = SettlementContracts({
+            hasher: hasher,
+            verifier: verifier,
+            weth: IWETH9(address(weth)),
+            permit2: permit2,
+            vkeys: vkeys
+        });
+    }
+
+    /// @notice Create a SettlementContracts struct using the darkpool's verifier
+    function getSettlementContracts() public view returns (SettlementContracts memory contracts) {
+        DarkpoolV2 darkpoolImpl = DarkpoolV2(address(darkpool));
+        contracts = getSettlementContracts(darkpoolImpl.verifier());
     }
 }

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -19,6 +19,7 @@ import {
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { NativeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/NativeSettledPrivateIntent.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
@@ -41,8 +42,9 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         returns (SettlementContext memory)
     {
         SettlementContext memory settlementContext = _createSettlementContext();
+        SettlementContracts memory contracts = getSettlementContracts();
         SettlementLib.executeSettlementBundle(
-            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, hasher, vkeys, darkpoolState
+            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, contracts, darkpoolState
         );
         return settlementContext;
     }

--- a/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
@@ -8,7 +8,10 @@ import { ObligationBundle } from "darkpoolv2-types/settlement/ObligationBundle.s
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
+import { TestVerifierV2 } from "test-contracts/TestVerifierV2.sol";
 import { PublicIntentSettlementTestUtils } from "./Utils.sol";
 
 contract ObligationCompatibilityTest is PublicIntentSettlementTestUtils {
@@ -17,13 +20,16 @@ contract ObligationCompatibilityTest is PublicIntentSettlementTestUtils {
     // -----------
 
     /// @notice Wrapper to convert memory to calldata for library call
-    function _validateObligationBundle(ObligationBundle calldata bundle) public view {
+    function _validateObligationBundle(ObligationBundle calldata bundle) public {
         SettlementContext memory settlementContext = _createSettlementContext();
-        SettlementLib.validateObligationBundle(bundle, settlementContext, vkeys);
+        // Create a dummy verifier since it's not used in validateObligationBundle
+        IVerifier dummyVerifier = new TestVerifierV2();
+        SettlementContracts memory contracts = getSettlementContracts(dummyVerifier);
+        SettlementLib.validateObligationBundle(bundle, settlementContext, darkpoolState, contracts);
     }
 
     /// @notice Helper that accepts memory and calls library with calldata
-    function validateObligationBundleHelper(ObligationBundle memory bundle) internal view {
+    function validateObligationBundleHelper(ObligationBundle memory bundle) internal {
         this._validateObligationBundle(bundle);
     }
 

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
@@ -14,6 +14,7 @@ import {
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { RenegadeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/RenegadeSettledPrivateIntent.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
@@ -33,8 +34,9 @@ contract RenegadeSettledPrivateFillAuthorizationTest is RenegadeSettledPrivateFi
         returns (SettlementContext memory)
     {
         SettlementContext memory settlementContext = _createSettlementContext();
+        SettlementContracts memory contracts = getSettlementContracts();
         SettlementLib.executeSettlementBundle(
-            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, hasher, vkeys, darkpoolState
+            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, contracts, darkpoolState
         );
         return settlementContext;
     }

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
@@ -153,6 +153,7 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
         PostMatchBalanceShare memory party1InBalanceShares = randomPostMatchBalanceShare();
         PostMatchBalanceShare memory party1OutBalanceShares = randomPostMatchBalanceShare();
 
+        FixedPoint memory protocolFee = darkpool.getDefaultProtocolFee();
         IntentAndBalancePrivateSettlementStatement memory statement = IntentAndBalancePrivateSettlementStatement({
             newAmountPublicShare0: randomScalar(),
             newInBalancePublicShares0: party0InBalanceShares,
@@ -162,7 +163,7 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
             newOutBalancePublicShares1: party1OutBalanceShares,
             relayerFee0: randomFee(),
             relayerFee1: randomFee(),
-            protocolFee: randomFee()
+            protocolFee: protocolFee
         });
 
         return PrivateObligationBundle({ statement: statement, proof: createDummyProof() });

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
@@ -13,6 +13,7 @@ import {
 import { SettlementContext } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
+import { SettlementContracts } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { RenegadeSettledPrivateIntentLib } from "darkpoolv2-lib/settlement/RenegadeSettledPrivateIntent.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
@@ -40,8 +41,9 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
         returns (SettlementContext memory)
     {
         SettlementContext memory settlementContext = _createSettlementContext();
+        SettlementContracts memory contracts = getSettlementContracts();
         SettlementLib.executeSettlementBundle(
-            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, hasher, vkeys, darkpoolState
+            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, contracts, darkpoolState
         );
         return settlementContext;
     }


### PR DESCRIPTION
### Purpose
This PR:
- Adds verification of the fees charged in the private obligation bundle.
- Groups the contracts used for settlement into a `SettlementContracts` type. The motivation for this was a stack too deep error, but it serves a cleanup purpose regardless.

### Testing
 - [x] All tests pass 