### PR TITLE
darkpoolv2: emit `NotePosted` and `NullifierSpent` event

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -80,9 +80,6 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     /// @notice Emitted when the external fee collection address is changed
     /// @param newAddress The new fee collection address
     event ExternalFeeCollectionAddressChanged(address indexed newAddress);
-    /// @notice Emitted when a note is posted to the darkpool
-    /// @param noteCommitment The commitment to the note
-    event NotePosted(uint256 indexed noteCommitment);
 
     // -----------
     // | Storage |

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -132,6 +132,9 @@ interface IDarkpoolV2 {
     /// @notice Emitted when a new recovery ID is registered on-chain
     /// @param recoveryId The recovery ID that was registered
     event RecoveryIdRegistered(BN254.ScalarField indexed recoveryId);
+    /// @notice Emitted when a note is posted to the darkpool
+    /// @param noteCommitment The commitment to the note
+    event NotePosted(uint256 indexed noteCommitment);
 
     /// @notice Initialize the darkpool contract
     /// @param initialOwner The initial owner of the contract

--- a/src/darkpool/v2/libraries/DarkpoolState.sol
+++ b/src/darkpool/v2/libraries/DarkpoolState.sol
@@ -214,6 +214,9 @@ library DarkpoolStateLib {
     /// @param nullifier The nullifier to spend
     function spendNullifier(DarkpoolState storage state, BN254.ScalarField nullifier) internal {
         state.nullifierSet.spend(nullifier);
+
+        // Emit the nullifier spent event
+        emit IDarkpoolV2.NullifierSpent(nullifier);
     }
 
     /// @notice Check if a nullifier has been spent

--- a/src/darkpool/v2/libraries/StateUpdatesLib.sol
+++ b/src/darkpool/v2/libraries/StateUpdatesLib.sol
@@ -281,6 +281,9 @@ library StateUpdatesLib {
         state.insertMerkleLeaf(proofBundle.merkleDepth, newBalanceCommitment, contracts.hasher);
         state.insertMerkleLeaf(proofBundle.merkleDepth, noteCommitment, contracts.hasher);
 
+        // Emit the note posted event
+        emit IDarkpoolV2.NotePosted(BN254.ScalarField.unwrap(noteCommitment));
+
         // Emit the recovery id
         emit IDarkpoolV2.RecoveryIdRegistered(proofBundle.statement.recoveryId);
     }
@@ -321,6 +324,9 @@ library StateUpdatesLib {
         state.spendNullifier(balanceNullifier);
         state.insertMerkleLeaf(proofBundle.merkleDepth, newBalanceCommitment, contracts.hasher);
         state.insertMerkleLeaf(proofBundle.merkleDepth, noteCommitment, contracts.hasher);
+
+        // Emit the note posted event
+        emit IDarkpoolV2.NotePosted(BN254.ScalarField.unwrap(noteCommitment));
 
         // Emit the recovery id
         emit IDarkpoolV2.RecoveryIdRegistered(proofBundle.statement.recoveryId);

--- a/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
+++ b/src/darkpool/v2/libraries/public_inputs/PublicInputsLib.sol
@@ -527,34 +527,4 @@ library PublicInputsLib {
         publicInputs[15] = BN254.ScalarField.wrap(statement.relayerFee1.repr);
         publicInputs[16] = BN254.ScalarField.wrap(statement.protocolFee.repr);
     }
-
-    /// @notice Get a dummy verification key for testing
-    /// @return A dummy verification key
-    /// @dev TODO: Replace with real verification key
-    function dummyVkey() internal pure returns (VerificationKey memory) {
-        return VerificationKey({
-            n: 0,
-            l: 0,
-            k: [BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO, BN254Helpers.ZERO],
-            qComms: [
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1(),
-                BN254.P1()
-            ],
-            sigmaComms: [BN254.P1(), BN254.P1(), BN254.P1(), BN254.P1(), BN254.P1()],
-            g: BN254.P1(),
-            h: BN254.P2(),
-            xH: BN254.P2()
-        });
-    }
 }

--- a/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
@@ -194,7 +194,7 @@ library ExternalSettlementLib {
                 state
             );
         } else {
-            // TODO: Add support for other settlement bundle types
+            // Note: External settlement of RENEGADE_SETTLED_PRIVATE_FILL is not supported.
             revert IDarkpoolV2.InvalidSettlementBundleType();
         }
     }

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol
@@ -744,7 +744,6 @@ library PrivateIntentPrivateBalanceBoundedLib {
 
         // Push the settlement proof to the settlement context
         BN254.ScalarField[] memory publicInputs = statement.statementSerialize();
-        // TODO: Update verification keys
         VerificationKey memory vk = contracts.vkeys.intentAndBalanceBoundedSettlementKeys();
         settlementContext.pushProof(publicInputs, proof, vk);
     }


### PR DESCRIPTION
### Purpose

This PR ensures `NotePosted` and `NullifierSpent` events are emitted when needed.

### Testing

- [x] All tests pass