### PR TITLE
abi: auth-helpers: Add auth helpers for verifying signatures

### DIFF
--- a/abi/src/v2/auth_helpers.rs
+++ b/abi/src/v2/auth_helpers.rs
@@ -1,25 +1,20 @@
 //! Authorization helpers for the V2 ABI
 
 use alloy::{
-    primitives::{keccak256, U256},
-    signers::{local::PrivateKeySigner, Error as SignerError, SignerSync},
+    primitives::{keccak256, Address, B256, U256},
+    signers::{local::PrivateKeySigner, Error as SignerError, Signature, SignerSync},
 };
 
 use crate::v2::IDarkpoolV2::SignatureWithNonce;
 
-/// Generate a signature with a nonce for a given message
+/// Compute the digest for signing with nonce
 ///
-/// This is H(H(payload) || nonce || chainId)
-pub fn sign_with_nonce(
-    payload: &[u8],
-    chain_id: u64,
-    signer: &PrivateKeySigner,
-) -> Result<SignatureWithNonce, SignerError> {
+/// This computes H(H(payload) || nonce || chainId)
+fn compute_digest_with_nonce(payload: &[u8], nonce: U256, chain_id: u64) -> B256 {
     // Pre-hash the payload
     let payload_digest = keccak256(payload);
 
     // Hash the payload with the nonce and chain ID
-    let nonce = U256::random();
     let nonce_bytes = nonce.to_be_bytes::<{ U256::BYTES }>();
     let chain_id_bytes = U256::from(chain_id).to_be_bytes::<{ U256::BYTES }>();
     let full_payload = [
@@ -28,12 +23,167 @@ pub fn sign_with_nonce(
         chain_id_bytes.as_slice(),
     ]
     .concat();
-    let digest = keccak256(&full_payload);
+    keccak256(&full_payload)
+}
 
-    let signature = signer.sign_hash_sync(&digest)?;
-    let sig_bytes = signature.as_bytes().to_vec();
-    Ok(SignatureWithNonce {
-        nonce,
-        signature: sig_bytes.into(),
-    })
+impl SignatureWithNonce {
+    /// Generate a signature with a nonce for a given message
+    ///
+    /// This is H(H(payload) || nonce || chainId)
+    pub fn sign(
+        payload: &[u8],
+        chain_id: u64,
+        signer: &PrivateKeySigner,
+    ) -> Result<Self, SignerError> {
+        let nonce = U256::random();
+        let digest = compute_digest_with_nonce(payload, nonce, chain_id);
+
+        let signature = signer.sign_hash_sync(&digest)?;
+        let sig_bytes = signature.as_bytes().to_vec();
+        Ok(Self {
+            nonce,
+            signature: sig_bytes.into(),
+        })
+    }
+
+    /// Validate this signature against a known address
+    ///
+    /// This reconstructs the digest H(H(payload) || nonce || chainId) and recovers
+    /// the signer address from the signature, then compares it to the expected address.
+    pub fn validate(
+        &self,
+        payload: &[u8],
+        chain_id: u64,
+        expected_address: Address,
+    ) -> Result<bool, SignerError> {
+        let digest = compute_digest_with_nonce(payload, self.nonce, chain_id);
+
+        // Parse the signature bytes (65 bytes: r, s, v)
+        let sig_bytes: &[u8] = self.signature.as_ref();
+        if sig_bytes.len() != 65 {
+            return Err(SignerError::message("Invalid signature length"));
+        }
+
+        // Extract recovery ID (v) from last byte and convert to parity bool
+        // v is 27 or 28 for legacy, or 0/1 for EIP-155. We normalize to 0/1.
+        let v = sig_bytes[64];
+        let parity = match v {
+            27 | 0 => false,
+            28 | 1 => true,
+            _ => return Err(SignerError::message("Invalid recovery ID")),
+        };
+        let signature = Signature::from_bytes_and_parity(&sig_bytes[..64], parity);
+
+        // Recover the signer address
+        let recovered_address = signature.recover_address_from_prehash(&digest)?;
+        Ok(recovered_address == expected_address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+
+    #[test]
+    fn test_sign_and_validate_compatibility() {
+        // Create a test signer
+        let signer = PrivateKeySigner::random();
+        let signer_address = signer.address();
+
+        // Test payload and chain ID
+        let payload = b"test message";
+        let chain_id = 1u64;
+
+        // Sign the payload
+        let signature_with_nonce =
+            SignatureWithNonce::sign(payload, chain_id, &signer).expect("Failed to sign");
+
+        // Validate the signature
+        let is_valid = signature_with_nonce
+            .validate(payload, chain_id, signer_address)
+            .expect("Failed to validate signature");
+
+        assert!(
+            is_valid,
+            "Signature validation should succeed for correct signer"
+        );
+    }
+
+    #[test]
+    fn test_validate_signature_invalid_address() {
+        // Create a test signer
+        let signer = PrivateKeySigner::random();
+
+        // Test payload and chain ID
+        let payload = b"test message";
+        let chain_id = 1u64;
+
+        // Sign the payload
+        let signature_with_nonce =
+            SignatureWithNonce::sign(payload, chain_id, &signer).expect("Failed to sign");
+
+        // Test with wrong address
+        let wrong_address = Address::ZERO;
+        let is_valid = signature_with_nonce
+            .validate(payload, chain_id, wrong_address)
+            .expect("Failed to validate signature");
+
+        assert!(
+            !is_valid,
+            "Signature validation should fail for wrong address"
+        );
+    }
+
+    #[test]
+    fn test_validate_signature_invalid_payload() {
+        // Create a test signer
+        let signer = PrivateKeySigner::random();
+        let signer_address = signer.address();
+
+        // Test payload and chain ID
+        let payload = b"test message";
+        let chain_id = 1u64;
+
+        // Sign the payload
+        let signature_with_nonce =
+            SignatureWithNonce::sign(payload, chain_id, &signer).expect("Failed to sign");
+
+        // Test with wrong payload
+        let wrong_payload = b"wrong message";
+        let is_valid = signature_with_nonce
+            .validate(wrong_payload, chain_id, signer_address)
+            .expect("Failed to validate signature");
+
+        assert!(
+            !is_valid,
+            "Signature validation should fail for wrong payload"
+        );
+    }
+
+    #[test]
+    fn test_validate_signature_invalid_chain_id() {
+        // Create a test signer
+        let signer = PrivateKeySigner::random();
+        let signer_address = signer.address();
+
+        // Test payload and chain ID
+        let payload = b"test message";
+        let chain_id = 1u64;
+
+        // Sign the payload
+        let signature_with_nonce =
+            SignatureWithNonce::sign(payload, chain_id, &signer).expect("Failed to sign");
+
+        // Test with wrong chain ID
+        let wrong_chain_id = 2u64;
+        let is_valid = signature_with_nonce
+            .validate(payload, wrong_chain_id, signer_address)
+            .expect("Failed to validate signature");
+
+        assert!(
+            !is_valid,
+            "Signature validation should fail for wrong chain ID"
+        );
+    }
 }

--- a/abi/src/v2/relayer_types/intent.rs
+++ b/abi/src/v2/relayer_types/intent.rs
@@ -14,6 +14,7 @@ use renegade_crypto_v2::fields::scalar_to_u256;
 use {
     crate::v2::IDarkpoolV2::PublicIntentPermit,
     alloy::{
+        primitives::Address,
         signers::{local::PrivateKeySigner, Error as SignerError},
         sol_types::SolValue,
     },
@@ -101,7 +102,17 @@ impl PublicIntentPermit {
         chain_id: u64,
         signer: &PrivateKeySigner,
     ) -> Result<SignatureWithNonce, SignerError> {
-        use crate::v2::auth_helpers::sign_with_nonce;
-        sign_with_nonce(self.abi_encode().as_slice(), chain_id, signer)
+        let payload = self.abi_encode();
+        SignatureWithNonce::sign(&payload, chain_id, signer)
+    }
+
+    /// Validate a signature for a public intent permit against a known address
+    pub fn validate(
+        &self,
+        chain_id: u64,
+        signature_with_nonce: &SignatureWithNonce,
+        expected_address: Address,
+    ) -> Result<bool, SignerError> {
+        signature_with_nonce.validate(self.abi_encode().as_slice(), chain_id, expected_address)
     }
 }

--- a/abi/src/v2/relayer_types/obligation.rs
+++ b/abi/src/v2/relayer_types/obligation.rs
@@ -46,9 +46,7 @@ impl SettlementObligation {
     ) -> Result<SignatureWithNonce, SignerError> {
         use alloy::sol_types::SolValue;
 
-        use crate::v2::auth_helpers::sign_with_nonce;
-
         let payload = (relayer_fee_rate.clone(), self.clone()).abi_encode();
-        sign_with_nonce(payload.as_slice(), chain_id, signer)
+        SignatureWithNonce::sign(payload.as_slice(), chain_id, signer)
     }
 }

--- a/integration/v2/src/tests/settlement/private_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/private_intent_public_balance.rs
@@ -9,9 +9,8 @@ use rand::{Rng, thread_rng};
 use renegade_abi::v2::{
     IDarkpoolV2::{
         ObligationBundle, PrivateIntentAuthBundle, PrivateIntentAuthBundleFirstFill,
-        SettlementBundle,
+        SettlementBundle, SignatureWithNonce,
     },
-    auth_helpers::sign_with_nonce,
 };
 use renegade_account_types::MerkleAuthenticationPath;
 use renegade_circuit_types::{Commitment, PlonkLinkProof, PlonkProof, ProofLinkingHint};
@@ -377,10 +376,10 @@ pub(crate) fn build_auth_bundle_first_fill(
     validity_statement: &IntentOnlyFirstFillValidityStatement,
     validity_proof: &PlonkProof,
 ) -> Result<PrivateIntentAuthBundleFirstFill> {
-    // Pass raw commitment bytes to sign_with_nonce which will hash them.
+    // Pass raw commitment bytes to SignatureWithNonce::sign which will hash them.
     // This matches the Solidity: keccak256(keccak256(commitment) || nonce || chainId)
     let comm_u256 = scalar_to_u256(&commitment);
-    let signature = sign_with_nonce(&comm_u256.to_be_bytes_vec(), chain_id, owner)?;
+    let signature = SignatureWithNonce::sign(&comm_u256.to_be_bytes_vec(), chain_id, owner)?;
 
     Ok(PrivateIntentAuthBundleFirstFill {
         intentSignature: signature,

--- a/integration/v2/src/tests/state_updates/cancel_order.rs
+++ b/integration/v2/src/tests/state_updates/cancel_order.rs
@@ -1,9 +1,8 @@
 //! Tests for canceling an order
 
 use eyre::Result;
-use renegade_abi::v2::{
-    IDarkpoolV2::{OrderCancellationAuth, OrderCancellationProofBundle},
-    auth_helpers::sign_with_nonce,
+use renegade_abi::v2::IDarkpoolV2::{
+    OrderCancellationAuth, OrderCancellationProofBundle, SignatureWithNonce,
 };
 use renegade_account_types::MerkleAuthenticationPath;
 use renegade_circuit_types::PlonkProof;
@@ -71,7 +70,7 @@ fn create_auth_bundle(
     args: &TestArgs,
 ) -> Result<OrderCancellationAuth> {
     let nullifier = intent.compute_nullifier();
-    let signature = sign_with_nonce(&nullifier.to_bytes_be(), chain_id, &args.party0_signer())?;
+    let signature = SignatureWithNonce::sign(&nullifier.to_bytes_be(), chain_id, &args.party0_signer())?;
 
     Ok(OrderCancellationAuth { signature })
 }

--- a/integration/v2/src/tests/state_updates/fees/private_relayer_fee.rs
+++ b/integration/v2/src/tests/state_updates/fees/private_relayer_fee.rs
@@ -2,9 +2,8 @@
 
 use alloy::sol_types::SolValue;
 use eyre::Result;
-use renegade_abi::v2::{
-    IDarkpoolV2::{ElGamalCiphertext, PrivateRelayerFeePaymentProofBundle, SignatureWithNonce},
-    auth_helpers::sign_with_nonce,
+use renegade_abi::v2::IDarkpoolV2::{
+    ElGamalCiphertext, PrivateRelayerFeePaymentProofBundle, SignatureWithNonce,
 };
 use renegade_account_types::MerkleAuthenticationPath;
 use renegade_circuit_types::PlonkProof;
@@ -88,7 +87,7 @@ fn sign_ciphertext(
 ) -> Result<SignatureWithNonce> {
     let signer = &args.relayer_signer;
     let ciphertext = ElGamalCiphertext::from(cipher.clone());
-    let sig = sign_with_nonce(&ciphertext.abi_encode(), chain_id, signer)?;
+    let sig = SignatureWithNonce::sign(&ciphertext.abi_encode(), chain_id, signer)?;
     Ok(sig)
 }
 


### PR DESCRIPTION
### Purpose
This PR adds auth helpers for verifying `SignatureWithNonce` instances and uses these helpers in the public intent permit.

### Testing
- [x] All integration tests pass