### PR TITLE
darkpoolv2: Darkpool: Whitelist tokens

### DIFF
--- a/script/v2/DeployDev.s.sol
+++ b/script/v2/DeployDev.s.sol
@@ -10,6 +10,7 @@ import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
 import { IPermit2 } from "permit2-lib/interfaces/IPermit2.sol";
 import { WethMock } from "test-contracts/WethMock.sol";
 import { MockERC20 } from "solmate/src/test/utils/mocks/MockERC20.sol";
+import { DarkpoolV2 } from "darkpoolv2-contracts/DarkpoolV2.sol";
 
 import { BN254 } from "solidity-bn254/BN254.sol";
 import { EncryptionKey, BabyJubJubPoint } from "renegade-lib/Ciphertext.sol";
@@ -51,7 +52,7 @@ contract DeployDevScript is Script, DeployV2Utils {
         // Call the shared deployment logic
         uint256 dummyProtocolFee = 1;
         address dummyExternalFeeRecipient = address(0x42);
-        deployCore(
+        address darkpoolAddr = deployCore(
             msg.sender, // Use deployer as owner
             dummyProtocolFee,
             dummyExternalFeeRecipient,
@@ -60,6 +61,14 @@ contract DeployDevScript is Script, DeployV2Utils {
             weth,
             vm
         );
+
+        // Whitelist tokens for the darkpool
+        DarkpoolV2 darkpool = DarkpoolV2(darkpoolAddr);
+        darkpool.setTokenWhitelist(address(baseToken), true);
+        darkpool.setTokenWhitelist(address(quoteToken), true);
+        darkpool.setTokenWhitelist(address(weth), true);
+        console.log("Whitelisted tokens: BaseToken, QuoteToken, WETH");
+
         vm.stopBroadcast();
     }
 }

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -171,6 +171,13 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
         return _state.getProtocolFeeKey();
     }
 
+    /// @notice Check if a token is whitelisted
+    /// @param token The token address to check
+    /// @return Whether the token is whitelisted
+    function isTokenWhitelisted(address token) public view returns (bool) {
+        return _state.isTokenWhitelisted(token);
+    }
+
     // -----------------
     // | State Updates |
     // -----------------
@@ -343,6 +350,13 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     function setHasher(IHasher newHasher) external onlyOwner {
         if (address(newHasher) == address(0)) revert IDarkpoolV2.AddressCannotBeZero();
         hasher = newHasher;
+    }
+
+    /// @notice Set the whitelist status for a token
+    /// @param token The token address to set whitelist status for
+    /// @param whitelisted Whether the token should be whitelisted
+    function setTokenWhitelist(address token, bool whitelisted) external onlyOwner {
+        _state.setTokenWhitelist(token, whitelisted);
     }
 
     /// @notice Pause the darkpool

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -121,6 +121,8 @@ interface IDarkpoolV2 {
     error AddressCannotBeZero();
     /// @notice Thrown when fee is set to zero
     error FeeCannotBeZero();
+    /// @notice Thrown when a token is not whitelisted
+    error TokenNotWhitelisted(address token);
 
     // --- Events --- //
 
@@ -350,4 +352,14 @@ interface IDarkpoolV2 {
     /// @notice Set the hasher contract
     /// @param newHasher The new hasher contract
     function setHasher(IHasher newHasher) external;
+
+    /// @notice Check if a token is whitelisted
+    /// @param token The token address to check
+    /// @return Whether the token is whitelisted
+    function isTokenWhitelisted(address token) external view returns (bool);
+
+    /// @notice Set the whitelist status for a token
+    /// @param token The token address to set whitelist status for
+    /// @param whitelisted Whether the token should be whitelisted
+    function setTokenWhitelist(address token, bool whitelisted) external;
 }

--- a/src/darkpool/v2/libraries/DarkpoolState.sol
+++ b/src/darkpool/v2/libraries/DarkpoolState.sol
@@ -35,6 +35,9 @@ struct DarkpoolState {
     /// @dev Only external match fees are overridden, internal match fees are always the protocol fee rate
     /// @dev Key is keccak256(abi.encodePacked(token0, token1)) where token0 < token1
     mapping(bytes32 => FixedPoint) perPairFeeOverrides;
+    /// @notice Mapping of whitelisted ERC20 tokens
+    /// @dev Only whitelisted tokens can be deposited or used in matches
+    mapping(address => bool) whitelistedTokens;
     /// @notice The Merkle mountain range for state element commitments
     MerkleMountainLib.MerkleMountainRange merkleMountainRange;
     /// @notice The nullifier set for the darkpool
@@ -160,6 +163,14 @@ library DarkpoolStateLib {
         return FeeRate({ rate: rate, recipient: state.protocolFeeRecipient });
     }
 
+    /// @notice Check if a token is whitelisted
+    /// @param state The darkpool state
+    /// @param token The token address to check
+    /// @return Whether the token is whitelisted
+    function isTokenWhitelisted(DarkpoolState storage state, address token) internal view returns (bool) {
+        return state.whitelistedTokens[token];
+    }
+
     // --- Setters --- //
 
     /// @notice Set the amount remaining for an open public intent
@@ -207,6 +218,14 @@ library DarkpoolStateLib {
     {
         bytes32 pairKey = _getPairKey(asset0, asset1);
         state.perPairFeeOverrides[pairKey] = feeRate;
+    }
+
+    /// @notice Set the whitelist status for a token
+    /// @param state The darkpool state
+    /// @param token The token address to set whitelist status for
+    /// @param whitelisted Whether the token should be whitelisted
+    function setTokenWhitelist(DarkpoolState storage state, address token, bool whitelisted) internal {
+        state.whitelistedTokens[token] = whitelisted;
     }
 
     /// @notice Spend a nullifier

--- a/src/darkpool/v2/libraries/TransferLib.sol
+++ b/src/darkpool/v2/libraries/TransferLib.sol
@@ -169,7 +169,9 @@ library ExternalTransferLib {
         ISignatureTransfer.TokenPermissions memory tokenPermissions =
             ISignatureTransfer.TokenPermissions({ token: deposit.token, amount: deposit.amount });
         ISignatureTransfer.PermitTransferFrom memory permit = ISignatureTransfer.PermitTransferFrom({
-            permitted: tokenPermissions, nonce: auth.permit2Nonce, deadline: auth.permit2Deadline
+            permitted: tokenPermissions,
+            nonce: auth.permit2Nonce,
+            deadline: auth.permit2Deadline
         });
         ISignatureTransfer.SignatureTransferDetails memory transferDetails =
             ISignatureTransfer.SignatureTransferDetails({ to: address(this), requestedAmount: deposit.amount });

--- a/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
+++ b/src/darkpool/v2/libraries/settlement/ExternalSettlementLib.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 
 import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMatchResultBundle.sol";
-import { BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
 import {
     SettlementBundle,
     SettlementBundleType,
@@ -52,6 +52,15 @@ library ExternalSettlementLib {
     {
         // Validate the bounded match result
         BoundedMatchResultLib.validateBoundedMatchResult(matchBundle.permit.matchResult, externalPartyAmountIn);
+
+        // Validate that tokens are whitelisted
+        BoundedMatchResult calldata boundedMatchResult = matchBundle.permit.matchResult;
+        if (!state.isTokenWhitelisted(boundedMatchResult.internalPartyInputToken)) {
+            revert IDarkpoolV2.TokenNotWhitelisted(boundedMatchResult.internalPartyInputToken);
+        }
+        if (!state.isTokenWhitelisted(boundedMatchResult.internalPartyOutputToken)) {
+            revert IDarkpoolV2.TokenNotWhitelisted(boundedMatchResult.internalPartyOutputToken);
+        }
 
         // Allocate a settlement context
         SettlementContext memory settlementContext = allocateExternalSettlementContext(internalPartySettlementBundle);

--- a/test/darkpool/v2/DarkpoolV2TestBase.sol
+++ b/test/darkpool/v2/DarkpoolV2TestBase.sol
@@ -138,6 +138,22 @@ contract DarkpoolV2TestBase is TestUtils {
             permit2
         );
         darkpoolRealVerifier = IDarkpoolV2(address(darkpoolRealVerifierProxy));
+
+        // Whitelist tokens for testing
+        vm.prank(darkpoolOwner);
+        darkpool.setTokenWhitelist(address(baseToken), true);
+        vm.prank(darkpoolOwner);
+        darkpool.setTokenWhitelist(address(quoteToken), true);
+        vm.prank(darkpoolOwner);
+        darkpool.setTokenWhitelist(address(weth), true);
+
+        // Also whitelist tokens for the real verifier darkpool
+        vm.prank(darkpoolOwner);
+        darkpoolRealVerifier.setTokenWhitelist(address(baseToken), true);
+        vm.prank(darkpoolOwner);
+        darkpoolRealVerifier.setTokenWhitelist(address(quoteToken), true);
+        vm.prank(darkpoolOwner);
+        darkpoolRealVerifier.setTokenWhitelist(address(weth), true);
     }
 
     /**
@@ -195,7 +211,10 @@ contract DarkpoolV2TestBase is TestUtils {
     /// @param min The minimum fixed point value
     /// @param max The maximum fixed point value
     /// @return result The random fixed point value
-    function randomFixedPoint(FixedPoint memory min, FixedPoint memory max)
+    function randomFixedPoint(
+        FixedPoint memory min,
+        FixedPoint memory max
+    )
         internal
         returns (FixedPoint memory result)
     {
@@ -260,7 +279,11 @@ contract DarkpoolV2TestBase is TestUtils {
     /// @param verifier The verifier to use (if not provided, uses the darkpool's verifier)
     function getSettlementContracts(IVerifier verifier) public view returns (DarkpoolContracts memory contracts) {
         contracts = DarkpoolContracts({
-            hasher: hasher, verifier: verifier, weth: IWETH9(address(weth)), permit2: permit2, vkeys: vkeys
+            hasher: hasher,
+            verifier: verifier,
+            weth: IWETH9(address(weth)),
+            permit2: permit2,
+            vkeys: vkeys
         });
     }
 

--- a/test/darkpool/v2/DarkpoolV2TestUtils.sol
+++ b/test/darkpool/v2/DarkpoolV2TestUtils.sol
@@ -15,7 +15,7 @@ import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
 import { Intent, IntentPublicShare } from "darkpoolv2-types/Intent.sol";
 import { PostMatchBalanceShare } from "darkpoolv2-types/Balance.sol";
 import { PartialCommitment } from "darkpoolv2-types/PartialCommitment.sol";
-import { DarkpoolState } from "darkpoolv2-contracts/DarkpoolV2.sol";
+import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 
 import { PlonkProof, LinkingProof } from "renegade-lib/verifier/Types.sol";
 import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
@@ -24,6 +24,7 @@ import { FeeRate } from "darkpoolv2-types/Fee.sol";
 contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
     using FixedPointLib for FixedPoint;
     using MerkleMountainLib for MerkleMountainLib.MerkleMountainRange;
+    using DarkpoolStateLib for DarkpoolState;
 
     // Test wallets
     Vm.Wallet internal intentOwner;
@@ -58,6 +59,11 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
         // Initialize the darkpoolState's merkle mountain range to match the darkpool contract's initialization
         // This ensures that roots stored during initialization are available in the test state
         MerkleMountainLib.initialize(darkpoolState.merkleMountainRange, DarkpoolConstants.DEFAULT_MERKLE_DEPTH);
+
+        // Whitelist tokens in the test state to match the contract state
+        darkpoolState.setTokenWhitelist(address(baseToken), true);
+        darkpoolState.setTokenWhitelist(address(quoteToken), true);
+        darkpoolState.setTokenWhitelist(address(weth), true);
     }
 
     // --- ERC20 Balances --- //
@@ -138,7 +144,9 @@ contract DarkpoolV2TestUtils is DarkpoolV2TestBase {
     /// @dev Generate a random post match balance share
     function randomPostMatchBalanceShare() internal returns (PostMatchBalanceShare memory) {
         return PostMatchBalanceShare({
-            relayerFeeBalance: randomScalar(), protocolFeeBalance: randomScalar(), amount: randomScalar()
+            relayerFeeBalance: randomScalar(),
+            protocolFeeBalance: randomScalar(),
+            amount: randomScalar()
         });
     }
 


### PR DESCRIPTION
### Purpose
This PR adds a token whitelist to the darkpool. We whitelist tokens mostly to simplify the security model and avoid considering arbitrary ERC20 behavior.

### Testing
- [x] Unit tests pass
- [x] Integration tests pass