### PR TITLE
darkpoolv2: remove unused transfer executor field

### DIFF
--- a/script/v2/DeployV2Utils.sol
+++ b/script/v2/DeployV2Utils.sol
@@ -17,7 +17,6 @@ import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
 import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
-import { TransferExecutor } from "darkpoolv1-contracts/TransferExecutor.sol";
 import { GasSponsor } from "darkpoolv1-contracts/GasSponsor.sol";
 import { GasSponsorProxy } from "darkpoolv1-proxies/GasSponsorProxy.sol";
 import { MalleableMatchConnector } from "renegade-connectors/MalleableMatchConnector.sol";
@@ -26,17 +25,8 @@ import { DeployUtils } from "../utils/DeployUtils.sol";
 
 /// @title DeployV2Utils
 /// @author Renegade Eng
-/// @notice Deployment utilities for the Renegade darkpool v1
+/// @notice Deployment utilities for the Renegade darkpool v2
 contract DeployV2Utils {
-    /// @notice Deploy the TransferExecutor contract
-    /// @param vm The VM to write deployments
-    /// @return The deployed TransferExecutor address
-    function deployTransferExecutor(Vm vm) internal returns (address) {
-        TransferExecutor transferExecutor = new TransferExecutor();
-        DeployUtils.writeDeployment(vm, "TransferExecutor", address(transferExecutor));
-        return address(transferExecutor);
-    }
-
     /// @notice Deploy the VKeys and Verifier contracts
     /// @param vm The VM to write deployments
     /// @return The deployed VKeys contract
@@ -129,7 +119,6 @@ contract DeployV2Utils {
         // Deploy library contracts for the darkpool
         IHasher hasher = IHasher(DeployUtils.deployHasher(vm));
         (IVkeys vkeys, IVerifier verifier) = deployVKeysAndVerifier(vm);
-        address transferExecutor = deployTransferExecutor(vm);
 
         // Deploy Darkpool with all required parameters
         DarkpoolV2 darkpool = new DarkpoolV2();
@@ -143,8 +132,7 @@ contract DeployV2Utils {
             hasher,
             vkeys,
             verifier,
-            permit2,
-            transferExecutor
+            permit2
         );
 
         DeployUtils.writeDeployment(vm, "Darkpool", address(darkpool));

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -79,8 +79,6 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     IPermit2 public permit2;
     /// @notice The WETH9 contract instance used for depositing/withdrawing native tokens
     IWETH9 public weth;
-    /// @notice The TransferExecutor contract for handling external transfers
-    address public transferExecutor;
 
     // --- Protocol Level State Storage --- //
 
@@ -110,8 +108,7 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         IHasher hasher_,
         IVkeys vkeys_,
         IVerifier verifier_,
-        IPermit2 permit2_,
-        address transferExecutor_
+        IPermit2 permit2_
     )
         public
         initializer
@@ -127,7 +124,6 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         verifier = verifier_;
         permit2 = permit2_;
         weth = weth_;
-        transferExecutor = transferExecutor_;
     }
 
     // -----------------

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -179,7 +179,6 @@ interface IDarkpoolV2 {
     /// @param vkeys_ The verification keys for the darkpool
     /// @param verifier_ The verifier for the darkpool
     /// @param permit2_ The Permit2 contract instance
-    /// @param transferExecutor_ The TransferExecutor contract address
     function initialize(
         address initialOwner,
         uint256 defaultProtocolFeeRateRepr,
@@ -189,8 +188,7 @@ interface IDarkpoolV2 {
         IHasher hasher_,
         IVkeys vkeys_,
         IVerifier verifier_,
-        IPermit2 permit2_,
-        address transferExecutor_
+        IPermit2 permit2_
     )
         external;
 

--- a/src/darkpool/v2/proxies/DarkpoolV2Proxy.sol
+++ b/src/darkpool/v2/proxies/DarkpoolV2Proxy.sol
@@ -29,7 +29,6 @@ contract DarkpoolV2Proxy is TransparentUpgradeableProxy {
     /// @param hasher The hasher for the darkpool
     /// @param verifier The verifier for the darkpool
     /// @param permit2 The Permit2 contract instance for handling deposits
-    /// @param transferExecutor The TransferExecutor contract address
     constructor(
         address implementation,
         address admin,
@@ -41,8 +40,7 @@ contract DarkpoolV2Proxy is TransparentUpgradeableProxy {
         IHasher hasher,
         IVkeys vkeys,
         IVerifier verifier,
-        IPermit2 permit2,
-        address transferExecutor
+        IPermit2 permit2
     )
         payable
         TransparentUpgradeableProxy(
@@ -58,8 +56,7 @@ contract DarkpoolV2Proxy is TransparentUpgradeableProxy {
                 hasher,
                 vkeys,
                 verifier,
-                permit2,
-                transferExecutor
+                permit2
             )
         )
     { }

--- a/test/darkpool/v2/DarkpoolV2TestBase.sol
+++ b/test/darkpool/v2/DarkpoolV2TestBase.sol
@@ -13,7 +13,6 @@ import { EncryptionKey, BabyJubJubPoint } from "renegade-lib/Ciphertext.sol";
 import { DarkpoolV2 } from "darkpoolv2-contracts/DarkpoolV2.sol";
 import { DarkpoolV2Proxy } from "darkpoolv2-proxies/DarkpoolV2Proxy.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
-import { TransferExecutor } from "darkpoolv1-contracts/TransferExecutor.sol";
 import { NullifierLib } from "renegade-lib/NullifierSet.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { IVerifier } from "darkpoolv2-interfaces/IVerifier.sol";
@@ -49,7 +48,6 @@ contract DarkpoolV2TestBase is TestUtils {
     ERC20Mock public quoteToken;
     ERC20Mock public baseToken;
     WethMock public weth;
-    TransferExecutor public transferExecutor;
     /// @dev Gas sponsor contract (points to the darkpool with disabled verification)
     IGasSponsor public gasSponsor;
 
@@ -101,9 +99,6 @@ contract DarkpoolV2TestBase is TestUtils {
         IVerifier realVerifier = new Verifier(vkeys);
         EncryptionKey memory protocolFeeKey = randomEncryptionKey();
 
-        // Deploy TransferExecutor
-        transferExecutor = new TransferExecutor();
-
         // Set admin and protocol fee addresses
         darkpoolOwner = vm.randomAddress();
         protocolFeeAddr = vm.randomAddress();
@@ -125,8 +120,7 @@ contract DarkpoolV2TestBase is TestUtils {
             hasher,
             vkeys,
             verifier,
-            permit2,
-            address(transferExecutor)
+            permit2
         );
         darkpool = IDarkpoolV2(address(darkpoolProxy));
 
@@ -141,8 +135,7 @@ contract DarkpoolV2TestBase is TestUtils {
             hasher,
             vkeys,
             realVerifier,
-            permit2,
-            address(transferExecutor)
+            permit2
         );
         darkpoolRealVerifier = IDarkpoolV2(address(darkpoolRealVerifierProxy));
     }


### PR DESCRIPTION
### Purpose

This PR removes the transfer executor from the v2 implementation as it is unused and was carried over from v1.

### Testing

- [x] All tests pass