### PR TITLE
darkpoolv2: NativeSettledPublicIntent: Fix bounded match fee malleability

### DIFF
--- a/abi/src/v2/relayer_types/bounded_match_result.rs
+++ b/abi/src/v2/relayer_types/bounded_match_result.rs
@@ -6,8 +6,6 @@ use crate::v2::{
     relayer_types::u128_to_u256,
     IDarkpoolV2::{self, BoundedMatchResultPermit},
 };
-use alloy::signers::Error as SignerError;
-use alloy::{signers::local::PrivateKeySigner, sol_types::SolValue};
 use darkpool_types::bounded_match_result::BoundedMatchResult as CircuitBoundedMatchResult;
 
 impl From<CircuitBoundedMatchResult> for IDarkpoolV2::BoundedMatchResult {
@@ -29,22 +27,16 @@ impl From<CircuitBoundedMatchResult> for IDarkpoolV2::BoundedMatchResult {
 
 #[cfg(feature = "v2-auth-helpers")]
 impl BoundedMatchResultBundle {
-    pub fn new(
-        chain_id: u64,
-        bounded_match_result: &CircuitBoundedMatchResult,
-        executor_signer: &PrivateKeySigner,
-    ) -> Result<Self, SignerError> {
-        use crate::v2::auth_helpers::sign_with_nonce;
-
+    /// Create a new bounded match result bundle
+    ///
+    /// Note: The executor signature is no longer part of BoundedMatchResultBundle.
+    /// For public intents, the executor signature (signing feeRate + matchResult)
+    /// should be provided via PublicIntentAuthBundle.executorSignature.
+    pub fn new(bounded_match_result: &CircuitBoundedMatchResult) -> Self {
         let permit = BoundedMatchResultPermit {
             matchResult: bounded_match_result.clone().into(),
         };
-        let payload = permit.abi_encode();
-        let executor_signature = sign_with_nonce(payload.as_slice(), chain_id, executor_signer)?;
 
-        Ok(Self {
-            permit,
-            executorSignature: executor_signature,
-        })
+        Self { permit }
     }
 }

--- a/src/darkpool/v2/types/settlement/BoundedMatchResultBundle.sol
+++ b/src/darkpool/v2/types/settlement/BoundedMatchResultBundle.sol
@@ -1,37 +1,22 @@
 /// SPDX-License-Identifier: Apache
-// solhint-disable one-contract-per-file
 pragma solidity ^0.8.24;
 
-import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
-import { SignatureWithNonce } from "darkpoolv2-types/settlement/SignatureWithNonce.sol";
 import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
 
 // --------------------------------------------
 // | Bounded Match Result Authorization Types |
 // --------------------------------------------
 
-/// @notice Bounded match result authorization payload with signature attached
+/// @notice Bounded match result authorization payload
+/// @dev The executor signature is now provided via PublicIntentAuthBundle.executorSignature
+/// and signs (relayerFeeRate, matchResult) to prevent fee malleability
 struct BoundedMatchResultBundle {
     /// @dev The bounded match result authorization permit
     BoundedMatchResultPermit permit;
-    /// @dev The signature of the bounded match result by the authorized executor
-    SignatureWithNonce executorSignature;
 }
 
 /// @notice Bounded match result authorization data
 struct BoundedMatchResultPermit {
     /// @dev The bounded match result
     BoundedMatchResult matchResult;
-}
-
-/// @title Bounded Match Result Permit Library
-/// @author Renegade Eng
-/// @notice Library for bounded match result permit operations
-library BoundedMatchResultPermitLib {
-    /// @notice Compute the hash of a `BoundedMatchResultPermit`
-    /// @param permit The `BoundedMatchResultPermit` to compute the hash of
-    /// @return The hash of the `BoundedMatchResultPermit`
-    function computeHash(BoundedMatchResultPermit memory permit) internal pure returns (bytes32) {
-        return EfficientHashLib.hash(abi.encode(permit));
-    }
 }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -14,6 +14,7 @@ import { PostMatchBalanceShare, PostMatchBalanceShareLib } from "darkpoolv2-type
 import { FeeRate } from "darkpoolv2-types/Fee.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 
 // ---------------------------
@@ -180,6 +181,24 @@ library SettlementBundleLib {
     {
         // Encode and hash the fee take with the obligation
         bytes memory encoded = abi.encode(bundleData.relayerFeeRate, obligation);
+        digest = EfficientHashLib.hash(encoded);
+    }
+
+    /// @notice Compute the digest which the executor must sign for a bounded match
+    /// @dev The digest is the hash of the relayer's fee take and the bounded match result. The executor authorizes both
+    /// these values through a signature.
+    /// @param bundleData The bundle data containing the relayer fee rate
+    /// @param matchResult The bounded match result
+    /// @return digest The digest which the executor must sign
+    function computeBoundedMatchExecutorDigest(
+        PublicIntentPublicBalanceBundle memory bundleData,
+        BoundedMatchResult calldata matchResult
+    )
+        internal
+        pure
+        returns (bytes32 digest)
+    {
+        bytes memory encoded = abi.encode(bundleData.relayerFeeRate, matchResult);
         digest = EfficientHashLib.hash(encoded);
     }
 

--- a/test/darkpool/v2/settlement/external-match/native-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-private-intents/FullMatchTests.t.sol
@@ -37,7 +37,7 @@ contract FullMatchTests is BoundedPrivateIntentTestUtils {
 
         // Create bounded match result and bundle
         BoundedMatchResult memory matchResult = createBoundedMatchResultForObligation(internalPartyObligation, price);
-        matchBundle = createBoundedMatchResultBundleWithSigners(matchResult, executor.privateKey);
+        matchBundle = createBoundedMatchResultBundle(matchResult);
 
         // Create the internal party settlement bundle
         internalPartySettlementBundle =

--- a/test/darkpool/v2/settlement/external-match/native-settled-public-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-public-intents/FullMatchTests.t.sol
@@ -30,7 +30,8 @@ contract FullMatchTests is PublicIntentExternalMatchTestUtils {
             PublicIntentPermit memory internalPartyPermit,
             SettlementObligation memory internalPartyObligation,
             SettlementObligation memory externalPartyObligation,
-            BoundedMatchResultBundle memory matchBundle
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
         )
     {
         // Create obligations for the trade
@@ -53,6 +54,11 @@ contract FullMatchTests is PublicIntentExternalMatchTestUtils {
         // Create bounded match result bundle
         matchBundle = createBoundedMatchResultBundleForObligation(internalPartyObligation, price);
 
+        // Create settlement bundle with executor signature over (feeRate, matchResult)
+        internalPartySettlementBundle = createBoundedMatchSettlementBundleWithSigners(
+            internalPartyIntent, matchBundle.permit.matchResult, internalParty.privateKey, executor.privateKey
+        );
+
         // Capitalize the parties for their obligations
         capitalizeParty(internalParty.addr, internalPartyObligation);
         capitalizeExternalParty(externalPartyObligation);
@@ -69,12 +75,9 @@ contract FullMatchTests is PublicIntentExternalMatchTestUtils {
             PublicIntentPermit memory internalPartyPermit,
             SettlementObligation memory internalPartyObligation,
             SettlementObligation memory externalPartyObligation,
-            BoundedMatchResultBundle memory matchBundle
+            BoundedMatchResultBundle memory matchBundle,
+            SettlementBundle memory internalPartySettlementBundle
         ) = _createMatchData();
-
-        SettlementBundle memory internalPartySettlementBundle = createPublicIntentSettlementBundleWithSigners(
-            internalPartyPermit.intent, internalPartyObligation, internalParty.privateKey, executor.privateKey
-        );
 
         // Choose a trade size and build the actual obligations that will be used in settlement
         (uint256 externalPartyAmountIn, uint256 externalPartyAmountOut) =

--- a/test/darkpool/v2/settlement/external-match/renegade-settled-private-intents/FullMatchTests.t.sol
+++ b/test/darkpool/v2/settlement/external-match/renegade-settled-private-intents/FullMatchTests.t.sol
@@ -45,7 +45,7 @@ contract FullMatchTests is RenegadeSettledBoundedPrivateIntentTestUtils {
 
         // Create bounded match result and bundle
         BoundedMatchResult memory matchResult = createBoundedMatchResultForObligation(internalPartyObligation, price);
-        matchBundle = createBoundedMatchResultBundleWithSigners(matchResult, executor.privateKey);
+        matchBundle = createBoundedMatchResultBundle(matchResult);
 
         // Create the internal party settlement bundle
         internalPartySettlementBundle = createRenegadeSettledBoundedBundle(isFirstFill, matchResult, oneTimeOwner);


### PR DESCRIPTION
### Purpose
This PR fixes a fee malleability vulnerability in bounded matches where the executor signature only signed the match result, not the relayer fee rate. This allowed attackers to frontrun and set `relayerFeeRate = 0`.

Changes:
- Add `computeBoundedMatchExecutorDigest()` that hashes `(feeRate, matchResult)`
- Update `validateBoundedMatchResultAuthorization` to use unified `PublicIntentAuthBundle.executorSignature`

### Testing
- [x] Unit tests pass