### PR TITLE
Ring0 settlement integration tests

### DIFF
--- a/integration/v2/src/tests/settlement/external_match/mod.rs
+++ b/integration/v2/src/tests/settlement/external_match/mod.rs
@@ -1,13 +1,17 @@
 //! External settlement tests
 
+use crate::{
+    test_args::TestArgs,
+    tests::settlement::{BOUNDED_MAX_AMT, Intent, get_total_fee, random_price},
+    util::transactions::wait_for_tx_success,
+};
 use alloy::primitives::U256;
 use eyre::Result;
+use rand::{Rng, thread_rng};
+use renegade_circuits::test_helpers::create_bounded_match_result_with_balance;
 use renegade_crypto::fields::scalar_to_u128;
+use renegade_darkpool_types::bounded_match_result::BoundedMatchResult;
 use renegade_darkpool_types::{fee::FeeTake, settlement_obligation::SettlementObligation};
-
-use crate::{
-    test_args::TestArgs, tests::settlement::get_total_fee, util::transactions::wait_for_tx_success,
-};
 
 pub mod private_intent_private_balance;
 pub mod private_intent_public_balance;
@@ -62,4 +66,34 @@ pub async fn setup_external_match(args: &TestArgs) -> Result<()> {
     wait_for_tx_success(quote.approve(darkpool, amt)).await?;
 
     Ok(())
+}
+
+/// Create an intent and bounded match result constrained by a balance amount
+///
+/// This ensures `max_internal_party_amount_in <= balance_amount`, satisfying
+/// the circuit's capitalization constraint.
+///
+/// Party 0 (internal party) sells the base; Party 1 (external party) sells the quote
+///
+/// Returns the intent, bounded match result, and balance amount used
+pub(crate) fn create_intent_and_bounded_match_result(
+    args: &TestArgs,
+) -> Result<(Intent, BoundedMatchResult, u128)> {
+    let mut rng = thread_rng();
+    // Generate balance first, then intent amount >= balance for meaningful bounded results
+    let balance_amount = rng.gen_range(1..BOUNDED_MAX_AMT);
+    let amount_in = rng.gen_range(balance_amount..=BOUNDED_MAX_AMT);
+    let min_price = random_price();
+    let internal_party_intent = Intent {
+        in_token: args.base_addr()?,
+        out_token: args.quote_addr()?,
+        owner: args.party0_addr(),
+        min_price,
+        amount_in,
+    };
+
+    // Use create_bounded_match_result_with_balance to ensure max <= balance_amount
+    let bounded_match_result =
+        create_bounded_match_result_with_balance(&internal_party_intent, balance_amount);
+    Ok((internal_party_intent, bounded_match_result, balance_amount))
 }

--- a/integration/v2/src/tests/settlement/external_match/mod.rs
+++ b/integration/v2/src/tests/settlement/external_match/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 
 pub mod private_intent_private_balance;
 pub mod private_intent_public_balance;
+pub mod public_intent_public_balance;
 
 /// Compute the fee take for an external match
 pub async fn compute_fee_take(

--- a/integration/v2/src/tests/settlement/external_match/private_intent_private_balance.rs
+++ b/integration/v2/src/tests/settlement/external_match/private_intent_private_balance.rs
@@ -4,10 +4,12 @@ use crate::{
     test_args::TestArgs,
     tests::settlement::{
         compute_fee_take as compute_fee_take_single,
-        external_match::{compute_fee_take, setup_external_match},
+        external_match::{
+            compute_fee_take, create_intent_and_bounded_match_result, setup_external_match,
+        },
+        fund_ring2_party,
         private_intent_private_balance::{
-            build_auth_bundle_first_fill, fund_ring2_party,
-            generate_existing_output_balance_validity_proof,
+            build_auth_bundle_first_fill, generate_existing_output_balance_validity_proof,
             generate_new_output_balance_validity_proof,
             generate_output_balance_settlement_linking_proof, generate_validity_proof_first_fill,
             generate_validity_proof_subsequent_fill, generate_validity_settlement_linking_proof,
@@ -40,9 +42,7 @@ use renegade_darkpool_types::{
 };
 use test_helpers::{assert_eq_result, integration_test_async};
 
-use super::private_intent_public_balance::{
-    create_intent_and_bounded_match_result, create_obligations, pick_external_party_amt_in,
-};
+use super::private_intent_public_balance::{create_obligations, pick_external_party_amt_in};
 
 /// Test settling a Ring 2 match against an external party's intent
 ///

--- a/integration/v2/src/tests/settlement/external_match/private_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/external_match/private_intent_public_balance.rs
@@ -17,7 +17,6 @@ use alloy::{primitives::U256, signers::local::PrivateKeySigner};
 use eyre::Result;
 use rand::{Rng, thread_rng};
 use renegade_abi::v2::{IDarkpoolV2::SettlementBundle, relayer_types::u256_to_u128};
-use renegade_crypto::fields::scalar_to_u256;
 use renegade_account_types::MerkleAuthenticationPath;
 use renegade_circuit_types::{PlonkProof, ProofLinkingHint};
 use renegade_circuits::{
@@ -27,6 +26,7 @@ use renegade_circuits::{
         self, IntentOnlyBoundedSettlementCircuit, IntentOnlyBoundedSettlementStatement,
     },
 };
+use renegade_crypto::fields::scalar_to_u256;
 use renegade_darkpool_types::{
     bounded_match_result::BoundedMatchResult,
     intent::{DarkpoolStateIntent, Intent},

--- a/integration/v2/src/tests/settlement/external_match/public_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/external_match/public_intent_public_balance.rs
@@ -2,15 +2,11 @@ use crate::{
     TestArgs, U256,
     tests::settlement::{
         external_match::{
-            compute_fee_take,
-            private_intent_public_balance::{
-                create_intent_and_bounded_match_result, create_obligations,
-                pick_external_party_amt_in,
-            },
+            compute_fee_take, create_intent_and_bounded_match_result,
+            private_intent_public_balance::{create_obligations, pick_external_party_amt_in},
             setup_external_match,
         },
-        private_intent_public_balance::fund_parties,
-        settlement_relayer_fee_rate,
+        fund_parties, settlement_relayer_fee_rate,
     },
     wait_for_tx_success,
 };
@@ -22,7 +18,7 @@ use renegade_abi::v2::IDarkpoolV2::{
 };
 use test_helpers::{assert_eq_result, integration_test_async};
 
-/// Tests settling a natively-settled public intent via external match
+/// Tests settling a natively-settled public intent via external match (ring 0)
 #[allow(non_snake_case)]
 async fn test_bounded_settlement__native_settled_public_intent(args: TestArgs) -> Result<()> {
     // Setup the external party (tx_submitter) with funding and darkpool approval
@@ -47,7 +43,8 @@ async fn test_bounded_settlement__native_settled_public_intent(args: TestArgs) -
     let payload = (
         relayer_fee_rate.clone(),
         BoundedMatchResult::from(bounded_match_result.clone()),
-    ).abi_encode();
+    )
+        .abi_encode();
 
     // Sign the payload and chain ID
     let executor_signature =

--- a/integration/v2/src/tests/settlement/external_match/public_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/external_match/public_intent_public_balance.rs
@@ -1,0 +1,125 @@
+use crate::{
+    TestArgs, U256,
+    tests::settlement::{
+        external_match::{
+            compute_fee_take,
+            private_intent_public_balance::{
+                create_intent_and_bounded_match_result, create_obligations,
+                pick_external_party_amt_in,
+            },
+            setup_external_match,
+        },
+        private_intent_public_balance::fund_parties,
+        settlement_relayer_fee_rate,
+    },
+    wait_for_tx_success,
+};
+use alloy::sol_types::SolValue;
+use eyre::Result;
+use renegade_abi::v2::IDarkpoolV2::{
+    BoundedMatchResult, PublicIntentAuthBundle, PublicIntentPermit, SettlementBundle,
+    SignatureWithNonce, SignedPermitSingle,
+};
+use test_helpers::{assert_eq_result, integration_test_async};
+
+/// Tests settling a natively-settled public intent via external match
+#[allow(non_snake_case)]
+async fn test_bounded_settlement__native_settled_public_intent(args: TestArgs) -> Result<()> {
+    // Setup the external party (tx_submitter) with funding and darkpool approval
+    setup_external_match(&args).await?;
+
+    // Fund the parties, party0 (internal party) sells the base; party1 (external party) sells the quote
+    fund_parties(&args).await?;
+
+    let (intent, bounded_match_result, _balance_amt) =
+        create_intent_and_bounded_match_result(&args)?;
+
+    let relayer_fee_rate = settlement_relayer_fee_rate(&args);
+
+    let external_party_amt_in = pick_external_party_amt_in(&bounded_match_result);
+    let (internal_obligation, external_obligation) =
+        create_obligations(&bounded_match_result, external_party_amt_in);
+
+    let chain_id = args.chain_id().await?;
+    let executor_signer = &args.relayer_signer;
+
+    // ABI-encode the payload to sign
+    let payload = (
+        relayer_fee_rate.clone(),
+        BoundedMatchResult::from(bounded_match_result.clone()),
+    ).abi_encode();
+
+    // Sign the payload and chain ID
+    let executor_signature =
+        SignatureWithNonce::sign(payload.as_slice(), chain_id, &executor_signer)?;
+
+    // Generate the auth bundle
+    let permit = PublicIntentPermit {
+        intent: intent.clone().into(),
+        executor: args.relayer_signer_addr(),
+    };
+    let intent_signature = permit.sign(chain_id, &args.party0_signer())?;
+
+    let auth_bundle = PublicIntentAuthBundle {
+        intentPermit: permit,
+        intentSignature: intent_signature,
+        executorSignature: executor_signature,
+        allowancePermit: SignedPermitSingle::default(),
+    };
+
+    let settlement_bundle =
+        SettlementBundle::public_intent_settlement(auth_bundle, relayer_fee_rate);
+
+    // Get balances before fill
+    let external_party = args.tx_submitter.address();
+
+    let internal_party_base_before = args.base_balance(args.party0_addr()).await?;
+    let external_party_base_before = args.base_balance(external_party).await?;
+    let internal_party_quote_before = args.quote_balance(args.party0_addr()).await?;
+    let external_party_quote_before = args.quote_balance(external_party).await?;
+
+    let tx = args.darkpool.settleExternalMatch(
+        external_party_amt_in,
+        external_party, // recipient
+        bounded_match_result.clone().into(),
+        settlement_bundle,
+    );
+    wait_for_tx_success(tx).await?;
+
+    // Get balances after fill
+    let internal_party_base_after = args.base_balance(args.party0_addr()).await?;
+    let external_party_base_after = args.base_balance(external_party).await?;
+    let internal_party_quote_after = args.quote_balance(args.party0_addr()).await?;
+    let external_party_quote_after = args.quote_balance(external_party).await?;
+
+    // Verify balance updates
+    let (internal_party_fee_take, external_party_fee_take) =
+        compute_fee_take(&internal_obligation, &external_obligation, &args).await?;
+    let internal_party_total_fee = U256::from(internal_party_fee_take.total());
+    let external_party_total_fee = U256::from(external_party_fee_take.total());
+    assert_eq_result!(
+        internal_party_base_after,
+        // Internal party sells base: balance decreases by amount_in
+        internal_party_base_before - U256::from(internal_obligation.amount_in)
+    )?;
+    assert_eq_result!(
+        internal_party_quote_after,
+        // Internal party receives quote (amount_out) net of fees
+        internal_party_quote_before + U256::from(internal_obligation.amount_out)
+            - internal_party_total_fee
+    )?;
+    assert_eq_result!(
+        external_party_base_after,
+        // External party receives base (amount_out)
+        external_party_base_before + U256::from(external_obligation.amount_out)
+            - external_party_total_fee
+    )?;
+    assert_eq_result!(
+        external_party_quote_after,
+        // External party pays quote (amount_in)
+        external_party_quote_before - U256::from(external_obligation.amount_in)
+    )?;
+
+    Ok(())
+}
+integration_test_async!(test_bounded_settlement__native_settled_public_intent);

--- a/integration/v2/src/tests/settlement/private_fill.rs
+++ b/integration/v2/src/tests/settlement/private_fill.rs
@@ -37,8 +37,8 @@ use test_helpers::{assert_eq_result, integration_test_async};
 use crate::{
     test_args::TestArgs,
     tests::settlement::{
-        compute_fee_take,
-        private_intent_private_balance::{self, create_intents_and_obligations, fund_ring2_party},
+        compute_fee_take, create_random_intents_and_obligations,
+        private_intent_private_balance::{self, fund_ring2_party},
         settlement_relayer_fee, split_obligation,
     },
     util::{merkle::find_state_element_opening, transactions::wait_for_tx_success},
@@ -48,7 +48,8 @@ use crate::{
 #[allow(non_snake_case)]
 pub async fn test_settlement__private_fill(args: TestArgs) -> Result<()> {
     // Build the intents and obligations
-    let (intent0, intent1, obligation0, obligation1) = create_intents_and_obligations(&args)?;
+    let (intent0, intent1, obligation0, obligation1) =
+        create_random_intents_and_obligations(&args).await?;
 
     // Fund both parties
     let (mut input_bal0, input_bal0_opening) =

--- a/integration/v2/src/tests/settlement/private_fill.rs
+++ b/integration/v2/src/tests/settlement/private_fill.rs
@@ -37,8 +37,8 @@ use test_helpers::{assert_eq_result, integration_test_async};
 use crate::{
     test_args::TestArgs,
     tests::settlement::{
-        compute_fee_take, create_random_intents_and_obligations,
-        private_intent_private_balance::{self, fund_ring2_party},
+        compute_fee_take, create_random_intents_and_obligations, fund_ring2_party,
+        private_intent_private_balance::{self},
         settlement_relayer_fee, split_obligation,
     },
     util::{merkle::find_state_element_opening, transactions::wait_for_tx_success},

--- a/integration/v2/src/tests/settlement/private_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/private_intent_public_balance.rs
@@ -1,9 +1,6 @@
 //! Tests for settling a natively-settled private intent
 
-use alloy::{
-    primitives::{Address, U160, U256, aliases::U48},
-    signers::local::PrivateKeySigner,
-};
+use alloy::{primitives::U256, signers::local::PrivateKeySigner};
 use eyre::Result;
 use renegade_abi::v2::IDarkpoolV2::{
     ObligationBundle, PrivateIntentAuthBundle, PrivateIntentAuthBundleFirstFill, SettlementBundle,
@@ -38,13 +35,10 @@ use test_helpers::{assert_eq_result, integration_test_async};
 use crate::{
     test_args::TestArgs,
     tests::settlement::{
-        compute_fee_take, create_random_intents_and_obligations, settlement_relayer_fee,
-        split_obligation,
+        compute_fee_take, create_random_intents_and_obligations, fund_parties,
+        settlement_relayer_fee, split_obligation,
     },
-    util::{
-        merkle::find_state_element_opening,
-        transactions::{send_tx, wait_for_tx_success},
-    },
+    util::{merkle::find_state_element_opening, transactions::wait_for_tx_success},
 };
 
 /// Tests settling a natively-settled private intent
@@ -172,46 +166,6 @@ integration_test_async!(test_settlement__native_settled_private_intent);
 // -----------
 // | Helpers |
 // -----------
-
-// --- Funding --- //
-
-/// Fund the two parties with the base and quote tokens
-///
-/// Test setup will fund the parties with the tokens and approve the permit2 contract to spend the tokens.
-pub(crate) async fn fund_parties(args: &TestArgs) -> Result<()> {
-    let base = args.base_addr()?;
-    let quote = args.quote_addr()?;
-    approve_balance(base, &args.party0_signer(), args).await?;
-    approve_balance(quote, &args.party1_signer(), args).await?;
-    Ok(())
-}
-
-/// Approve a balance to be spent by the darkpool via the permit2 contract
-pub(crate) async fn approve_balance(
-    token: Address,
-    signer: &PrivateKeySigner,
-    args: &TestArgs,
-) -> Result<()> {
-    // Approve Permit2 to spend the ERC20 tokens
-    let erc20 = args.erc20_from_addr_with_signer(token, signer.clone())?;
-    let permit2_addr = args.permit2_addr()?;
-    send_tx(erc20.approve(permit2_addr, U256::MAX)).await?;
-
-    // Approve the darkpool to spend the tokens via Permit2
-    let amt = U160::MAX;
-    let permit2 = args.permit2_with_signer(signer)?;
-    let darkpool = args.darkpool_addr();
-    let expiration = U48::MAX;
-    send_tx(permit2.approve(token, darkpool, amt, expiration)).await?;
-
-    Ok(())
-}
-
-// --- Intents --- //
-
-/// Create two matching intents and obligations
-///
-/// Party 0 sells the base; party1 sells the quote
 
 // --- Prover --- //
 

--- a/integration/v2/src/tests/settlement/public_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/public_intent_public_balance.rs
@@ -2,10 +2,10 @@
 use crate::{
     U256,
     test_args::TestArgs,
-    tests::settlement::private_intent_private_balance::{
-        build_settlement_bundle_ring0, fund_ring0_party,
+    tests::settlement::{
+        compute_fee_take, create_random_intents_and_obligations, fund_ring0_party,
+        private_intent_private_balance::build_settlement_bundle_ring0,
     },
-    tests::settlement::{compute_fee_take, create_random_intents_and_obligations},
     wait_for_tx_success,
 };
 use eyre::Result;

--- a/integration/v2/src/tests/settlement/public_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/public_intent_public_balance.rs
@@ -1,0 +1,83 @@
+//! Tests for settling a public-public (ring0) fill
+use crate::{
+    U256,
+    test_args::TestArgs,
+    tests::settlement::private_intent_private_balance::{
+        build_settlement_bundle_ring0, fund_ring0_party,
+    },
+    tests::settlement::{compute_fee_take, create_random_intents_and_obligations},
+    wait_for_tx_success,
+};
+use eyre::Result;
+use renegade_abi::v2::IDarkpoolV2::ObligationBundle;
+use test_helpers::{assert_eq_result, integration_test_async};
+
+#[allow(non_snake_case)]
+pub async fn test_settlement__public_public_fill(args: TestArgs) -> Result<()> {
+    // Build the intents and obligations
+    let (intent0, intent1, obligation0, obligation1) =
+        create_random_intents_and_obligations(&args).await?;
+
+    let signer0 = args.party0_signer();
+    let signer1 = args.party1_signer();
+
+    // Fund both parties
+    fund_ring0_party(&signer0, &obligation0, &args).await?;
+    fund_ring0_party(&args.party1_signer(), &obligation1, &args).await?;
+
+    // Build obligation bundle
+    let obligation_bundle =
+        ObligationBundle::new_public(obligation0.clone().into(), obligation1.clone().into());
+
+    // Build settlement bundles
+    let settlement_bundle0 =
+        build_settlement_bundle_ring0(&signer0, &intent0, &obligation0, &args).await?;
+    let settlement_bundle1 =
+        build_settlement_bundle_ring0(&signer1, &intent1, &obligation1, &args).await?;
+
+    // Get balances before the trade
+    let party0_base_before = args.base_balance(args.party0_addr()).await?;
+    let party1_base_before = args.base_balance(args.party1_addr()).await?;
+    let party0_quote_before = args.quote_balance(args.party0_addr()).await?;
+    let party1_quote_before = args.quote_balance(args.party1_addr()).await?;
+
+    // Execute the transaction
+    let tx = args
+        .darkpool
+        .settleMatch(obligation_bundle, settlement_bundle0, settlement_bundle1);
+    let tx_receipt = wait_for_tx_success(tx).await.unwrap();
+
+    // Print the gas used
+    println!("\nGas used for a ring0 trade: {}", tx_receipt.gas_used);
+
+    // Get balances after the trade
+    let party0_base_after = args.base_balance(args.party0_addr()).await?;
+    let party1_base_after = args.base_balance(args.party1_addr()).await?;
+    let party0_quote_after = args.quote_balance(args.party0_addr()).await?;
+    let party1_quote_after = args.quote_balance(args.party1_addr()).await?;
+
+    // Verify balance updates
+    let fee_take0 = compute_fee_take(&obligation0, &args).await?;
+    let fee_take1 = compute_fee_take(&obligation1, &args).await?;
+    let total_fee0 = U256::from(fee_take0.total());
+    let total_fee1 = U256::from(fee_take1.total());
+    assert_eq_result!(
+        party0_base_after,
+        party0_base_before - U256::from(obligation0.amount_in)
+    )?;
+    assert_eq_result!(
+        party0_quote_after,
+        party0_quote_before + U256::from(obligation0.amount_out) - total_fee0
+    )?;
+    assert_eq_result!(
+        party1_base_after,
+        party1_base_before + U256::from(obligation1.amount_out) - total_fee1
+    )?;
+    assert_eq_result!(
+        party1_quote_after,
+        party1_quote_before - U256::from(obligation1.amount_in)
+    )?;
+
+    Ok(())
+}
+integration_test_async!(test_settlement__public_public_fill);

--- a/integration/v2/src/tests/state_updates/cancel_order.rs
+++ b/integration/v2/src/tests/state_updates/cancel_order.rs
@@ -70,7 +70,8 @@ fn create_auth_bundle(
     args: &TestArgs,
 ) -> Result<OrderCancellationAuth> {
     let nullifier = intent.compute_nullifier();
-    let signature = SignatureWithNonce::sign(&nullifier.to_bytes_be(), chain_id, &args.party0_signer())?;
+    let signature =
+        SignatureWithNonce::sign(&nullifier.to_bytes_be(), chain_id, &args.party0_signer())?;
 
     Ok(OrderCancellationAuth { signature })
 }

--- a/integration/v2/src/tests/state_updates/mod.rs
+++ b/integration/v2/src/tests/state_updates/mod.rs
@@ -7,8 +7,9 @@ use renegade_darkpool_types::{balance::DarkpoolStateBalance, intent::DarkpoolSta
 use crate::{
     test_args::TestArgs,
     tests::settlement::{
+        create_random_intents_and_obligations,
         private_fill::{self, SubsequentFillStateElements},
-        private_intent_private_balance::{self, fund_ring2_party},
+        private_intent_private_balance::fund_ring2_party,
         split_obligation,
     },
     util::{merkle::find_state_element_opening, transactions::wait_for_tx_success},
@@ -47,7 +48,7 @@ pub(crate) async fn setup_private_intent_private_balance(
 ) -> Result<PrivateIntentPrivateBalanceElements> {
     // Build intents and obligations for a trade
     let (intent0, intent1, obligation0, obligation1) =
-        private_intent_private_balance::create_intents_and_obligations(args)?;
+        create_random_intents_and_obligations(args).await?;
 
     // Split the obligations
     // We want to return a set of state elements that are not completely filled or exhausted, so we only execute a first fill

--- a/integration/v2/src/tests/state_updates/mod.rs
+++ b/integration/v2/src/tests/state_updates/mod.rs
@@ -7,9 +7,8 @@ use renegade_darkpool_types::{balance::DarkpoolStateBalance, intent::DarkpoolSta
 use crate::{
     test_args::TestArgs,
     tests::settlement::{
-        create_random_intents_and_obligations,
+        create_random_intents_and_obligations, fund_ring2_party,
         private_fill::{self, SubsequentFillStateElements},
-        private_intent_private_balance::fund_ring2_party,
         split_obligation,
     },
     util::{merkle::find_state_element_opening, transactions::wait_for_tx_success},

--- a/integration/v2/src/util/deposit.rs
+++ b/integration/v2/src/util/deposit.rs
@@ -3,8 +3,8 @@
 use alloy::{primitives::Address, signers::local::PrivateKeySigner};
 use eyre::Result;
 use renegade_abi::v2::{
-    transfer_auth::deposit::create_deposit_permit,
     IDarkpoolV2::{Deposit, DepositAuth},
+    transfer_auth::deposit::create_deposit_permit,
 };
 use renegade_constants::Scalar;
 use renegade_crypto::fields::scalar_to_u256;


### PR DESCRIPTION
I added two new integration tests for ring 0 settlement:

| Test |  Function |  Gas cost  |
|-|-|-|
| External-internal settlement | `test_bounded_settlement__native_settled_public_intent` | 454712 |
| Internal-internal settlement | `test_settlement__public_public_fill` | 557928 |

I also refactored some integration test helper functions (e.g. `fund_parties()` is used by a few tests so I've moved it to `integration/v2/src/tests/settlement/mod.rs`).

## Testing

```bash

./script/bin/run-integration-tests.sh --release --test test_settlement__public_public_fill --disable-code-size-limit && \
./script/bin/run-integration-tests.sh --release --test test_bounded_settlement__native_settled_public_intent --disable-code-size-limit 
```