### PR TITLE
darkpoolv2: DarkpoolState: Namespace spent nonces by `address`

### DIFF
--- a/src/darkpool/v2/libraries/DarkpoolState.sol
+++ b/src/darkpool/v2/libraries/DarkpoolState.sol
@@ -22,7 +22,8 @@ struct DarkpoolState {
     mapping(bytes32 => uint256) openPublicIntents;
     /// @notice A store of spent signature nonces for user updates
     /// @dev This is used to prevent a relayer from submitting the same update twice
-    mapping(uint256 => bool) spentNonces;
+    /// @dev Nonces are namespaced by signer address to prevent cross-user collisions
+    mapping(address => mapping(uint256 => bool)) spentNonces;
     /// @notice The default protocol fee rate for the darkpool
     FixedPoint defaultProtocolFeeRate;
     /// @notice The address at which external parties pay protocol fees
@@ -197,10 +198,11 @@ library DarkpoolStateLib {
 
     /// @notice Spend a signature nonce
     /// @param state The darkpool state
+    /// @param signer The address of the signer who owns the nonce
     /// @param nonce The nonce to spend
-    function spendNonce(DarkpoolState storage state, uint256 nonce) internal {
-        if (state.spentNonces[nonce]) revert NonceAlreadySpent();
-        state.spentNonces[nonce] = true;
+    function spendNonce(DarkpoolState storage state, address signer, uint256 nonce) internal {
+        if (state.spentNonces[signer][nonce]) revert NonceAlreadySpent();
+        state.spentNonces[signer][nonce] = true;
     }
 
     /// @notice Set the per-pair fee override for a trading pair

--- a/src/darkpool/v2/types/settlement/SignatureWithNonce.sol
+++ b/src/darkpool/v2/types/settlement/SignatureWithNonce.sol
@@ -32,6 +32,7 @@ library SignatureWithNonceLib {
     /// @param state The darkpool state to spend the nonce in
     /// @return Whether the signature is valid
     /// @dev Verifies the signature over H(digest || nonce || chainId) and always spends the nonce to prevent replay
+    /// @dev Nonces are namespaced by signer address to prevent cross-user collisions
     function verifyPrehashedAndSpendNonce(
         SignatureWithNonce memory signature,
         address expectedSigner,
@@ -41,8 +42,8 @@ library SignatureWithNonceLib {
         internal
         returns (bool)
     {
-        // Spend the nonce to prevent replay
-        state.spendNonce(signature.nonce);
+        // Spend the nonce to prevent replay (namespaced by signer)
+        state.spendNonce(expectedSigner, signature.nonce);
 
         // Verify the signature
         bytes32 signatureHash = EfficientHashLib.hash(digest, bytes32(signature.nonce), bytes32(block.chainid));


### PR DESCRIPTION
### Purpose
This PR namespaces the `spentNonces` mapping by the signer's `address`. This prevents a DoS attack in which an adversary observes a signature nonce and frontruns it to block a transaction.

### Testing
- [x] Unit tests pass
- [x] Added a test to validate the namespacing.