### PR TITLE
Minor fixes to unit and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Please refer to our [whitepaper](https://www.renegade.fi/whitepaper.pdf) and [do
 ``` shell
 curl -L https://foundry.paradigm.xyz | bash
 ```
+Remember to run `foundryup` in a new terminal after running this command.
 
 ### Install `huffc`
 
 ```shell
 curl -L get.huff.sh | bash
 ```
+Remember to run `huffupp` in a new terminal after running this command.
 
 ### Install Cargo
 The integration tests are written in rust, and the unit test use rust reference implementations:
@@ -48,7 +50,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Clone the repo
 ``` shell
-git clone --recurse-submodules https://github.com/renegade-fi/renegade-solidity-contracts
+git clone --recurse-submodules https://github.com/renegade-fi/renegade-contracts
 ```
 
 ## Running unit tests
@@ -61,7 +63,7 @@ forge test --ffi -vv
 
 Assuming you have installed foundry and cargo, you can run the integration tests directly with:
 ```shell
-./scripts/run-integration-tests.sh --release
+./script/bin/run-integration-tests.sh --release
 ```
 This will:
 1. Start an `anvil` node

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -85,7 +85,7 @@ contract TestUtils is Test {
     function compileRustBinary(string memory manifestPath) internal virtual {
         string[] memory compileInputs = new string[](5);
         compileInputs[0] = "cargo";
-        compileInputs[1] = "+nightly-2025-02-20";
+        compileInputs[1] = "+nightly-2025-11-25";
         compileInputs[2] = "build";
         compileInputs[3] = "--quiet";
         compileInputs[4] = string.concat("--manifest-path=", manifestPath);


### PR DESCRIPTION
I ran the instructions in `README.md` and ran into issues running unit tests, such as:

```
Ran 9 tests for test/Verifier.t.sol:VerifierTest
[FAIL: vm.ffi: ffi command ["cargo", "+nightly-2025-02-20", "build", "--quiet", "--manifest-path=test/rust-reference-impls/verifier/Cargo.toml"] exited with code 101. stderr: error: rustc 1.87.0-nightly is not supported by the following packages:
  alloy@1.4.3 requires rustc 1.88
  alloy-consensus@1.4.3 requires rustc 1.88
  alloy-consensus-any@1.4.3 requires rustc 1.88
  alloy-contract@1.4.3 requires rustc 1.88
  alloy-eip2930@0.2.3 requires rustc 1.88
  alloy-eip7702@0.6.3 requires rustc 1.88
  alloy-eips@1.4.3 requires rustc 1.88
  alloy-json-rpc@1.4.3 requires rustc 1.88
  alloy-network@1.4.3 requires rustc 1.88
  alloy-network-primitives@1.4.3 requires rustc 1.88
  alloy-provider@1.4.3 requires rustc 1.88
  alloy-rpc-client@1.4.3 requires rustc 1.88
  alloy-rpc-types@1.4.3 requires rustc 1.88
  alloy-rpc-types-any@1.4.3 requires rustc 1.88
  alloy-rpc-types-eth@1.4.3 requires rustc 1.88
  alloy-serde@1.4.3 requires rustc 1.88
  alloy-signer@1.4.3 requires rustc 1.88
  alloy-signer-local@1.4.3 requires rustc 1.88
  alloy-transport@1.4.3 requires rustc 1.88
  alloy-transport-http@1.4.3 requires rustc 1.88
  alloy-tx-macros@1.4.3 requires rustc 1.88
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.87.0-nightly
```

To fix the above, this PR changes `compileRustBinary` in `test/utils/TestUtils.sol` to use the correct Rust nightly version. As of the time of writing, it is `nightly-2025-11-25` (see https://github.com/renegade-fi/renegade/blob/joey/relayer-v2/rust-toolchain).

This PR also fixes the path to the integration test script in the readme, and adds reminders to the developer to run `foundryup` and `huffup` after running their respective installation scripts. 