### PR TITLE
darkpoolv2: nullify public intents

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -245,6 +245,23 @@
             "internalType": "address"
           }
         ]
+      },
+      {
+        "name": "intentSignature",
+        "type": "tuple",
+        "internalType": "struct SignatureWithNonce",
+        "components": [
+          {
+            "name": "nonce",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
       }
     ],
     "outputs": [],
@@ -2884,6 +2901,11 @@
   {
     "type": "error",
     "name": "ProofVerificationFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PublicOrderAlreadyCancelled",
     "inputs": []
   },
   {

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -197,8 +197,14 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     }
 
     /// @inheritdoc IDarkpoolV2
-    function cancelPublicOrder(OrderCancellationAuth memory auth, PublicIntentPermit calldata permit) public {
-        StateUpdatesLib.cancelPublicOrder(_state, auth, permit);
+    function cancelPublicOrder(
+        OrderCancellationAuth memory auth,
+        PublicIntentPermit calldata permit,
+        SignatureWithNonce calldata intentSignature
+    )
+        public
+    {
+        StateUpdatesLib.cancelPublicOrder(_state, auth, permit, intentSignature);
     }
 
     /// @inheritdoc IDarkpoolV2

--- a/src/darkpool/v2/libraries/StateUpdatesLib.sol
+++ b/src/darkpool/v2/libraries/StateUpdatesLib.sol
@@ -79,33 +79,47 @@ library StateUpdatesLib {
     }
 
     /// @notice Cancel a public intent
-    /// @dev This cancels a public intent by zeroing its entry in the openPublicIntents mapping.
-    /// @dev User signs H("cancel" || intentHash) where intentHash is the hash of the permit.
+    /// @dev This cancels a public intent by spending its nullifier and zeroing its amountRemaining.
+    /// @dev The nullifier is computed as H(intentHash || intentSignature.nonce) where intentSignature
+    /// is the original signature the user created when authorizing the intent.
+    /// @dev User signs H("cancel" || intentNullifier) for the cancellation.
     /// @param state The darkpool state containing all storage references
     /// @param auth The authorization for the order cancellation
     /// @param permit The public intent permit identifying the intent to cancel
+    /// @param intentSignature The original signature used to authorize the intent (contains the nonce
+    /// needed to compute the nullifier)
     function cancelPublicOrder(
         DarkpoolState storage state,
         OrderCancellationAuth calldata auth,
-        PublicIntentPermit calldata permit
+        PublicIntentPermit calldata permit,
+        SignatureWithNonce calldata intentSignature
     )
         external
     {
-        // 1. Compute the intent hash
+        // 1. Compute the intent hash and nullifier
         bytes32 intentHash = permit.computeHash();
+        BN254.ScalarField intentNullifier =
+            BN254.ScalarField.wrap(uint256(keccak256(abi.encodePacked(intentHash, intentSignature.nonce))));
 
-        // 2. Compute the cancel digest with domain separation: H("cancel" || intentHash)
-        bytes32 cancelDigest = keccak256(abi.encodePacked(DarkpoolConstants.CANCEL_DOMAIN, intentHash));
+        // 2. Compute the cancel digest with domain separation: H("cancel" || intentNullifier)
+        bytes32 cancelDigest =
+            keccak256(abi.encodePacked(DarkpoolConstants.CANCEL_DOMAIN, BN254.ScalarField.unwrap(intentNullifier)));
 
         // 3. Verify the signature over the cancel digest by the owner (with nonce for replay protection)
         address owner = permit.intent.owner;
         bool sigValid = auth.signature.verifyPrehashedAndSpendNonce(owner, cancelDigest, state);
         if (!sigValid) revert IDarkpoolV2.InvalidOrderCancellationSignature();
 
-        // 4. Cancel the intent by setting the amount remaining to 0
+        // 4. Spend the nullifier if not already spent (pre-first-fill case)
+        // Post-first-fill: nullifier was already spent during first fill, so we skip
+        if (!state.isNullifierSpent(intentNullifier)) {
+            state.spendNullifier(intentNullifier);
+        }
+
+        // 5. Zero out the amount remaining (no-op pre-fill, actual effect post-fill)
         state.setOpenIntentAmountRemaining(intentHash, 0);
 
-        // 5. Emit cancellation event
+        // 6. Emit cancellation event
         emit IDarkpoolV2.PublicOrderCancelled(intentHash, owner);
     }
 

--- a/src/darkpool/v2/types/settlement/IntentBundle.sol
+++ b/src/darkpool/v2/types/settlement/IntentBundle.sol
@@ -2,6 +2,7 @@
 // solhint-disable one-contract-per-file
 pragma solidity ^0.8.24;
 
+import { BN254 } from "solidity-bn254/BN254.sol";
 import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { Intent } from "darkpoolv2-types/Intent.sol";
 import {
@@ -51,6 +52,15 @@ library PublicIntentPermitLib {
     /// @return The hash of the public intent permit
     function computeHash(PublicIntentPermit memory permit) internal pure returns (bytes32) {
         return EfficientHashLib.hash(abi.encode(permit));
+    }
+
+    /// @notice Compute the nullifier for a public intent
+    /// @dev The nullifier uniquely identifies an intent + signature combination: H(intentHash || nonce)
+    /// @param intentHash The hash of the public intent permit
+    /// @param nonce The nonce from the intent signature
+    /// @return The nullifier as a scalar field element
+    function computeNullifier(bytes32 intentHash, uint256 nonce) internal pure returns (BN254.ScalarField) {
+        return BN254.ScalarField.wrap(uint256(keccak256(abi.encodePacked(intentHash, nonce))));
     }
 }
 

--- a/test/darkpool/v2/state-updates/PublicIntentCancellation.t.sol
+++ b/test/darkpool/v2/state-updates/PublicIntentCancellation.t.sol
@@ -13,6 +13,7 @@ import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
 import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
 import { DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
 import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
 
 /// @title PublicIntentCancellationTest
 /// @author Renegade Eng
@@ -72,8 +73,8 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
     {
         uint256 nonce = vm.randomUint();
         bytes32 intentHash = permit.computeHash();
-        // Compute the intent nullifier: H(intentHash || intentSignature.nonce)
-        uint256 intentNullifier = uint256(keccak256(abi.encodePacked(intentHash, intentSignature.nonce)));
+        uint256 intentNullifier =
+            BN254.ScalarField.unwrap(PublicIntentPermitLib.computeNullifier(intentHash, intentSignature.nonce));
         bytes32 cancelDigest = keccak256(abi.encodePacked(DarkpoolConstants.CANCEL_DOMAIN, intentNullifier));
         bytes32 signatureHash = EfficientHashLib.hash(cancelDigest, bytes32(nonce), bytes32(block.chainid));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, signatureHash);
@@ -119,8 +120,8 @@ contract PublicIntentCancellationTest is DarkpoolV2TestUtils {
         returns (OrderCancellationAuth memory auth)
     {
         bytes32 intentHash = permit.computeHash();
-        // Compute the intent nullifier: H(intentHash || intentSignature.nonce)
-        uint256 intentNullifier = uint256(keccak256(abi.encodePacked(intentHash, intentSignature.nonce)));
+        uint256 intentNullifier =
+            BN254.ScalarField.unwrap(PublicIntentPermitLib.computeNullifier(intentHash, intentSignature.nonce));
         bytes32 cancelDigest = keccak256(abi.encodePacked(DarkpoolConstants.CANCEL_DOMAIN, intentNullifier));
         bytes32 signatureHash = EfficientHashLib.hash(cancelDigest, bytes32(cancelNonce), bytes32(block.chainid));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, signatureHash);


### PR DESCRIPTION
### Purpose

This PR adds nullifier-based cancellation for public intents. Previously, cancelling an intent before its first fill was ineffective—an executor could still hold onto the creation signature and submit a first fill, since there was no on-chain record that the intent had been cancelled.

 The solution computes a nullifier as H(intentHash || intentSignature.nonce):
 - On first fill: the nullifier is checked and spent, preventing replay
 - On cancellation: the nullifier is spent, blocking any future first fills using that authorization

 The user passes their original SignatureWithNonce to cancelPublicOrder, which extracts the nonce to compute the nullifier.

### Testing
 - [x] Unit tests pass
 - [x] Updated cancellation tests to verify nullifier is spent on cancel