### PR TITLE
darkpoolv2: StateUpdates: Allow users to revoke nonces

### DIFF
--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -39,6 +39,7 @@ import {
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 import { PublicIntentPermit } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { SettlementLib } from "darkpoolv2-lib/settlement/SettlementLib.sol";
 import { ExternalSettlementLib } from "darkpoolv2-lib/settlement/ExternalSettlementLib.sol";
@@ -198,6 +199,18 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     /// @inheritdoc IDarkpoolV2
     function cancelPublicOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) public {
         StateUpdatesLib.cancelPublicOrder(_state, auth, permit);
+    }
+
+    /// @inheritdoc IDarkpoolV2
+    function revokeNonce(
+        address owner,
+        uint256 nonceToRevoke,
+        SignatureWithNonce memory signature
+    )
+        public
+        whenNotPaused
+    {
+        StateUpdatesLib.revokeNonce(_state, owner, nonceToRevoke, signature);
     }
 
     // --- Deposit --- //

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -19,6 +19,7 @@ import { BoundedMatchResultBundle } from "darkpoolv2-types/settlement/BoundedMat
 import { DepositAuth } from "darkpoolv2-types/transfers/Deposit.sol";
 import { WithdrawalAuth } from "darkpoolv2-types/transfers/Withdrawal.sol";
 import { OrderCancellationAuth } from "darkpoolv2-types/OrderCancellation.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 import { PublicIntentPermit } from "darkpoolv2-types/settlement/IntentBundle.sol";
 import { EncryptionKey } from "renegade-lib/Ciphertext.sol";
 import { FixedPoint } from "renegade-lib/FixedPoint.sol";
@@ -147,6 +148,10 @@ interface IDarkpoolV2 {
     /// @param orderHash The hash of the cancelled order
     /// @param owner The owner who cancelled the order
     event PublicOrderCancelled(bytes32 indexed orderHash, address indexed owner);
+    /// @notice Emitted when a nonce is revoked
+    /// @param revokedNonce The nonce that was revoked
+    /// @param owner The owner who revoked the nonce
+    event NonceRevoked(uint256 indexed revokedNonce, address indexed owner);
 
     // --- Admin Events --- //
 
@@ -266,6 +271,15 @@ interface IDarkpoolV2 {
     /// @param auth The authorization for the order cancellation
     /// @param permit The public intent permit identifying the intent to cancel
     function cancelPublicOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) external;
+
+    /// @notice Revoke a nonce to invalidate previously signed bundles
+    /// @dev This allows users to proactively invalidate signed bundles (e.g., first-fill bundles) that they've
+    /// given to relayers but haven't been submitted yet. The owner must sign H("revoke" || nonceToRevoke) with
+    /// a nonce for replay protection.
+    /// @param owner The owner who is revoking the nonce
+    /// @param nonceToRevoke The nonce to revoke
+    /// @param signature The signature over the revoke digest (with nonce for replay protection)
+    function revokeNonce(address owner, uint256 nonceToRevoke, SignatureWithNonce memory signature) external;
 
     /// @notice Pay protocol fees publicly on a balance
     /// @param proofBundle The proof bundle for the public protocol fee payment

--- a/src/darkpool/v2/libraries/Constants.sol
+++ b/src/darkpool/v2/libraries/Constants.sol
@@ -11,6 +11,9 @@ library DarkpoolConstants {
     /// @notice Domain separator for public intent cancellation signatures
     /// @dev Used to prevent signature reuse across different message types
     bytes internal constant CANCEL_DOMAIN = "cancel";
+    /// @notice Domain separator for nonce revocation signatures
+    /// @dev Used to prevent signature reuse across different message types
+    bytes internal constant REVOKE_NONCE_DOMAIN = "revoke";
     /// @notice The address used for native tokens in trade settlement
     /// @dev This is currently just ETH, but intentionally written abstractly
     address internal constant NATIVE_TOKEN_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;

--- a/test/darkpool/v2/state-updates/NonceRevocation.t.sol
+++ b/test/darkpool/v2/state-updates/NonceRevocation.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+/* solhint-disable gas-small-strings */
+/* solhint-disable func-name-mixedcase */
+pragma solidity ^0.8.24;
+
+import { DarkpoolV2TestUtils } from "../DarkpoolV2TestUtils.sol";
+import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+
+/// @title NonceRevocationTest
+/// @author Renegade Eng
+/// @notice Tests for the nonce revocation functionality in DarkpoolV2
+contract NonceRevocationTest is DarkpoolV2TestUtils {
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @notice Create a revocation signature signed with the given private key
+    /// @param nonceToRevoke The nonce to revoke
+    /// @param privateKey The private key to sign with
+    /// @return signature The revocation signature
+    function _createRevokeNonceSignature(
+        uint256 nonceToRevoke,
+        uint256 privateKey
+    )
+        internal
+        returns (SignatureWithNonce memory signature)
+    {
+        uint256 authNonce = vm.randomUint();
+        bytes32 revokeDigest =
+            keccak256(abi.encodePacked(DarkpoolConstants.REVOKE_NONCE_DOMAIN, bytes32(nonceToRevoke)));
+        bytes32 signatureHash = EfficientHashLib.hash(revokeDigest, bytes32(authNonce), bytes32(block.chainid));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, signatureHash);
+        bytes memory sigBytes = abi.encodePacked(r, s, v);
+        signature = SignatureWithNonce({ nonce: authNonce, signature: sigBytes });
+    }
+
+    /// @notice Create a revocation signature with correct signer (owner)
+    /// @param nonceToRevoke The nonce to revoke
+    /// @return signature The revocation signature signed by the intent owner
+    function createRevokeNonceSignature(uint256 nonceToRevoke) internal returns (SignatureWithNonce memory signature) {
+        return _createRevokeNonceSignature(nonceToRevoke, intentOwner.privateKey);
+    }
+
+    /// @notice Create a revocation signature with wrong signer
+    /// @param nonceToRevoke The nonce to revoke
+    /// @return signature The revocation signature signed by the wrong signer
+    function createRevokeNonceSignatureWrongSigner(uint256 nonceToRevoke)
+        internal
+        returns (SignatureWithNonce memory signature)
+    {
+        return _createRevokeNonceSignature(nonceToRevoke, wrongSigner.privateKey);
+    }
+
+    // ---------
+    // | Tests |
+    // ---------
+
+    /// @notice Test that revoking a nonce succeeds
+    function test_revokeNonce_succeeds() public {
+        uint256 nonceToRevoke = vm.randomUint();
+        SignatureWithNonce memory signature = createRevokeNonceSignature(nonceToRevoke);
+
+        // Execute the revocation - should succeed
+        vm.prank(intentOwner.addr);
+        darkpool.revokeNonce(intentOwner.addr, nonceToRevoke, signature);
+
+        // Verify nonce is spent by trying to revoke it again (should fail)
+        SignatureWithNonce memory signature2 = createRevokeNonceSignature(nonceToRevoke);
+        vm.prank(intentOwner.addr);
+        vm.expectRevert(DarkpoolStateLib.NonceAlreadySpent.selector);
+        darkpool.revokeNonce(intentOwner.addr, nonceToRevoke, signature2);
+    }
+
+    /// @notice Test that the same nonce cannot be revoked twice (replay protection)
+    function test_revokeNonce_nonceReplay() public {
+        uint256 nonceToRevoke = vm.randomUint();
+        SignatureWithNonce memory signature = createRevokeNonceSignature(nonceToRevoke);
+
+        // Execute the revocation once - should succeed
+        vm.prank(intentOwner.addr);
+        darkpool.revokeNonce(intentOwner.addr, nonceToRevoke, signature);
+
+        // Try to revoke the same nonce again - should revert because nonce is already spent
+        SignatureWithNonce memory signature2 = createRevokeNonceSignature(nonceToRevoke);
+        vm.prank(intentOwner.addr);
+        vm.expectRevert(DarkpoolStateLib.NonceAlreadySpent.selector);
+        darkpool.revokeNonce(intentOwner.addr, nonceToRevoke, signature2);
+    }
+
+    /// @notice Test that revoking a nonce requires the correct owner signature
+    function test_revokeNonce_requiresOwnerSignature() public {
+        uint256 nonceToRevoke = vm.randomUint();
+        SignatureWithNonce memory signature = createRevokeNonceSignatureWrongSigner(nonceToRevoke);
+
+        // Should revert due to invalid signature
+        vm.prank(intentOwner.addr);
+        vm.expectRevert(IDarkpoolV2.InvalidOrderCancellationSignature.selector);
+        darkpool.revokeNonce(intentOwner.addr, nonceToRevoke, signature);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR allows a user to revoke a nonce for a signature that has not been yet spent on-chain.

### Testing
- [x] Unit tests pass
- [x] Added nonce revocation tests.