### PR TITLE
darkpoolv2: state-updates: Implement private relayer fees

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -252,7 +252,8 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
 
     /// @inheritdoc IDarkpoolV2
     function payPrivateRelayerFee(PrivateRelayerFeePaymentProofBundle calldata proofBundle) public {
-        StateUpdatesLib.payPrivateRelayerFee(proofBundle);
+        DarkpoolContracts memory contracts = _getDarkpoolContracts();
+        StateUpdatesLib.payPrivateRelayerFee(proofBundle, contracts, _state);
     }
 
     // --------------

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -33,6 +33,8 @@ interface IDarkpoolV2 {
     // --- Error Messages --- //
     /// @notice The nullifier has already been spent
     error NullifierAlreadySpent();
+    /// @notice Error thrown when a signature nonce has already been spent
+    error NonceAlreadySpent();
     /// @notice Thrown when a Merkle root is not in the history
     error InvalidMerkleRoot();
     /// @notice Thrown when the Merkle depth is invalid
@@ -103,6 +105,8 @@ interface IDarkpoolV2 {
     error InvalidProtocolFeeReceiver();
     /// @notice Thrown when the protocol fee encryption key does not match the expected value
     error InvalidProtocolFeeEncryptionKey();
+    /// @notice Thrown when the relayer ciphertext signature is invalid
+    error InvalidRelayerCiphertextSignature();
 
     // --- Events --- //
 

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol
@@ -19,10 +19,9 @@ import { DarkpoolContracts } from "darkpoolv2-contracts/DarkpoolV2.sol";
 import {
     RenegadeSettledIntentAuthBundleFirstFill,
     RenegadeSettledIntentAuthBundle,
-    SignatureWithNonce,
-    SignatureWithNonceLib,
     PrivateIntentPrivateBalanceAuthBundleLib
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 import {
     OutputBalanceBundle,
     OutputBalanceBundleLib,
@@ -287,9 +286,8 @@ library PrivateIntentPrivateBalanceBundleLib {
         bytes32 digest = PrivateIntentPrivateBalanceAuthBundleLib.getOwnerSignatureDigest(bundleData);
         address signer = bundleData.statement.oneTimeAuthorizingAddress;
 
-        bool valid = bundleData.ownerSignature.verifyPrehashed(signer, digest);
+        bool valid = bundleData.ownerSignature.verifyPrehashedAndSpendNonce(signer, digest, state);
         if (!valid) revert IDarkpoolV2.InvalidOwnerSignature();
-        state.spendNonce(bundleData.ownerSignature.nonce);
     }
 
     // --------------------------------

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
@@ -29,7 +29,7 @@ import { SettlementBundle, SettlementBundleType } from "darkpoolv2-types/settlem
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { DarkpoolContracts } from "darkpoolv2-contracts/DarkpoolV2.sol";
 import { SettlementObligation, SettlementObligationLib } from "darkpoolv2-types/Obligation.sol";
-import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignatureWithNonce, SignatureWithNonceLib } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 import { SimpleTransfer } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
 
 // ---------------------------------
@@ -333,9 +333,8 @@ library PrivateIntentPublicBalanceBundleLib {
         uint256 commitment = BN254.ScalarField.unwrap(preMatchIntentCommitment);
 
         bytes32 commitmentHash = EfficientHashLib.hash(bytes32(commitment));
-        bool valid = authBundle.intentSignature.verifyPrehashed(intentOwner, commitmentHash);
+        bool valid = authBundle.intentSignature.verifyPrehashedAndSpendNonce(intentOwner, commitmentHash, state);
         if (!valid) revert IDarkpoolV2.InvalidIntentCommitmentSignature();
-        state.spendNonce(authBundle.intentSignature.nonce);
     }
 
     // -------------------------

--- a/src/darkpool/v2/types/ProofBundles.sol
+++ b/src/darkpool/v2/types/ProofBundles.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
+import { ElGamalCiphertext } from "renegade-lib/Ciphertext.sol";
 import {
     ValidDepositStatement,
     ValidBalanceCreateStatement,
@@ -96,6 +98,10 @@ struct PrivateProtocolFeePaymentProofBundle {
 struct PrivateRelayerFeePaymentProofBundle {
     /// @dev The Merkle depth of the balance
     uint256 merkleDepth;
+    /// @dev The note ciphertext
+    ElGamalCiphertext noteCiphertext;
+    /// @dev A signature by the relayer authorizing the encryption of the note
+    SignatureWithNonce relayerCiphertextSignature;
     /// @dev The statement of the private relayer fee payment validity
     ValidPrivateRelayerFeePaymentStatement statement;
     /// @dev The proof of the private relayer fee payment validity

--- a/src/darkpool/v2/types/settlement/BoundedMatchResultBundle.sol
+++ b/src/darkpool/v2/types/settlement/BoundedMatchResultBundle.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.24;
 
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-import { SignatureWithNonce } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
 
 // --------------------------------------------

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-import { ECDSALib } from "renegade-lib/ECDSA.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import {
     IntentOnlyValidityStatement,
@@ -13,48 +12,11 @@ import {
     IntentAndBalanceValidityStatement
 } from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 
 // ------------------------------
 // | Intent Authorization Types |
 // ------------------------------
-
-/// @notice A signature with a nonce
-/// @dev We assume the signature is encoded in the format:
-/// - r in the first 32 bytes
-/// - s in the next 32 bytes
-/// - v in the last byte
-/// @dev We further assume that the signature is over the following:
-/// H(H(message) || nonce)
-struct SignatureWithNonce {
-    /// @dev The nonce of the signature
-    uint256 nonce;
-    /// @dev The signature
-    bytes signature;
-}
-
-/// @title Signature With Nonce Library
-/// @author Renegade Eng
-/// @notice Library for computing the hash of a signature with a nonce
-library SignatureWithNonceLib {
-    /// @notice Verify a signature with a nonce
-    /// @param signature The signature to verify
-    /// @param expectedSigner The expected signer of the signature
-    /// @param digest The bytes32 digest of the message to verify
-    /// @return Whether the signature is valid
-    /// @dev Verifies the signature over H(digest || nonce)
-    function verifyPrehashed(
-        SignatureWithNonce memory signature,
-        address expectedSigner,
-        bytes32 digest
-    )
-        internal
-        pure
-        returns (bool)
-    {
-        bytes32 signatureHash = EfficientHashLib.hash(digest, bytes32(signature.nonce));
-        return ECDSALib.verify(signatureHash, signature.signature, expectedSigner);
-    }
-}
 
 // --- Public Intent Authorization --- //
 

--- a/src/darkpool/v2/types/settlement/SignatureWithNonce.sol
+++ b/src/darkpool/v2/types/settlement/SignatureWithNonce.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache
+pragma solidity ^0.8.24;
+
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { ECDSALib } from "renegade-lib/ECDSA.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+
+/// @notice A signature with a nonce
+/// @dev We assume the signature is encoded in the format:
+/// - r in the first 32 bytes
+/// - s in the next 32 bytes
+/// - v in the last byte
+/// @dev We further assume that the signature is over the following:
+/// H(H(message) || nonce)
+struct SignatureWithNonce {
+    /// @dev The nonce of the signature
+    uint256 nonce;
+    /// @dev The signature
+    bytes signature;
+}
+
+/// @title Signature With Nonce Library
+/// @author Renegade Eng
+/// @notice Library for computing the hash of a signature with a nonce
+library SignatureWithNonceLib {
+    using DarkpoolStateLib for DarkpoolState;
+
+    /// @notice Verify a signature with a nonce and spend the nonce
+    /// @param signature The signature to verify
+    /// @param expectedSigner The expected signer of the signature
+    /// @param digest The bytes32 digest of the message to verify
+    /// @param state The darkpool state to spend the nonce in
+    /// @return Whether the signature is valid
+    /// @dev Verifies the signature over H(digest || nonce) and always spends the nonce to prevent replay
+    function verifyPrehashedAndSpendNonce(
+        SignatureWithNonce memory signature,
+        address expectedSigner,
+        bytes32 digest,
+        DarkpoolState storage state
+    )
+        internal
+        returns (bool)
+    {
+        // Spend the nonce to prevent replay
+        state.spendNonce(signature.nonce);
+
+        // Verify the signature
+        bytes32 signatureHash = EfficientHashLib.hash(digest, bytes32(signature.nonce));
+        return ECDSALib.verify(signatureHash, signature.signature, expectedSigner);
+    }
+}

--- a/test/darkpool/v2/state-updates/PrivateRelayerFee.t.sol
+++ b/test/darkpool/v2/state-updates/PrivateRelayerFee.t.sol
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+/* solhint-disable gas-small-strings */
+/* solhint-disable func-name-mixedcase */
+pragma solidity ^0.8.24;
+
+import { Vm } from "forge-std/Vm.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { DarkpoolV2TestUtils } from "../DarkpoolV2TestUtils.sol";
+import { PrivateRelayerFeePaymentProofBundle } from "darkpoolv2-types/ProofBundles.sol";
+import { ValidPrivateRelayerFeePaymentStatement } from "darkpoolv2-lib/public_inputs/Fees.sol";
+import { MerkleMountainLib } from "renegade-lib/merkle/MerkleMountain.sol";
+import { ElGamalCiphertext, BabyJubJubPoint } from "renegade-lib/Ciphertext.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
+/// @title PrivateRelayerFeeTest
+/// @author Renegade Eng
+/// @notice Tests for the private relayer fee payment functionality in DarkpoolV2
+contract PrivateRelayerFeeTest is DarkpoolV2TestUtils {
+    using MerkleMountainLib for MerkleMountainLib.MerkleMountainRange;
+
+    // Test state
+    MerkleMountainLib.MerkleMountainRange private testMountain;
+    Vm.Wallet private relayerWallet;
+
+    /// @notice Set up the test environment
+    function setUp() public override {
+        super.setUp();
+        // Create a wallet for the relayer to sign ciphertexts
+        relayerWallet = vm.createWallet("relayer");
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @notice Create a dummy ElGamalCiphertext
+    /// @return ciphertext The created ciphertext
+    function createDummyCiphertext() internal returns (ElGamalCiphertext memory ciphertext) {
+        BN254.ScalarField[] memory ciphertextData = new BN254.ScalarField[](3);
+        ciphertextData[0] = randomScalar();
+        ciphertextData[1] = randomScalar();
+        ciphertextData[2] = randomScalar();
+
+        ciphertext = ElGamalCiphertext({
+            ephemeralKey: BabyJubJubPoint({ x: randomScalar(), y: randomScalar() }),
+            ciphertext: ciphertextData
+        });
+    }
+
+    /// @notice Create a signature with nonce for the ciphertext
+    /// @param ciphertext The ciphertext to sign
+    /// @param signerPrivateKey The private key of the signer
+    /// @return signature The signature with nonce
+    function signCiphertext(
+        ElGamalCiphertext memory ciphertext,
+        uint256 signerPrivateKey
+    )
+        internal
+        returns (SignatureWithNonce memory signature)
+    {
+        // Hash the ciphertext bytes
+        bytes memory ciphertextBytes = abi.encode(ciphertext);
+        bytes32 ciphertextHash = EfficientHashLib.hash(ciphertextBytes);
+
+        // Hash the ciphertext hash with a nonce
+        uint256 nonce = randomUint();
+        bytes32 signatureDigest = EfficientHashLib.hash(ciphertextHash, bytes32(nonce));
+
+        // Create the signature
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, signatureDigest);
+        signature = SignatureWithNonce({ nonce: nonce, signature: abi.encodePacked(r, s, v) });
+    }
+
+    /// @notice Create a private relayer fee payment proof bundle
+    /// @param merkleRoot The Merkle root for the balance
+    /// @param receiver The relayer fee receiver address
+    /// @param signerPrivateKey The private key to sign the ciphertext
+    /// @return proofBundle The created proof bundle
+    function createPrivateRelayerFeeProofBundle(
+        BN254.ScalarField merkleRoot,
+        address receiver,
+        uint256 signerPrivateKey
+    )
+        internal
+        returns (PrivateRelayerFeePaymentProofBundle memory proofBundle)
+    {
+        BN254.ScalarField oldBalanceNullifier = randomScalar();
+        BN254.ScalarField newBalanceCommitment = randomScalar();
+        BN254.ScalarField recoveryId = randomScalar();
+        BN254.ScalarField newRelayerFeeBalanceShare = randomScalar();
+        BN254.ScalarField noteCommitment = randomScalar();
+        uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
+
+        ElGamalCiphertext memory noteCiphertext = createDummyCiphertext();
+        SignatureWithNonce memory relayerSignature = signCiphertext(noteCiphertext, signerPrivateKey);
+
+        ValidPrivateRelayerFeePaymentStatement memory statement = ValidPrivateRelayerFeePaymentStatement({
+            merkleRoot: merkleRoot,
+            oldBalanceNullifier: oldBalanceNullifier,
+            newBalanceCommitment: newBalanceCommitment,
+            recoveryId: recoveryId,
+            newRelayerFeeBalanceShare: newRelayerFeeBalanceShare,
+            relayerFeeReceiver: receiver,
+            noteCommitment: noteCommitment
+        });
+
+        proofBundle = PrivateRelayerFeePaymentProofBundle({
+            merkleDepth: merkleDepth,
+            noteCiphertext: noteCiphertext,
+            relayerCiphertextSignature: relayerSignature,
+            statement: statement,
+            proof: createDummyProof()
+        });
+    }
+
+    /// @notice Generate random private relayer fee payment calldata with valid relayer config
+    /// @return proofBundle The proof bundle for the fee payment
+    function generateRandomFeePaymentCalldata()
+        internal
+        returns (PrivateRelayerFeePaymentProofBundle memory proofBundle)
+    {
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+        proofBundle = createPrivateRelayerFeeProofBundle(merkleRoot, relayerWallet.addr, relayerWallet.privateKey);
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// @notice Test a successful private relayer fee payment
+    function test_payPrivateRelayerFee_success() public {
+        // Generate test data
+        PrivateRelayerFeePaymentProofBundle memory proofBundle = generateRandomFeePaymentCalldata();
+
+        // Execute the fee payment (should not revert)
+        darkpool.payPrivateRelayerFee(proofBundle);
+    }
+
+    /// @notice Test the Merkle root after a private fee payment
+    /// @dev Both the new balance commitment and note commitment should be inserted
+    function test_payPrivateRelayerFee_merkleRoot() public {
+        // Generate test data
+        PrivateRelayerFeePaymentProofBundle memory proofBundle = generateRandomFeePaymentCalldata();
+
+        // Execute the fee payment
+        darkpool.payPrivateRelayerFee(proofBundle);
+
+        // Build a parallel merkle tree with the same operations
+        uint256 depth = proofBundle.merkleDepth;
+        testMountain.insertLeaf(depth, proofBundle.statement.newBalanceCommitment, hasher);
+        testMountain.insertLeaf(depth, proofBundle.statement.noteCommitment, hasher);
+        BN254.ScalarField root = testMountain.getRoot(depth);
+
+        // The root should be in the darkpool's history
+        bool rootInHistory = darkpool.rootInHistory(root);
+        assertTrue(rootInHistory, "Merkle root should be in history after both insertions");
+    }
+
+    /// @notice Test fee payment with invalid Merkle root
+    function test_payPrivateRelayerFee_invalidMerkleRoot_reverts() public {
+        // Use a random Merkle root that is NOT in history
+        BN254.ScalarField invalidMerkleRoot = randomScalar();
+        address receiver = relayerWallet.addr;
+        PrivateRelayerFeePaymentProofBundle memory proofBundle =
+            createPrivateRelayerFeeProofBundle(invalidMerkleRoot, receiver, relayerWallet.privateKey);
+
+        // Should revert due to invalid Merkle root
+        vm.expectRevert(IDarkpoolV2.InvalidMerkleRoot.selector);
+        darkpool.payPrivateRelayerFee(proofBundle);
+    }
+
+    /// @notice Test that double spending the same signature nonce + nullifier fails
+    function test_payPrivateRelayerFee_doubleSpend_reverts() public {
+        // Generate test data
+        PrivateRelayerFeePaymentProofBundle memory proofBundle = generateRandomFeePaymentCalldata();
+
+        // Execute the first fee payment
+        darkpool.payPrivateRelayerFee(proofBundle);
+
+        // Second attempt with the same signature nonce + nullifier should fail
+        vm.expectRevert(IDarkpoolV2.NonceAlreadySpent.selector);
+        darkpool.payPrivateRelayerFee(proofBundle);
+    }
+
+    /// @notice Test fee payment with wrong relayer fee receiver
+    function test_payPrivateRelayerFee_wrongReceiver_reverts() public {
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+        address wrongReceiver = vm.randomAddress();
+        PrivateRelayerFeePaymentProofBundle memory proofBundle =
+            createPrivateRelayerFeeProofBundle(merkleRoot, wrongReceiver, relayerWallet.privateKey);
+
+        // Should revert due to invalid relayer ciphertext signature (receiver doesn't match signer)
+        vm.expectRevert(IDarkpoolV2.InvalidRelayerCiphertextSignature.selector);
+        darkpool.payPrivateRelayerFee(proofBundle);
+    }
+
+    /// @notice Test fee payment with invalid signature (wrong signer)
+    function test_payPrivateRelayerFee_invalidSignature_reverts() public {
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+        address receiver = relayerWallet.addr;
+        // Use wrong signer's private key (signature won't match receiver)
+        PrivateRelayerFeePaymentProofBundle memory proofBundle =
+            createPrivateRelayerFeeProofBundle(merkleRoot, receiver, wrongSigner.privateKey);
+
+        // Should revert due to invalid relayer ciphertext signature
+        vm.expectRevert(IDarkpoolV2.InvalidRelayerCiphertextSignature.selector);
+        darkpool.payPrivateRelayerFee(proofBundle);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds an implementation of the private relayer fee payment contract method, along with tests.

The note ciphertext here is verified by a signature over the ciphertext's abi encoding. 

I also made a change to automatically spend the nonce in the `SignatureWithNonce` library. This removes the need for the caller to remember to spend the nonce.

### Testing
- [x] All tests pass