### PR TITLE
Specify the Rust nightly version in integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Please refer to our [whitepaper](https://www.renegade.fi/whitepaper.pdf) and [do
 ``` shell
 curl -L https://foundry.paradigm.xyz | bash
 ```
+Remember to run `foundryup` in a new terminal after running this command.
 
 ### Install `huffc`
 
 ```shell
 curl -L get.huff.sh | bash
 ```
+Remember to run `huffupp` in a new terminal after running this command.
 
 ### Install Cargo
 The integration tests are written in rust, and the unit test use rust reference implementations:
@@ -48,7 +50,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Clone the repo
 ``` shell
-git clone --recurse-submodules https://github.com/renegade-fi/renegade-solidity-contracts
+git clone --recurse-submodules https://github.com/renegade-fi/renegade-contracts
 ```
 
 ## Running unit tests
@@ -61,7 +63,7 @@ forge test --ffi -vv
 
 Assuming you have installed foundry and cargo, you can run the integration tests directly with:
 ```shell
-./scripts/run-integration-tests.sh --release
+./script/bin/run-integration-tests.sh --release
 ```
 This will:
 1. Start an `anvil` node

--- a/script/bin/run-integration-tests.sh
+++ b/script/bin/run-integration-tests.sh
@@ -97,7 +97,8 @@ if ! forge script script/$VERSION/DeployDev.s.sol \
     --ffi \
     --rpc-url http://localhost:8545 \
     --private-key $ANVIL_PKEY \
-    --broadcast; then
+    --broadcast \
+    --slow; then
     echo "Forge script failed. Cleaning up and exiting..."
     exit 1
 fi

--- a/script/bin/run-integration-tests.sh
+++ b/script/bin/run-integration-tests.sh
@@ -111,12 +111,12 @@ if [ "$SKIP_TESTS" = false ]; then
     fi
     if [ -n "$TEST_NAME" ]; then
         echo "Running specific test: $TEST_NAME"
-        if ! (cd integration/$VERSION && cargo run $CARGO_ARGS -- --test "$TEST_NAME"); then
+        if ! (cd integration/$VERSION && cargo +nightly-2025-11-25 run $CARGO_ARGS -- --test "$TEST_NAME"); then
             echo "Integration tests failed. Cleaning up and exiting..."
             exit 1
         fi
     else
-        if ! (cd integration/$VERSION && cargo run $CARGO_ARGS); then
+        if ! (cd integration/$VERSION && cargo +nightly-2025-11-25 run $CARGO_ARGS); then
             echo "Integration tests failed. Cleaning up and exiting..."
             exit 1
         fi

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -85,7 +85,7 @@ contract TestUtils is Test {
     function compileRustBinary(string memory manifestPath) internal virtual {
         string[] memory compileInputs = new string[](5);
         compileInputs[0] = "cargo";
-        compileInputs[1] = "+nightly-2025-02-20";
+        compileInputs[1] = "+nightly-2025-11-25";
         compileInputs[2] = "build";
         compileInputs[3] = "--quiet";
         compileInputs[4] = string.concat("--manifest-path=", manifestPath);


### PR DESCRIPTION
I ran into Rust compilation issues when running `script/bin/run-integration-tests.sh` with a different Rust/Cargo version than `nightly-2025-11-25`. To address this, this PR edits the integration test script to specify this nightly version.

Another way to fix this is to make set `nightly-2025-11-25` as one's default Rust version but IMHO it is better to be explicit so that future issues can be more easily caught.

I also added `--slow` to the `forge` deployment command (which ensures that each transaction is sent only when the previous one has been confirmed and is successful).

BTW, running the integration tests with either `anvil --disable-code-size-limit` separately or not separately, worked OK.