### PR TITLE
darkpoolv2: register permit2 allowance on ring 0 first fill

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -2473,6 +2473,38 @@
   },
   {
     "type": "error",
+    "name": "PermitSpenderMismatch",
+    "inputs": [
+      {
+        "name": "permitSpender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "expected",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "PermitTokenMismatch",
+    "inputs": [
+      {
+        "name": "permitToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "transferToken",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "PriceTooLarge",
     "inputs": [
       {
@@ -12645,7 +12677,7 @@
         "internalType": "struct PublicIntentAuthBundle",
         "components": [
           {
-            "name": "permit",
+            "name": "intentPermit",
             "type": "tuple",
             "internalType": "struct PublicIntentPermit",
             "components": [
@@ -12721,6 +12753,62 @@
                 "name": "nonce",
                 "type": "uint256",
                 "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "allowancePermit",
+            "type": "tuple",
+            "internalType": "struct SignedPermitSingle",
+            "components": [
+              {
+                "name": "permitSingle",
+                "type": "tuple",
+                "internalType": "struct IAllowanceTransfer.PermitSingle",
+                "components": [
+                  {
+                    "name": "details",
+                    "type": "tuple",
+                    "internalType": "struct IAllowanceTransfer.PermitDetails",
+                    "components": [
+                      {
+                        "name": "token",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "amount",
+                        "type": "uint160",
+                        "internalType": "uint160"
+                      },
+                      {
+                        "name": "expiration",
+                        "type": "uint48",
+                        "internalType": "uint48"
+                      },
+                      {
+                        "name": "nonce",
+                        "type": "uint48",
+                        "internalType": "uint48"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "spender",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "sigDeadline",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
               },
               {
                 "name": "signature",
@@ -12739,7 +12827,7 @@
         "internalType": "struct PublicIntentAuthBundle",
         "components": [
           {
-            "name": "permit",
+            "name": "intentPermit",
             "type": "tuple",
             "internalType": "struct PublicIntentPermit",
             "components": [
@@ -12815,6 +12903,62 @@
                 "name": "nonce",
                 "type": "uint256",
                 "internalType": "uint256"
+              },
+              {
+                "name": "signature",
+                "type": "bytes",
+                "internalType": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "allowancePermit",
+            "type": "tuple",
+            "internalType": "struct SignedPermitSingle",
+            "components": [
+              {
+                "name": "permitSingle",
+                "type": "tuple",
+                "internalType": "struct IAllowanceTransfer.PermitSingle",
+                "components": [
+                  {
+                    "name": "details",
+                    "type": "tuple",
+                    "internalType": "struct IAllowanceTransfer.PermitDetails",
+                    "components": [
+                      {
+                        "name": "token",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "amount",
+                        "type": "uint160",
+                        "internalType": "uint160"
+                      },
+                      {
+                        "name": "expiration",
+                        "type": "uint48",
+                        "internalType": "uint48"
+                      },
+                      {
+                        "name": "nonce",
+                        "type": "uint48",
+                        "internalType": "uint48"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "spender",
+                    "type": "address",
+                    "internalType": "address"
+                  },
+                  {
+                    "name": "sigDeadline",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
               },
               {
                 "name": "signature",
@@ -12954,7 +13098,7 @@
             "internalType": "struct PublicIntentAuthBundle",
             "components": [
               {
-                "name": "permit",
+                "name": "intentPermit",
                 "type": "tuple",
                 "internalType": "struct PublicIntentPermit",
                 "components": [
@@ -13030,6 +13174,62 @@
                     "name": "nonce",
                     "type": "uint256",
                     "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "allowancePermit",
+                "type": "tuple",
+                "internalType": "struct SignedPermitSingle",
+                "components": [
+                  {
+                    "name": "permitSingle",
+                    "type": "tuple",
+                    "internalType": "struct IAllowanceTransfer.PermitSingle",
+                    "components": [
+                      {
+                        "name": "details",
+                        "type": "tuple",
+                        "internalType": "struct IAllowanceTransfer.PermitDetails",
+                        "components": [
+                          {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "address"
+                          },
+                          {
+                            "name": "amount",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                          },
+                          {
+                            "name": "expiration",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                          },
+                          {
+                            "name": "nonce",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "spender",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "sigDeadline",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
                   },
                   {
                     "name": "signature",
@@ -13079,7 +13279,7 @@
             "internalType": "struct PublicIntentAuthBundle",
             "components": [
               {
-                "name": "permit",
+                "name": "intentPermit",
                 "type": "tuple",
                 "internalType": "struct PublicIntentPermit",
                 "components": [
@@ -13155,6 +13355,62 @@
                     "name": "nonce",
                     "type": "uint256",
                     "internalType": "uint256"
+                  },
+                  {
+                    "name": "signature",
+                    "type": "bytes",
+                    "internalType": "bytes"
+                  }
+                ]
+              },
+              {
+                "name": "allowancePermit",
+                "type": "tuple",
+                "internalType": "struct SignedPermitSingle",
+                "components": [
+                  {
+                    "name": "permitSingle",
+                    "type": "tuple",
+                    "internalType": "struct IAllowanceTransfer.PermitSingle",
+                    "components": [
+                      {
+                        "name": "details",
+                        "type": "tuple",
+                        "internalType": "struct IAllowanceTransfer.PermitDetails",
+                        "components": [
+                          {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "address"
+                          },
+                          {
+                            "name": "amount",
+                            "type": "uint160",
+                            "internalType": "uint160"
+                          },
+                          {
+                            "name": "expiration",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                          },
+                          {
+                            "name": "nonce",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "spender",
+                        "type": "address",
+                        "internalType": "address"
+                      },
+                      {
+                        "name": "sigDeadline",
+                        "type": "uint256",
+                        "internalType": "uint256"
+                      }
+                    ]
                   },
                   {
                     "name": "signature",
@@ -20849,6 +21105,62 @@
                         "name": "transferType",
                         "type": "uint8",
                         "internalType": "enum SimpleTransferType"
+                      },
+                      {
+                        "name": "allowancePermit",
+                        "type": "tuple",
+                        "internalType": "struct SignedPermitSingle",
+                        "components": [
+                          {
+                            "name": "permitSingle",
+                            "type": "tuple",
+                            "internalType": "struct IAllowanceTransfer.PermitSingle",
+                            "components": [
+                              {
+                                "name": "details",
+                                "type": "tuple",
+                                "internalType": "struct IAllowanceTransfer.PermitDetails",
+                                "components": [
+                                  {
+                                    "name": "token",
+                                    "type": "address",
+                                    "internalType": "address"
+                                  },
+                                  {
+                                    "name": "amount",
+                                    "type": "uint160",
+                                    "internalType": "uint160"
+                                  },
+                                  {
+                                    "name": "expiration",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  },
+                                  {
+                                    "name": "nonce",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "spender",
+                                "type": "address",
+                                "internalType": "address"
+                              },
+                              {
+                                "name": "sigDeadline",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                              }
+                            ]
+                          },
+                          {
+                            "name": "signature",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
                       }
                     ]
                   },
@@ -20888,6 +21200,62 @@
                         "name": "transferType",
                         "type": "uint8",
                         "internalType": "enum SimpleTransferType"
+                      },
+                      {
+                        "name": "allowancePermit",
+                        "type": "tuple",
+                        "internalType": "struct SignedPermitSingle",
+                        "components": [
+                          {
+                            "name": "permitSingle",
+                            "type": "tuple",
+                            "internalType": "struct IAllowanceTransfer.PermitSingle",
+                            "components": [
+                              {
+                                "name": "details",
+                                "type": "tuple",
+                                "internalType": "struct IAllowanceTransfer.PermitDetails",
+                                "components": [
+                                  {
+                                    "name": "token",
+                                    "type": "address",
+                                    "internalType": "address"
+                                  },
+                                  {
+                                    "name": "amount",
+                                    "type": "uint160",
+                                    "internalType": "uint160"
+                                  },
+                                  {
+                                    "name": "expiration",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  },
+                                  {
+                                    "name": "nonce",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "spender",
+                                "type": "address",
+                                "internalType": "address"
+                              },
+                              {
+                                "name": "sigDeadline",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                              }
+                            ]
+                          },
+                          {
+                            "name": "signature",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
                       }
                     ]
                   },
@@ -21310,6 +21678,62 @@
                         "name": "transferType",
                         "type": "uint8",
                         "internalType": "enum SimpleTransferType"
+                      },
+                      {
+                        "name": "allowancePermit",
+                        "type": "tuple",
+                        "internalType": "struct SignedPermitSingle",
+                        "components": [
+                          {
+                            "name": "permitSingle",
+                            "type": "tuple",
+                            "internalType": "struct IAllowanceTransfer.PermitSingle",
+                            "components": [
+                              {
+                                "name": "details",
+                                "type": "tuple",
+                                "internalType": "struct IAllowanceTransfer.PermitDetails",
+                                "components": [
+                                  {
+                                    "name": "token",
+                                    "type": "address",
+                                    "internalType": "address"
+                                  },
+                                  {
+                                    "name": "amount",
+                                    "type": "uint160",
+                                    "internalType": "uint160"
+                                  },
+                                  {
+                                    "name": "expiration",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  },
+                                  {
+                                    "name": "nonce",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "spender",
+                                "type": "address",
+                                "internalType": "address"
+                              },
+                              {
+                                "name": "sigDeadline",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                              }
+                            ]
+                          },
+                          {
+                            "name": "signature",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
                       }
                     ]
                   },
@@ -21349,6 +21773,62 @@
                         "name": "transferType",
                         "type": "uint8",
                         "internalType": "enum SimpleTransferType"
+                      },
+                      {
+                        "name": "allowancePermit",
+                        "type": "tuple",
+                        "internalType": "struct SignedPermitSingle",
+                        "components": [
+                          {
+                            "name": "permitSingle",
+                            "type": "tuple",
+                            "internalType": "struct IAllowanceTransfer.PermitSingle",
+                            "components": [
+                              {
+                                "name": "details",
+                                "type": "tuple",
+                                "internalType": "struct IAllowanceTransfer.PermitDetails",
+                                "components": [
+                                  {
+                                    "name": "token",
+                                    "type": "address",
+                                    "internalType": "address"
+                                  },
+                                  {
+                                    "name": "amount",
+                                    "type": "uint160",
+                                    "internalType": "uint160"
+                                  },
+                                  {
+                                    "name": "expiration",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  },
+                                  {
+                                    "name": "nonce",
+                                    "type": "uint48",
+                                    "internalType": "uint48"
+                                  }
+                                ]
+                              },
+                              {
+                                "name": "spender",
+                                "type": "address",
+                                "internalType": "address"
+                              },
+                              {
+                                "name": "sigDeadline",
+                                "type": "uint256",
+                                "internalType": "uint256"
+                              }
+                            ]
+                          },
+                          {
+                            "name": "signature",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                          }
+                        ]
                       }
                     ]
                   },

--- a/abi/src/v2/transfer_auth/mod.rs
+++ b/abi/src/v2/transfer_auth/mod.rs
@@ -1,4 +1,5 @@
 //! Transfer authorization helpers for deposits (Permit2) and withdrawals
 
 pub mod deposit;
+pub mod permit2_allowance;
 pub mod withdrawal;

--- a/abi/src/v2/transfer_auth/permit2_allowance.rs
+++ b/abi/src/v2/transfer_auth/permit2_allowance.rs
@@ -1,0 +1,21 @@
+//! Default implementation for SignedPermitSingle
+
+use crate::v2::{IDarkpoolV2::SignedPermitSingle, IAllowanceTransfer};
+
+impl Default for SignedPermitSingle {
+    fn default() -> Self {
+        Self {
+            permitSingle: IAllowanceTransfer::PermitSingle {
+                details: IAllowanceTransfer::PermitDetails {
+                    token: Default::default(),
+                    amount: Default::default(),
+                    expiration: Default::default(),
+                    nonce: Default::default(),
+                },
+                spender: Default::default(),
+                sigDeadline: Default::default(),
+            },
+            signature: Default::default(),
+        }
+    }
+}

--- a/integration/v2/src/tests/settlement/private_intent_private_balance.rs
+++ b/integration/v2/src/tests/settlement/private_intent_private_balance.rs
@@ -10,9 +10,9 @@ use alloy::{
 use eyre::Result;
 use rand::{Rng, thread_rng};
 use renegade_abi::v2::IDarkpoolV2::{
-    self, Deposit, ObligationBundle, OutputBalanceBundle, PublicIntentAuthBundle,
-    PublicIntentPermit, RenegadeSettledIntentAuthBundle, RenegadeSettledIntentAuthBundleFirstFill,
-    SettlementBundle,
+    self, Deposit, ObligationBundle, OutputBalanceBundle, PublicIntentAuthBundle, PublicIntentPermit,
+    RenegadeSettledIntentAuthBundle, RenegadeSettledIntentAuthBundleFirstFill, SettlementBundle,
+    SignedPermitSingle,
 };
 use renegade_circuit_types::{PlonkLinkProof, PlonkProof, ProofLinkingHint};
 use renegade_circuits::{
@@ -285,9 +285,10 @@ pub fn build_settlement_bundle_ring0(
     let executor_signature =
         contracts_obligation.create_executor_signature(&relayer_fee, executor_signer)?;
     let auth_bundle = PublicIntentAuthBundle {
-        permit,
+        intentPermit: permit,
         intentSignature: intent_signature,
         executorSignature: executor_signature,
+        allowancePermit: SignedPermitSingle::default(),
     };
 
     Ok(SettlementBundle::public_intent_settlement(

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -112,6 +112,10 @@ interface IDarkpoolV2 {
     error InvalidProtocolFeeEncryptionKey();
     /// @notice Thrown when the relayer ciphertext signature is invalid
     error InvalidRelayerCiphertextSignature();
+    /// @notice Thrown when the permit token does not match the transfer token
+    error PermitTokenMismatch(address permitToken, address transferToken);
+    /// @notice Thrown when the permit spender is not the darkpool
+    error PermitSpenderMismatch(address permitSpender, address expected);
 
     // --- Events --- //
 

--- a/src/darkpool/v2/types/Fee.sol
+++ b/src/darkpool/v2/types/Fee.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { SimpleTransfer, SimpleTransferType } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
 
 /// @notice A fee rate for a match
 struct FeeRate {
@@ -69,11 +70,13 @@ library FeeTakeLib {
     /// @param feeTake The fee take to build the withdrawal transfer for
     /// @return The withdrawal transfer
     function buildWithdrawalTransfer(FeeTake memory feeTake) public pure returns (SimpleTransfer memory) {
+        SignedPermitSingle memory empty;
         return SimpleTransfer({
             account: feeTake.recipient,
             mint: feeTake.mint,
             amount: feeTake.fee,
-            transferType: SimpleTransferType.Withdrawal
+            transferType: SimpleTransferType.Withdrawal,
+            allowancePermit: empty
         });
     }
 }

--- a/src/darkpool/v2/types/Note.sol
+++ b/src/darkpool/v2/types/Note.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { SimpleTransfer, SimpleTransferType } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
 
 /// @title Note
 /// @author Renegade Eng
@@ -26,11 +27,13 @@ library NoteLib {
     /// @param note The note to build the transfer from
     /// @return The transfer
     function buildTransfer(Note memory note) public pure returns (SimpleTransfer memory) {
+        SignedPermitSingle memory empty;
         return SimpleTransfer({
             account: note.receiver,
             mint: note.mint,
             amount: note.amount,
-            transferType: SimpleTransferType.Withdrawal
+            transferType: SimpleTransferType.Withdrawal,
+            allowancePermit: empty
         });
     }
 }

--- a/src/darkpool/v2/types/Obligation.sol
+++ b/src/darkpool/v2/types/Obligation.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { SimpleTransfer, SimpleTransferType } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
 
 /// @notice A settlement obligation for a user
 struct SettlementObligation {
@@ -56,11 +57,30 @@ library SettlementObligationLib {
         pure
         returns (SimpleTransfer memory)
     {
+        SignedPermitSingle memory empty;
+        return buildPermit2AllowanceDeposit(obligation, owner, empty);
+    }
+
+    /// @notice Get the deposit transfer for a settlement obligation with optional Permit2 allowance permit
+    /// @param obligation The settlement obligation to get the deposit transfer for
+    /// @param owner The owner of the settlement obligation
+    /// @param allowancePermit Optional Permit2 allowance permit for first-fill (empty if using existing allowance)
+    /// @return The deposit transfer
+    function buildPermit2AllowanceDeposit(
+        SettlementObligation memory obligation,
+        address owner,
+        SignedPermitSingle memory allowancePermit
+    )
+        internal
+        pure
+        returns (SimpleTransfer memory)
+    {
         return SimpleTransfer({
             account: owner,
             mint: obligation.inputToken,
             amount: obligation.amountIn,
-            transferType: SimpleTransferType.Permit2AllowanceDeposit
+            transferType: SimpleTransferType.Permit2AllowanceDeposit,
+            allowancePermit: allowancePermit
         });
     }
 
@@ -76,11 +96,13 @@ library SettlementObligationLib {
         pure
         returns (SimpleTransfer memory)
     {
+        SignedPermitSingle memory empty;
         return SimpleTransfer({
             account: owner,
             mint: obligation.inputToken,
             amount: obligation.amountIn,
-            transferType: SimpleTransferType.ERC20ApprovalDeposit
+            transferType: SimpleTransferType.ERC20ApprovalDeposit,
+            allowancePermit: empty
         });
     }
 
@@ -98,11 +120,13 @@ library SettlementObligationLib {
         pure
         returns (SimpleTransfer memory)
     {
+        SignedPermitSingle memory empty;
         return SimpleTransfer({
             account: owner,
             mint: obligation.outputToken,
             amount: obligation.amountOut - totalFee,
-            transferType: SimpleTransferType.Withdrawal
+            transferType: SimpleTransferType.Withdrawal,
+            allowancePermit: empty
         });
     }
 }

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -13,6 +13,7 @@ import {
 } from "darkpoolv2-lib/public_inputs/ValidityProofs.sol";
 import { PlonkProof } from "renegade-lib/verifier/Types.sol";
 import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
 
 // ------------------------------
 // | Intent Authorization Types |
@@ -22,13 +23,16 @@ import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNon
 
 /// @notice The public intent authorization payload with signature attached
 struct PublicIntentAuthBundle {
-    /// @dev The intent authorization permit
-    PublicIntentPermit permit;
+    /// @dev The intent authorization data (intent + authorized executor)
+    PublicIntentPermit intentPermit;
     /// @dev The signature of the intent
     SignatureWithNonce intentSignature;
     /// @dev The signature of the settlement obligation by the authorized executor
     /// @dev This authorizes the fields of the obligation, and importantly implicitly authorizes the price
     SignatureWithNonce executorSignature;
+    /// @dev Optional Permit2 allowance permit for first-fill of ring 0 intents. If provided, the permit
+    /// is registered before the transfer. Empty if using existing allowance.
+    SignedPermitSingle allowancePermit;
 }
 
 /// @notice Intent authorization data for a public intent

--- a/src/darkpool/v2/types/settlement/SettlementContext.sol
+++ b/src/darkpool/v2/types/settlement/SettlementContext.sol
@@ -36,6 +36,7 @@ library SettlementContextLib {
     /// @param numDeposits The initial number of deposits
     /// @param numWithdrawals The initial number of withdrawals
     /// @param verificationCapacity The capacity of the verifications list
+    /// @param proofLinkingCapacity The capacity of the proof linking arguments list
     /// @return The new settlement context
     function newContext(
         uint256 numDeposits,

--- a/src/darkpool/v2/types/transfers/SignedPermitSingle.sol
+++ b/src/darkpool/v2/types/transfers/SignedPermitSingle.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { IAllowanceTransfer } from "permit2-lib/interfaces/IAllowanceTransfer.sol";
+
+/// @notice A Permit2 PermitSingle bundled with its EIP-712 signature
+/// @dev Used to register a Permit2 allowance during settlement of a ring 0 intent.
+/// See: https://docs.uniswap.org/contracts/permit2/reference/allowance-transfer
+struct SignedPermitSingle {
+    /// @dev The Permit2 PermitSingle struct containing permit details, spender, and deadline
+    IAllowanceTransfer.PermitSingle permitSingle;
+    /// @dev The EIP-712 signature over the PermitSingle struct
+    bytes signature;
+}
+
+/// @title SignedPermitSingleLib
+/// @author Renegade Eng
+/// @notice Library for SignedPermitSingle operations
+library SignedPermitSingleLib {
+    /// @notice Check if permit data is provided
+    /// @dev A zero-length signature indicates no permit data exists
+    /// @param data The permit data to check
+    /// @return True if permit data exists (has a signature)
+    function exists(SignedPermitSingle memory data) internal pure returns (bool) {
+        return data.signature.length > 0;
+    }
+}

--- a/src/darkpool/v2/types/transfers/SimpleTransfer.sol
+++ b/src/darkpool/v2/types/transfers/SimpleTransfer.sol
@@ -2,6 +2,8 @@
 /* solhint-disable one-contract-per-file */
 pragma solidity ^0.8.24;
 
+import { SignedPermitSingle } from "./SignedPermitSingle.sol";
+
 /// @notice A simple ERC20 transfer
 /// @dev This is "simple" as opposed to the authorized transfers which represent deposit/withdrawals
 struct SimpleTransfer {
@@ -13,6 +15,9 @@ struct SimpleTransfer {
     uint256 amount;
     /// @dev The type of transfer
     SimpleTransferType transferType;
+    /// @dev Optional Permit2 allowance permit for first-fill of ring 0 intents. If provided, the permit
+    /// is registered before the transfer. Empty if using existing allowance.
+    SignedPermitSingle allowancePermit;
 }
 
 /// @notice The type of a simple ERC20 transfer

--- a/test/darkpool/v2/settlement/external-match/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-public-intents/Utils.sol
@@ -15,6 +15,7 @@ import {
     PublicIntentPermit,
     PublicIntentPermitLib
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
 import {
     BoundedMatchResultPermit,
     BoundedMatchResultBundle,
@@ -108,9 +109,13 @@ contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
         FeeRate memory feeRate = relayerFeeRate();
         SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
 
-        // Create auth bundle
+        // Create auth bundle with empty permit (no first-fill permit)
+        SignedPermitSingle memory emptyPermit;
         PublicIntentAuthBundle memory auth = PublicIntentAuthBundle({
-            permit: permit, intentSignature: intentSignature, executorSignature: executorSignature
+            intentPermit: permit,
+            intentSignature: intentSignature,
+            executorSignature: executorSignature,
+            allowancePermit: emptyPermit
         });
         PublicIntentPublicBalanceBundle memory bundleData =
             PublicIntentPublicBalanceBundle({ auth: auth, relayerFeeRate: feeRate });

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -85,7 +85,7 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
-        SignatureWithNonce memory sig = signIntentPermit(authBundle.permit, wrongSigner.privateKey);
+        SignatureWithNonce memory sig = signIntentPermit(authBundle.intentPermit, wrongSigner.privateKey);
         authBundle.intentSignature = sig;
         bundleData.auth = authBundle;
         bundle.data = abi.encode(bundleData);
@@ -138,9 +138,9 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
         PublicIntentAuthBundle memory authBundle = bundleData.auth;
 
-        bytes32 intentHash = authBundle.permit.computeHash();
+        bytes32 intentHash = authBundle.intentPermit.computeHash();
         uint256 amountRemaining = darkpoolState.openPublicIntents[intentHash];
-        uint256 expectedAmountRemaining = authBundle.permit.intent.amountIn - obligation0.amountIn;
+        uint256 expectedAmountRemaining = authBundle.intentPermit.intent.amountIn - obligation0.amountIn;
         assertEq(amountRemaining, expectedAmountRemaining, "Intent not cached");
 
         // Now create a second bundle with the same intent but invalid owner signature
@@ -150,7 +150,7 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
 
         // Setup an obligation for a smaller amount
         obligation0.amountIn = randomUint(1, amountRemaining);
-        uint256 minAmountOut = authBundle2.permit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
+        uint256 minAmountOut = authBundle2.intentPermit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
         obligation0.amountOut = minAmountOut + 1;
         FeeRate memory feeRate2 = relayerFeeRate();
         authBundle2.executorSignature = createExecutorSignature(feeRate2, obligation0, executor.privateKey);

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
@@ -64,7 +64,7 @@ contract IntentConstraintsTest is PublicIntentSettlementTestUtils {
         ObligationBundle memory corruptedObligationBundle = buildObligationBundle(obligation0, obligation1);
 
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
-        Intent memory intent = bundleData.auth.permit.intent;
+        Intent memory intent = bundleData.auth.intentPermit.intent;
         SettlementBundle memory newBundle = createPublicIntentSettlementBundle(intent, obligation0);
 
         // Expect the validation to revert with InvalidObligationPair
@@ -77,7 +77,7 @@ contract IntentConstraintsTest is PublicIntentSettlementTestUtils {
         // Create an intent and an obligation which is too large
         (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
-        Intent memory intent = bundleData.auth.permit.intent;
+        Intent memory intent = bundleData.auth.intentPermit.intent;
 
         // Decode and corrupt the obligation
         (, SettlementObligation memory obligation1) = obligationBundle.decodePublicObligationsMemory();
@@ -110,7 +110,7 @@ contract IntentConstraintsTest is PublicIntentSettlementTestUtils {
         // Create an intent and an obligation which has a bad price
         (SettlementBundle memory bundle, ObligationBundle memory obligationBundle) = createSamplePublicIntentBundle();
         PublicIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PublicIntentPublicBalanceBundle));
-        Intent memory intent = bundleData.auth.permit.intent;
+        Intent memory intent = bundleData.auth.intentPermit.intent;
         (, SettlementObligation memory obligation1) = obligationBundle.decodePublicObligationsMemory();
 
         // Corrupt the obligation

--- a/test/darkpool/v2/settlement/native-settled-public-intents/PermitSingle.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/PermitSingle.t.sol
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/* solhint-disable func-name-mixedcase */
+
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+import { IAllowanceTransfer } from "permit2-lib/interfaces/IAllowanceTransfer.sol";
+import { PermitHash } from "permit2-lib/libraries/PermitHash.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { Intent } from "darkpoolv2-types/Intent.sol";
+import {
+    SettlementBundle,
+    SettlementBundleType,
+    PublicIntentPublicBalanceBundle
+} from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { ObligationBundle, ObligationType } from "darkpoolv2-types/settlement/ObligationBundle.sol";
+import {
+    SignatureWithNonce,
+    PublicIntentAuthBundle,
+    PublicIntentPermit,
+    PublicIntentPermitLib
+} from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { FeeRate } from "darkpoolv2-types/Fee.sol";
+import { PublicIntentSettlementTestUtils } from "./Utils.sol";
+
+contract PermitSingleTests is PublicIntentSettlementTestUtils {
+    using PublicIntentPermitLib for PublicIntentPermit;
+    using FixedPointLib for FixedPoint;
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @dev Capitalize a party for their intent without granting Permit2 allowance to the darkpool
+    function _capitalizePartyWithoutPermit2Allowance(address addr, Intent memory intent) internal {
+        ERC20Mock erc20 = ERC20Mock(intent.inToken);
+        erc20.mint(addr, intent.amountIn);
+
+        vm.startPrank(addr);
+        erc20.approve(address(permit2), type(uint256).max);
+        vm.stopPrank();
+    }
+
+    // --- Permit Single Helpers --- //
+
+    /// @dev Create a Permit2 allowance permit
+    function _createSignedPermit(
+        uint256 ownerPrivateKey,
+        address token,
+        uint160 amount,
+        uint48 expiration,
+        uint48 nonce,
+        address spender
+    )
+        internal
+        view
+        returns (SignedPermitSingle memory)
+    {
+        uint256 sigDeadline = block.timestamp + 1 hours;
+        IAllowanceTransfer.PermitSingle memory permitSingle = IAllowanceTransfer.PermitSingle({
+            details: IAllowanceTransfer.PermitDetails({
+                token: token, amount: amount, expiration: expiration, nonce: nonce
+            }),
+            spender: spender,
+            sigDeadline: sigDeadline
+        });
+
+        bytes32 permitHash = PermitHash.hash(permitSingle);
+        bytes32 domainSeparator = IAllowanceTransfer(address(permit2)).DOMAIN_SEPARATOR();
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, permitHash));
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
+
+        return SignedPermitSingle({ permitSingle: permitSingle, signature: abi.encodePacked(r, s, v) });
+    }
+
+    // --- Settlement Bundle Helpers --- //
+
+    /// @dev Create a settlement bundle for a public intent with a Permit2 allowance permit
+    function _createSettlementBundleWithPermit(
+        Intent memory intent,
+        SettlementObligation memory obligation,
+        uint256 intentOwnerPrivateKey,
+        uint256 executorPrivateKey,
+        SignedPermitSingle memory allowancePermit
+    )
+        internal
+        returns (SettlementBundle memory)
+    {
+        PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
+        SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
+
+        FeeRate memory feeRate = relayerFeeRate();
+        SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
+
+        return SettlementBundle({
+            isFirstFill: false,
+            bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,
+            data: abi.encode(
+                PublicIntentPublicBalanceBundle({
+                    auth: PublicIntentAuthBundle({
+                        intentPermit: permit,
+                        intentSignature: intentSignature,
+                        executorSignature: executorSignature,
+                        allowancePermit: allowancePermit
+                    }),
+                    relayerFeeRate: feeRate
+                })
+            )
+        });
+    }
+
+    // --- Test Setup Helpers --- //
+
+    /// @dev Create match data (permits and obligations) without capitalizing parties
+    function _createMatchData()
+        internal
+        returns (
+            PublicIntentPermit memory permit0,
+            PublicIntentPermit memory permit1,
+            SettlementObligation memory obligation0,
+            SettlementObligation memory obligation1
+        )
+    {
+        FixedPoint memory price;
+        (obligation0, obligation1, price) = createTradeObligations();
+        uint256 baseAmount = obligation0.amountIn;
+        uint256 quoteAmount = obligation0.amountOut;
+
+        // Intent 0: sell base for quote (randomized size > obligation)
+        uint256 minPriceRepr = price.repr / 2;
+        uint256 intentSize0 = vm.randomUint(baseAmount, baseAmount * 2);
+        Intent memory intent0 = Intent({
+            inToken: address(baseToken),
+            outToken: address(quoteToken),
+            owner: party0.addr,
+            minPrice: FixedPointLib.wrap(minPriceRepr),
+            amountIn: intentSize0
+        });
+        permit0 = PublicIntentPermit({ intent: intent0, executor: executor.addr });
+
+        // Intent 1: buy base for quote (randomized size > obligation)
+        uint256 minIntentSize1 = price.unsafeFixedPointMul(intentSize0);
+        uint256 intentSize1 = vm.randomUint(minIntentSize1, minIntentSize1 * 2);
+        FixedPoint memory minPriceFixed = FixedPointLib.divIntegers(baseAmount, quoteAmount);
+        uint256 minPriceRepr1 = minPriceFixed.repr / 2;
+        Intent memory intent1 = Intent({
+            inToken: address(quoteToken),
+            outToken: address(baseToken),
+            owner: party1.addr,
+            minPrice: FixedPointLib.wrap(minPriceRepr1),
+            amountIn: intentSize1
+        });
+        permit1 = PublicIntentPermit({ intent: intent1, executor: executor.addr });
+    }
+
+    /// @dev Create an obligation bundle from two obligations
+    function _createObligationBundle(
+        SettlementObligation memory obligation0,
+        SettlementObligation memory obligation1
+    )
+        internal
+        pure
+        returns (ObligationBundle memory)
+    {
+        return ObligationBundle({ obligationType: ObligationType.PUBLIC, data: abi.encode(obligation0, obligation1) });
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// @notice Test that permit registration works on first fill (both parties use permit)
+    function test_permitRegistration_firstFill() public {
+        (
+            PublicIntentPermit memory permit0,
+            PublicIntentPermit memory permit1,
+            SettlementObligation memory obligation0,
+            SettlementObligation memory obligation1
+        ) = _createMatchData();
+
+        // Capitalize both parties WITHOUT permit2 allowance (to test permit registration)
+        _capitalizePartyWithoutPermit2Allowance(party0.addr, permit0.intent);
+        _capitalizePartyWithoutPermit2Allowance(party1.addr, permit1.intent);
+
+        // Verify neither party has Permit2 allowance before settlement
+        (uint160 allowance0Before,,) =
+            IAllowanceTransfer(address(permit2)).allowance(party0.addr, address(baseToken), address(darkpool));
+        (uint160 allowance1Before,,) =
+            IAllowanceTransfer(address(permit2)).allowance(party1.addr, address(quoteToken), address(darkpool));
+        assertEq(allowance0Before, 0, "party0 should not have permit2 allowance before");
+        assertEq(allowance1Before, 0, "party1 should not have permit2 allowance before");
+
+        // Create Permit2 allowance permits for both parties
+        SignedPermitSingle memory allowancePermit0 = _createSignedPermit(
+            party0.privateKey,
+            address(baseToken),
+            uint160(permit0.intent.amountIn),
+            uint48(block.timestamp + 1 days),
+            0, // nonce
+            address(darkpool)
+        );
+        SignedPermitSingle memory allowancePermit1 = _createSignedPermit(
+            party1.privateKey,
+            address(quoteToken),
+            uint160(permit1.intent.amountIn),
+            uint48(block.timestamp + 1 days),
+            0, // nonce
+            address(darkpool)
+        );
+
+        // Create settlement bundles with Permit2 allowance permits for both parties
+        ObligationBundle memory obligationBundle = _createObligationBundle(obligation0, obligation1);
+        SettlementBundle memory party0Bundle = _createSettlementBundleWithPermit(
+            permit0.intent, obligation0, party0.privateKey, executor.privateKey, allowancePermit0
+        );
+        SettlementBundle memory party1Bundle = _createSettlementBundleWithPermit(
+            permit1.intent, obligation1, party1.privateKey, executor.privateKey, allowancePermit1
+        );
+
+        darkpool.settleMatch(obligationBundle, party0Bundle, party1Bundle);
+
+        // Verify allowances decremented by the obligation amounts
+        (uint160 allowance0After,,) =
+            IAllowanceTransfer(address(permit2)).allowance(party0.addr, address(baseToken), address(darkpool));
+        (uint160 allowance1After,,) =
+            IAllowanceTransfer(address(permit2)).allowance(party1.addr, address(quoteToken), address(darkpool));
+        uint256 expectedAllowance0 = permit0.intent.amountIn - obligation0.amountIn;
+        uint256 expectedAllowance1 = permit1.intent.amountIn - obligation1.amountIn;
+        assertEq(allowance0After, expectedAllowance0, "party0 allowance should decrement by obligation amount");
+        assertEq(allowance1After, expectedAllowance1, "party1 allowance should decrement by obligation amount");
+    }
+
+    /// @notice Test that subsequent fills use the existing allowance without needing permit registration
+    /// @dev After first fill registers the permit, subsequent fills should work without permit data
+    function test_permitRegistration_subsequentFillUsesExistingAllowance() public {
+        // --- First Fill --- //
+
+        (
+            PublicIntentPermit memory permit0,
+            PublicIntentPermit memory permit1,
+            SettlementObligation memory trade1Obligation0,
+            SettlementObligation memory trade1Obligation1
+        ) = _createMatchData();
+        _capitalizePartyWithoutPermit2Allowance(party0.addr, permit0.intent);
+        capitalizeParty(party1.addr, permit1.intent);
+
+        FixedPoint memory firstTradePrice = FixedPointLib.div(
+            FixedPointLib.wrap(trade1Obligation0.amountOut), FixedPointLib.wrap(trade1Obligation0.amountIn)
+        );
+
+        SignedPermitSingle memory allowancePermit = _createSignedPermit(
+            party0.privateKey,
+            address(baseToken),
+            uint160(permit0.intent.amountIn),
+            uint48(block.timestamp + 1 days),
+            0, // nonce
+            address(darkpool)
+        );
+
+        ObligationBundle memory obligationBundle1 = _createObligationBundle(trade1Obligation0, trade1Obligation1);
+        SettlementBundle memory party0Bundle1 = _createSettlementBundleWithPermit(
+            permit0.intent, trade1Obligation0, party0.privateKey, executor.privateKey, allowancePermit
+        );
+        SettlementBundle memory party1Bundle1 = createPublicIntentSettlementBundleWithSigners(
+            permit1.intent, trade1Obligation1, party1.privateKey, executor.privateKey
+        );
+
+        darkpool.settleMatch(obligationBundle1, party0Bundle1, party1Bundle1);
+
+        // Verify allowance decremented after first fill
+        (uint160 allowanceAfterFill1,,) =
+            IAllowanceTransfer(address(permit2)).allowance(party0.addr, address(baseToken), address(darkpool));
+        uint256 expectedAllowanceAfterFill1 = permit0.intent.amountIn - trade1Obligation0.amountIn;
+        assertEq(
+            allowanceAfterFill1,
+            expectedAllowanceAfterFill1,
+            "allowance should decrement by obligation amount after first fill"
+        );
+
+        // --- Second Fill --- //
+
+        // Fill the rest of the intent
+        uint256 party0Input = darkpool.openPublicIntents(permit0.computeHash());
+        assertTrue(party0Input > 0, "intent should have remaining amount");
+        uint256 party0Output = firstTradePrice.unsafeFixedPointMul(party0Input);
+
+        // Create new obligations for second fill
+        SettlementObligation memory trade2Obligation0 = SettlementObligation({
+            inputToken: trade1Obligation0.inputToken,
+            outputToken: trade1Obligation0.outputToken,
+            amountIn: party0Input,
+            amountOut: party0Output
+        });
+        SettlementObligation memory trade2Obligation1 = SettlementObligation({
+            inputToken: trade1Obligation1.inputToken,
+            outputToken: trade1Obligation1.outputToken,
+            amountIn: party0Output,
+            amountOut: party0Input
+        });
+        ObligationBundle memory obligationBundle2 = _createObligationBundle(trade2Obligation0, trade2Obligation1);
+
+        // Second fill should work without permit data (uses existing allowance)
+        SettlementBundle memory party0Bundle2 = createPublicIntentSettlementBundleWithSigners(
+            permit0.intent, trade2Obligation0, party0.privateKey, executor.privateKey
+        );
+        SettlementBundle memory party1Bundle2 = createPublicIntentSettlementBundleWithSigners(
+            permit1.intent, trade2Obligation1, party1.privateKey, executor.privateKey
+        );
+
+        darkpool.settleMatch(obligationBundle2, party0Bundle2, party1Bundle2);
+
+        // --- Verify State Updates --- //
+
+        // Verify intent fully filled
+        uint256 actualRemaining = darkpool.openPublicIntents(permit0.computeHash());
+        assertEq(actualRemaining, 0, "intent should be fully filled");
+
+        // Verify allowance fully used
+        (uint160 allowanceAfterFill2,,) =
+            IAllowanceTransfer(address(permit2)).allowance(party0.addr, address(baseToken), address(darkpool));
+        assertEq(allowanceAfterFill2, 0, "allowance should be fully used");
+    }
+
+    // ---------------------------------
+    // | Permit Validation Error Tests |
+    // ---------------------------------
+
+    /// @notice Test that permit registration reverts when permit token doesn't match transfer token
+    function test_permitRegistration_revert_tokenMismatch() public {
+        (
+            PublicIntentPermit memory permit0,
+            PublicIntentPermit memory permit1,
+            SettlementObligation memory obligation0,
+            SettlementObligation memory obligation1
+        ) = _createMatchData();
+        _capitalizePartyWithoutPermit2Allowance(party0.addr, permit0.intent);
+        capitalizeParty(party1.addr, permit1.intent);
+
+        // Create permit for quoteToken but intent uses baseToken
+        SignedPermitSingle memory allowancePermit = _createSignedPermit(
+            party0.privateKey,
+            address(quoteToken),
+            uint160(permit0.intent.amountIn),
+            uint48(block.timestamp + 1 days),
+            0 // nonce
+        );
+
+        ObligationBundle memory obligationBundle = _createObligationBundle(obligation0, obligation1);
+        SettlementBundle memory party0Bundle = _createSettlementBundleWithPermit(
+            permit0.intent, obligation0, party0.privateKey, executor.privateKey, allowancePermit
+        );
+        SettlementBundle memory party1Bundle = createPublicIntentSettlementBundleWithSigners(
+            permit1.intent, obligation1, party1.privateKey, executor.privateKey
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IDarkpoolV2.PermitTokenMismatch.selector, address(quoteToken), address(baseToken))
+        );
+        darkpool.settleMatch(obligationBundle, party0Bundle, party1Bundle);
+    }
+
+    /// @notice Test that permit registration reverts when permit spender is not the darkpool
+    function test_permitRegistration_revert_spenderMismatch() public {
+        (
+            PublicIntentPermit memory permit0,
+            PublicIntentPermit memory permit1,
+            SettlementObligation memory obligation0,
+            SettlementObligation memory obligation1
+        ) = _createMatchData();
+        _capitalizePartyWithoutPermit2Allowance(party0.addr, permit0.intent);
+        capitalizeParty(party1.addr, permit1.intent);
+
+        address wrongSpender = address(0xdead);
+        SignedPermitSingle memory allowancePermit = _createSignedPermit(
+            party0.privateKey,
+            address(baseToken),
+            uint160(permit0.intent.amountIn),
+            uint48(block.timestamp + 1 days),
+            0, // nonce
+            wrongSpender
+        );
+
+        ObligationBundle memory obligationBundle = _createObligationBundle(obligation0, obligation1);
+        SettlementBundle memory party0Bundle = _createSettlementBundleWithPermit(
+            permit0.intent, obligation0, party0.privateKey, executor.privateKey, allowancePermit
+        );
+        SettlementBundle memory party1Bundle = createPublicIntentSettlementBundleWithSigners(
+            permit1.intent, obligation1, party1.privateKey, executor.privateKey
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IDarkpoolV2.PermitSpenderMismatch.selector, wrongSpender, address(darkpool))
+        );
+        darkpool.settleMatch(obligationBundle, party0Bundle, party1Bundle);
+    }
+}

--- a/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
@@ -17,6 +17,7 @@ import {
     PublicIntentPermit,
     PublicIntentPermitLib
 } from "darkpoolv2-types/settlement/IntentBundle.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
 import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
 import { FeeRate } from "darkpoolv2-types/Fee.sol";
@@ -85,10 +86,13 @@ contract PublicIntentSettlementTestUtils is SettlementTestUtils {
 
     // --- Dummy Data --- //
 
-    /// @dev Create a dummy `SettlementTransfers` list for the test
+    /// @dev Create a dummy `SettlementContext` for the test
     function _createSettlementContext() internal pure virtual returns (SettlementContext memory context) {
         context = SettlementContextLib.newContext(
-            1, /* numDeposits */ 3, /* numWithdrawals */ 1, /* verificationCapacity */ 1 /* proofLinkingCapacity */
+            1, // numDeposits
+            3, // numWithdrawals
+            1, // verificationCapacity
+            1 // proofLinkingCapacity
         );
     }
 
@@ -135,11 +139,13 @@ contract PublicIntentSettlementTestUtils is SettlementTestUtils {
         FeeRate memory feeRate = relayerFeeRate();
         SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
 
-        // Create auth bundle
+        // Create auth bundle with empty permit (no first-fill permit)
+        SignedPermitSingle memory emptyPermit;
         PublicIntentAuthBundle memory auth = PublicIntentAuthBundle({
-            permit: permit,
+            intentPermit: permit,
             intentSignature: intentSignature,
-            executorSignature: executorSignature
+            executorSignature: executorSignature,
+            allowancePermit: emptyPermit
         });
         PublicIntentPublicBalanceBundle memory bundleData =
             PublicIntentPublicBalanceBundle({ auth: auth, relayerFeeRate: feeRate });

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/Utils.sol
@@ -54,7 +54,10 @@ contract RenegadeSettledPrivateFillTestUtils is DarkpoolV2TestUtils {
     /// @dev Create a dummy `SettlementContext` for the test
     function _createSettlementContext() internal pure returns (SettlementContext memory context) {
         context = SettlementContextLib.newContext(
-            0, /* numDeposits */ 0, /* numWithdrawals */ 2, /* verificationCapacity */ 2 /* proofLinkingCapacity */
+            0, // numDeposits
+            0, // numWithdrawals
+            2, // verificationCapacity
+            2 // proofLinkingCapacity
         );
     }
 


### PR DESCRIPTION
### Purpose

This PR allows users to register permit on the first fill of a ring 0 intent through signature validation, which the Permit2 contract supports natively. We do so by allowing the user to attach a permit and a signature to the `PublicIntentAuthBundle` which the darkpool will detect and set its allowance as a spender in the Permit2 contract, given validation passes.

ABI was also regenerated and integration tests updated to ingest changes.

### Testing

- [x] All tests pass