### PR TITLE
darkpoolv2: state-updates: Validate Merkle roots for deposit + withdraw

### DIFF
--- a/test/darkpool/v2/state-updates/Deposit.t.sol
+++ b/test/darkpool/v2/state-updates/Deposit.t.sol
@@ -151,7 +151,7 @@ contract DepositTest is DarkpoolV2TestUtils {
         BN254.ScalarField oldBalanceNullifier = randomScalar();
         BN254.ScalarField newBalanceCommitment = randomScalar();
         BN254.ScalarField newAmountShare = randomScalar();
-        BN254.ScalarField merkleRoot = randomScalar();
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
         BN254.ScalarField recoveryId = randomScalar();
         uint256 merkleDepth = DarkpoolConstants.DEFAULT_MERKLE_DEPTH;
         ValidDepositStatement memory statement = ValidDepositStatement({

--- a/test/darkpool/v2/state-updates/OrderCancellation.t.sol
+++ b/test/darkpool/v2/state-updates/OrderCancellation.t.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.24;
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
 import { DarkpoolV2TestUtils } from "../DarkpoolV2TestUtils.sol";
 import { OrderCancellationProofBundle } from "darkpoolv2-types/ProofBundles.sol";
 import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
@@ -60,12 +61,14 @@ contract OrderCancellationTest is DarkpoolV2TestUtils {
     /// @notice Create an order cancellation proof bundle for testing
     /// @return The order cancellation proof bundle
     function createOrderCancellationProofBundle() internal returns (OrderCancellationProofBundle memory) {
-        BN254.ScalarField merkleRoot = randomScalar();
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
         BN254.ScalarField oldIntentNullifier = randomScalar();
         address owner = intentOwner.addr;
 
         ValidOrderCancellationStatement memory statement = ValidOrderCancellationStatement({
-            merkleRoot: merkleRoot, oldIntentNullifier: oldIntentNullifier, owner: owner
+            merkleRoot: merkleRoot,
+            oldIntentNullifier: oldIntentNullifier,
+            owner: owner
         });
 
         return OrderCancellationProofBundle({ statement: statement, proof: createDummyProof() });

--- a/test/darkpool/v2/state-updates/Withdrawal.t.sol
+++ b/test/darkpool/v2/state-updates/Withdrawal.t.sol
@@ -83,7 +83,7 @@ contract WithdrawalTest is DarkpoolV2TestUtils {
     /// @param withdrawal The withdrawal struct
     /// @return proofBundle The withdrawal proof bundle
     function createWithdrawalProofBundle(Withdrawal memory withdrawal) internal returns (WithdrawalProofBundle memory) {
-        BN254.ScalarField merkleRoot = randomScalar();
+        BN254.ScalarField merkleRoot = darkpool.getMerkleRoot(DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
         BN254.ScalarField oldBalanceNullifier = randomScalar();
         BN254.ScalarField newBalanceCommitment = randomScalar();
         BN254.ScalarField recoveryId = randomScalar();


### PR DESCRIPTION
### Purpose
This PR adds validation logic for Merkle roots in the deposit, withdraw, and private order cancellation pathways.

### Testing
- [x] Unit tests pass