### PR TITLE
darkpoolv2: add public order cancellation

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "function",
-    "name": "cancelOrder",
+    "name": "cancelPrivateOrder",
     "inputs": [
       {
         "name": "auth",
@@ -160,6 +160,89 @@
                 "internalType": "BN254.ScalarField"
               }
             ]
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelPublicOrder",
+    "inputs": [
+      {
+        "name": "auth",
+        "type": "tuple",
+        "internalType": "struct OrderCancellationAuth",
+        "components": [
+          {
+            "name": "signature",
+            "type": "tuple",
+            "internalType": "struct SignatureWithNonce",
+            "components": [
+              {
+                "name": "nonce",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "permit",
+        "type": "tuple",
+        "internalType": "struct PublicIntentPermit",
+        "components": [
+          {
+            "name": "intent",
+            "type": "tuple",
+            "internalType": "struct Intent",
+            "components": [
+              {
+                "name": "inToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "outToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "owner",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "minPrice",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "amountIn",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "executor",
+            "type": "address",
+            "internalType": "address"
           }
         ]
       }
@@ -2266,6 +2349,25 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "BN254.ScalarField"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PublicOrderCancelled",
+    "inputs": [
+      {
+        "name": "orderHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
       }
     ],
     "anonymous": false

--- a/integration/v2/src/tests/state_updates/cancel_order.rs
+++ b/integration/v2/src/tests/state_updates/cancel_order.rs
@@ -31,7 +31,7 @@ async fn test_cancel_order(args: TestArgs) -> Result<()> {
     // Submit a cancellation transaction
     let (auth, bundle) =
         generate_cancellation_bundle(&elements.intent, &elements.intent_opening, &args)?;
-    let tx = args.darkpool.cancelOrder(auth, bundle);
+    let tx = args.darkpool.cancelPrivateOrder(auth, bundle);
     wait_for_tx_success(tx).await?;
 
     // Check that the intent's nullifier is spent

--- a/src/darkpool/v1/interfaces/IDarkpool.sol
+++ b/src/darkpool/v1/interfaces/IDarkpool.sol
@@ -84,7 +84,7 @@ interface IDarkpool {
     event ExternalTransfer(address indexed account, address indexed mint, bool indexed isWithdrawal, uint256 amount);
     /// @notice Emitted when a note commitment is inserted into the Merkle tree
     /// @param noteCommitment The commitment inserted
-    event NotePosted(uint256 indexed noteCommitment);
+    event NotePosted(BN254.ScalarField indexed noteCommitment);
 
     /// @notice Initialize the darkpool
     /// @param initialOwner The initial owner of the contract

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -201,7 +201,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     // --- Order Cancellation --- //
 
     /// @inheritdoc IDarkpoolV2
-    function cancelOrder(
+    function cancelPrivateOrder(
         OrderCancellationAuth memory auth,
         OrderCancellationProofBundle calldata orderCancellationProofBundle
     )
@@ -211,7 +211,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     }
 
     /// @inheritdoc IDarkpoolV2
-    function cancelOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) public {
+    function cancelPublicOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) public {
         StateUpdatesLib.cancelPublicOrder(_state, auth, permit);
     }
 

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -39,6 +39,7 @@ import {
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
+import { PublicIntentPermit } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { ExternalSettlementLib } from "darkpoolv2-lib/settlement/ExternalSettlementLib.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
@@ -206,7 +207,12 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     )
         public
     {
-        StateUpdatesLib.cancelOrder(_state, verifier, auth, orderCancellationProofBundle);
+        StateUpdatesLib.cancelPrivateOrder(_state, verifier, auth, orderCancellationProofBundle);
+    }
+
+    /// @inheritdoc IDarkpoolV2
+    function cancelOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) public {
+        StateUpdatesLib.cancelPublicOrder(_state, auth, permit);
     }
 
     // --- Deposit --- //

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -19,6 +19,7 @@ import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMat
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
+import { PublicIntentPermit } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
 import { FixedPoint } from "renegade-lib/FixedPoint.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
@@ -136,9 +137,10 @@ interface IDarkpoolV2 {
     /// @notice Emitted when a new recovery ID is registered on-chain
     /// @param recoveryId The recovery ID that was registered
     event RecoveryIdRegistered(BN254.ScalarField indexed recoveryId);
-    /// @notice Emitted when a note is posted to the darkpool
-    /// @param noteCommitment The commitment to the note
-    event NotePosted(uint256 indexed noteCommitment);
+    /// @notice Emitted when a public order is cancelled
+    /// @param orderHash The hash of the cancelled order
+    /// @param owner The owner who cancelled the order
+    event PublicOrderCancelled(bytes32 indexed orderHash, address indexed owner);
 
     /// @notice Initialize the darkpool contract
     /// @param initialOwner The initial owner of the contract
@@ -232,6 +234,13 @@ interface IDarkpoolV2 {
         OrderCancellationProofBundle calldata orderCancellationProofBundle
     )
         external;
+
+    /// @notice Cancel a public intent in the darkpool
+    /// @dev This cancels a public intent by zeroing its entry in the openPublicIntents mapping.
+    /// @dev The owner must sign H("cancel" || intentHash) with a nonce for replay protection.
+    /// @param auth The authorization for the order cancellation
+    /// @param permit The public intent permit identifying the intent to cancel
+    function cancelOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) external;
 
     /// @notice Pay protocol fees publicly on a balance
     /// @param proofBundle The proof bundle for the public protocol fee payment

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -137,6 +137,9 @@ interface IDarkpoolV2 {
     /// @notice Emitted when a new recovery ID is registered on-chain
     /// @param recoveryId The recovery ID that was registered
     event RecoveryIdRegistered(BN254.ScalarField indexed recoveryId);
+    /// @notice Emitted when a note is posted to the darkpool
+    /// @param noteCommitment The commitment to the note
+    event NotePosted(uint256 indexed noteCommitment);
     /// @notice Emitted when a public order is cancelled
     /// @param orderHash The hash of the cancelled order
     /// @param owner The owner who cancelled the order
@@ -229,7 +232,7 @@ interface IDarkpoolV2 {
     /// @notice Cancel an order in the darkpool
     /// @param auth The authorization for the order cancellation
     /// @param orderCancellationProofBundle The proof bundle for the order cancellation
-    function cancelOrder(
+    function cancelPrivateOrder(
         OrderCancellationAuth memory auth,
         OrderCancellationProofBundle calldata orderCancellationProofBundle
     )
@@ -240,7 +243,7 @@ interface IDarkpoolV2 {
     /// @dev The owner must sign H("cancel" || intentHash) with a nonce for replay protection.
     /// @param auth The authorization for the order cancellation
     /// @param permit The public intent permit identifying the intent to cancel
-    function cancelOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) external;
+    function cancelPublicOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) external;
 
     /// @notice Pay protocol fees publicly on a balance
     /// @param proofBundle The proof bundle for the public protocol fee payment

--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -8,6 +8,9 @@ import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 /// @author Renegade Eng
 /// @notice This library contains constants for the darkpool
 library DarkpoolConstants {
+    /// @notice Domain separator for public intent cancellation signatures
+    /// @dev Used to prevent signature reuse across different message types
+    bytes internal constant CANCEL_DOMAIN = "cancel";
     /// @notice The address used for native tokens in trade settlement
     /// @dev This is currently just ETH, but intentionally written abstractly
     address internal constant NATIVE_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;

--- a/src/darkpool/v2/types/OrderCancellation.sol
+++ b/src/darkpool/v2/types/OrderCancellation.sol
@@ -4,8 +4,10 @@ pragma solidity ^0.8.24;
 import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 
 /// @notice The authorization for an order cancellation
-/// @dev This authorizes the cancellation of an intent, containing a signature over the intent's nullifier by the owner.
+/// @dev This authorizes the cancellation of an intent, containing a signature by the owner.
+/// @dev For private intents, the signature is over the intent's nullifier.
+/// @dev For public intents, the signature is over the digest H("cancel" || intentHash).
 struct OrderCancellationAuth {
-    /// @dev The signature of the intent nullifier with a nonce for replay protection
+    /// @dev Includes a nonce for replay protection
     SignatureWithNonce signature;
 }

--- a/test/darkpool/v2/settlement/native-settled-public-intents/PermitSingle.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/PermitSingle.t.sol
@@ -346,7 +346,8 @@ contract PermitSingleTests is PublicIntentSettlementTestUtils {
             address(quoteToken),
             uint160(permit0.intent.amountIn),
             uint48(block.timestamp + 1 days),
-            0 // nonce
+            0, // nonce
+            address(darkpool)
         );
 
         ObligationBundle memory obligationBundle = _createObligationBundle(obligation0, obligation1);

--- a/test/darkpool/v2/state-updates/OrderCancellation.t.sol
+++ b/test/darkpool/v2/state-updates/OrderCancellation.t.sol
@@ -65,9 +65,7 @@ contract OrderCancellationTest is DarkpoolV2TestUtils {
         address owner = intentOwner.addr;
 
         ValidOrderCancellationStatement memory statement = ValidOrderCancellationStatement({
-            merkleRoot: merkleRoot,
-            oldIntentNullifier: oldIntentNullifier,
-            owner: owner
+            merkleRoot: merkleRoot, oldIntentNullifier: oldIntentNullifier, owner: owner
         });
 
         return OrderCancellationProofBundle({ statement: statement, proof: createDummyProof() });
@@ -105,7 +103,7 @@ contract OrderCancellationTest is DarkpoolV2TestUtils {
 
         // Check that the nullifier is spent only in the cancellation
         assertFalse(darkpool.nullifierSpent(intentNullifier), "Nullifier should not be spent before cancellation");
-        darkpool.cancelOrder(auth, proofBundle);
+        darkpool.cancelPrivateOrder(auth, proofBundle);
         assertTrue(darkpool.nullifierSpent(intentNullifier), "Nullifier should be spent after cancellation");
     }
 
@@ -116,13 +114,13 @@ contract OrderCancellationTest is DarkpoolV2TestUtils {
         OrderCancellationAuth memory auth = createOrderCancellationAuth(proofBundle.statement.oldIntentNullifier);
 
         // Execute the cancellation once
-        darkpool.cancelOrder(auth, proofBundle);
+        darkpool.cancelPrivateOrder(auth, proofBundle);
 
         // Try to execute the same cancellation again with the same nullifier but a fresh nonce
         // Should revert because the nullifier is already spent
         OrderCancellationAuth memory auth2 = createOrderCancellationAuth(proofBundle.statement.oldIntentNullifier);
         vm.expectRevert(NullifierLib.NullifierAlreadySpent.selector);
-        darkpool.cancelOrder(auth2, proofBundle);
+        darkpool.cancelPrivateOrder(auth2, proofBundle);
     }
 
     /// @notice Test order cancellation with invalid signature
@@ -136,6 +134,6 @@ contract OrderCancellationTest is DarkpoolV2TestUtils {
 
         // Should revert due to invalid signature
         vm.expectRevert(IDarkpoolV2.InvalidOrderCancellationSignature.selector);
-        darkpool.cancelOrder(auth, proofBundle);
+        darkpool.cancelPrivateOrder(auth, proofBundle);
     }
 }

--- a/test/darkpool/v2/state-updates/PublicIntentCancellation.t.sol
+++ b/test/darkpool/v2/state-updates/PublicIntentCancellation.t.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+/* solhint-disable gas-small-strings */
+/* solhint-disable func-name-mixedcase */
+pragma solidity ^0.8.24;
+
+import { stdStorage, StdStorage } from "forge-std/Test.sol";
+import { DarkpoolV2TestUtils } from "../DarkpoolV2TestUtils.sol";
+import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
+import { Intent } from "darkpoolv2-types/Intent.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
+import { PublicIntentPermit, PublicIntentPermitLib } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+
+/// @title PublicIntentCancellationTest
+/// @author Renegade Eng
+/// @notice Tests for the public intent cancellation functionality in DarkpoolV2
+contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
+    using PublicIntentPermitLib for PublicIntentPermit;
+    using stdStorage for StdStorage;
+
+    /// @notice Set up the test environment
+    function setUp() public override {
+        super.setUp();
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @notice Set the open intent amount directly in storage
+    /// @param intentHash The intent hash
+    /// @param amount The amount to set
+    function _setOpenIntentAmount(bytes32 intentHash, uint256 amount) internal {
+        stdstore.target(address(darkpool)).sig("openPublicIntents(bytes32)").with_key(intentHash).checked_write(
+            amount
+        );
+    }
+
+    /// @notice Generate a random public intent permit
+    /// @return permit The random public intent permit
+    function generateRandomPublicIntentPermit() internal returns (PublicIntentPermit memory permit) {
+        Intent memory intent = Intent({
+            inToken: address(baseToken),
+            outToken: address(quoteToken),
+            owner: intentOwner.addr,
+            minPrice: randomPrice(),
+            amountIn: randomUint()
+        });
+
+        permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
+    }
+
+    /// @notice Create a cancellation auth signed with the given private key
+    /// @param permit The permit to cancel
+    /// @param privateKey The private key to sign with
+    /// @return auth The cancellation authorization
+    function _createOrderCancellationAuth(
+        PublicIntentPermit memory permit,
+        uint256 privateKey
+    )
+        internal
+        returns (OrderCancellationAuth memory auth)
+    {
+        uint256 nonce = vm.randomUint();
+        bytes32 intentHash = permit.computeHash();
+        bytes32 cancelDigest = keccak256(abi.encodePacked(DarkpoolConstants.CANCEL_DOMAIN, intentHash));
+        bytes32 signatureHash = EfficientHashLib.hash(cancelDigest, bytes32(nonce));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, signatureHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        auth = OrderCancellationAuth({ signature: SignatureWithNonce({ nonce: nonce, signature: signature }) });
+    }
+
+    /// @notice Create a cancellation auth with correct signature (owner)
+    function createOrderCancellationAuth(PublicIntentPermit memory permit) internal returns (OrderCancellationAuth memory) {
+        return _createOrderCancellationAuth(permit, intentOwner.privateKey);
+    }
+
+    /// @notice Create a cancellation auth with wrong signer
+    function createOrderCancellationAuthWrongSigner(PublicIntentPermit memory permit) internal returns (OrderCancellationAuth memory) {
+        return _createOrderCancellationAuth(permit, wrongSigner.privateKey);
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// @notice Test that the same nonce cannot be reused (replay protection)
+    function test_cancel_nonceReplay() public {
+        // Generate a random permit
+        PublicIntentPermit memory permit = generateRandomPublicIntentPermit();
+
+        // Create the cancellation auth
+        OrderCancellationAuth memory auth = createOrderCancellationAuth(permit);
+
+        // Execute the cancellation once - should succeed
+        darkpool.cancelOrder(auth, permit);
+
+        // Try to execute the same cancellation again with the same nonce
+        // Should revert because the nonce is already spent
+        vm.expectRevert(DarkpoolStateLib.NonceAlreadySpent.selector);
+        darkpool.cancelOrder(auth, permit);
+    }
+
+    /// @notice Test public intent cancellation with invalid signature (wrong signer)
+    function test_cancel_invalidSignature() public {
+        // Generate a random permit
+        PublicIntentPermit memory permit = generateRandomPublicIntentPermit();
+
+        // Create auth with wrong signer
+        OrderCancellationAuth memory auth = createOrderCancellationAuthWrongSigner(permit);
+
+        // Should revert due to invalid signature
+        vm.expectRevert(IDarkpoolV2.InvalidOrderCancellationSignature.selector);
+        darkpool.cancelOrder(auth, permit);
+    }
+
+    /// @notice Test cancelling an open intent with non-zero amount remaining
+    function test_cancel_openIntent() public {
+        // Generate a random permit
+        PublicIntentPermit memory permit = generateRandomPublicIntentPermit();
+        bytes32 intentHash = permit.computeHash();
+
+        // Set a non-zero amount in storage to simulate an open intent
+        uint256 openAmount = 1000 ether;
+        _setOpenIntentAmount(intentHash, openAmount);
+
+        // Verify the amount was set
+        uint256 amountBefore = darkpool.openPublicIntents(intentHash);
+        assertEq(amountBefore, openAmount, "Intent should have non-zero amount");
+
+        // Create and execute the cancellation
+        OrderCancellationAuth memory auth = createOrderCancellationAuth(permit);
+        darkpool.cancelOrder(auth, permit);
+
+        // Amount should now be 0
+        uint256 amountAfter = darkpool.openPublicIntents(intentHash);
+        assertEq(amountAfter, 0, "Intent amount should be 0 after cancellation");
+    }
+
+    /// @notice Test that a signature for one permit cannot cancel a different permit
+    function test_cancel_wrongPermit() public {
+        // Generate two different permits
+        PublicIntentPermit memory permitA = generateRandomPublicIntentPermit();
+        PublicIntentPermit memory permitB = generateRandomPublicIntentPermit();
+
+        // Create cancellation auth signed for permit A
+        OrderCancellationAuth memory authForA = createOrderCancellationAuth(permitA);
+
+        // Try to cancel permit B using the signature for permit A
+        // Should fail because the signature is over the wrong intentHash
+        vm.expectRevert(IDarkpoolV2.InvalidOrderCancellationSignature.selector);
+        darkpool.cancelOrder(authForA, permitB);
+    }
+}

--- a/test/darkpool/v2/state-updates/PublicIntentCancellation.t.sol
+++ b/test/darkpool/v2/state-updates/PublicIntentCancellation.t.sol
@@ -34,9 +34,7 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
     /// @param intentHash The intent hash
     /// @param amount The amount to set
     function _setOpenIntentAmount(bytes32 intentHash, uint256 amount) internal {
-        stdstore.target(address(darkpool)).sig("openPublicIntents(bytes32)").with_key(intentHash).checked_write(
-            amount
-        );
+        stdstore.target(address(darkpool)).sig("openPublicIntents(bytes32)").with_key(intentHash).checked_write(amount);
     }
 
     /// @notice Generate a random public intent permit
@@ -74,12 +72,18 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
     }
 
     /// @notice Create a cancellation auth with correct signature (owner)
-    function createOrderCancellationAuth(PublicIntentPermit memory permit) internal returns (OrderCancellationAuth memory) {
+    function createOrderCancellationAuth(PublicIntentPermit memory permit)
+        internal
+        returns (OrderCancellationAuth memory)
+    {
         return _createOrderCancellationAuth(permit, intentOwner.privateKey);
     }
 
     /// @notice Create a cancellation auth with wrong signer
-    function createOrderCancellationAuthWrongSigner(PublicIntentPermit memory permit) internal returns (OrderCancellationAuth memory) {
+    function createOrderCancellationAuthWrongSigner(PublicIntentPermit memory permit)
+        internal
+        returns (OrderCancellationAuth memory)
+    {
         return _createOrderCancellationAuth(permit, wrongSigner.privateKey);
     }
 
@@ -96,12 +100,12 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
         OrderCancellationAuth memory auth = createOrderCancellationAuth(permit);
 
         // Execute the cancellation once - should succeed
-        darkpool.cancelOrder(auth, permit);
+        darkpool.cancelPublicOrder(auth, permit);
 
         // Try to execute the same cancellation again with the same nonce
         // Should revert because the nonce is already spent
         vm.expectRevert(DarkpoolStateLib.NonceAlreadySpent.selector);
-        darkpool.cancelOrder(auth, permit);
+        darkpool.cancelPublicOrder(auth, permit);
     }
 
     /// @notice Test public intent cancellation with invalid signature (wrong signer)
@@ -114,7 +118,7 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
 
         // Should revert due to invalid signature
         vm.expectRevert(IDarkpoolV2.InvalidOrderCancellationSignature.selector);
-        darkpool.cancelOrder(auth, permit);
+        darkpool.cancelPublicOrder(auth, permit);
     }
 
     /// @notice Test cancelling an open intent with non-zero amount remaining
@@ -133,7 +137,7 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
 
         // Create and execute the cancellation
         OrderCancellationAuth memory auth = createOrderCancellationAuth(permit);
-        darkpool.cancelOrder(auth, permit);
+        darkpool.cancelPublicOrder(auth, permit);
 
         // Amount should now be 0
         uint256 amountAfter = darkpool.openPublicIntents(intentHash);
@@ -152,6 +156,6 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
         // Try to cancel permit B using the signature for permit A
         // Should fail because the signature is over the wrong intentHash
         vm.expectRevert(IDarkpoolV2.InvalidOrderCancellationSignature.selector);
-        darkpool.cancelOrder(authForA, permitB);
+        darkpool.cancelPublicOrder(authForA, permitB);
     }
 }


### PR DESCRIPTION
### Purpose

This PR adds public intent cancellation to the v2 darkpool. Users can cancel their public intents by signing H("cancel" || intentHash) with a nonce for replay protection, which zeros the intent's entry in the openPublicIntents mapping.

We use a domain separator to prevent a front-run attack wherein a user's tx to settle a match is front-run and is instead cancelled.

Entrypoint changes
- `cancelPrivateOrder`
- `cancelPublicOrder`

Events added
- `PublicOrderCancelled`

### Testing

- [x] Added tests pass