### PR TITLE
darkpoolv2: libraries: emit `RecoveryIdRegistered`

### DIFF
--- a/src/darkpool/v2/libraries/StateUpdatesLib.sol
+++ b/src/darkpool/v2/libraries/StateUpdatesLib.sol
@@ -104,6 +104,9 @@ library StateUpdatesLib {
         BN254.ScalarField balanceNullifier = depositProofBundle.statement.oldBalanceNullifier;
         state.spendNullifier(balanceNullifier);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+
+        // Emit the recovery id
+        emit IDarkpoolV2.RecoveryIdRegistered(depositProofBundle.statement.recoveryId);
     }
 
     /// @notice Deposit a new balance into the darkpool
@@ -135,6 +138,9 @@ library StateUpdatesLib {
         // 3. Update the state; insert the new balance
         uint256 merkleDepth = newBalanceProofBundle.merkleDepth;
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+
+        // Emit the recovery id
+        emit IDarkpoolV2.RecoveryIdRegistered(newBalanceProofBundle.statement.recoveryId);
     }
 
     // --- Withdrawal --- //
@@ -168,6 +174,9 @@ library StateUpdatesLib {
         BN254.ScalarField balanceNullifier = withdrawalProofBundle.statement.oldBalanceNullifier;
         state.spendNullifier(balanceNullifier);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
+
+        // Emit the recovery id
+        emit IDarkpoolV2.RecoveryIdRegistered(withdrawalProofBundle.statement.recoveryId);
     }
 
     // --- Fees --- //

--- a/src/darkpool/v2/libraries/settlement/bundles/RenegadeSettledPrivateFillLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/RenegadeSettledPrivateFillLib.sol
@@ -236,6 +236,11 @@ library RenegadeSettledPrivateFillLib {
         uint256 merkleDepth = bundleData.auth.merkleDepth;
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+
+        // 3. Emit recovery IDs for the intent and balance
+        IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
     }
 
     /// @notice Update the intent and input balance after authorization on a subsequent fill
@@ -282,6 +287,11 @@ library RenegadeSettledPrivateFillLib {
         uint256 merkleDepth = bundleData.auth.merkleDepth;
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
+
+        // 3. Emit recovery IDs for the intent and balance
+        IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
+        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
     }
 
     // --------------------------------


### PR DESCRIPTION
### Purpose

This PR adds `RecoveryIdRegistered` event emission in 
- deposit
- depositNewBalance
- withdraw
- `RenegadeSettledPrivateFill` balance + intent commitment update (was missing previously)

### Testing

- [x] All tests pass