### PR TITLE
darkpoolv2: settlement: Add public intent lifecycle events

### DIFF
--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -146,10 +146,27 @@ interface IDarkpoolV2 {
     /// @notice Emitted when a new recovery ID is registered on-chain
     /// @param recoveryId The recovery ID that was registered
     event RecoveryIdRegistered(BN254.ScalarField indexed recoveryId);
-    /// @notice Emitted when a public order is cancelled
-    /// @param orderHash The hash of the cancelled order
-    /// @param owner The owner who cancelled the order
-    event PublicOrderCancelled(bytes32 indexed orderHash, address indexed owner);
+    /// @notice Emitted on the first fill of a public intent, signaling its creation
+    /// @param intentHash The hash identifying this intent (key in openPublicIntents mapping)
+    event PublicIntentCreated(bytes32 indexed intentHash);
+
+    /// @notice Emitted on every fill of a public intent (partial or full)
+    /// @param intentHash The hash identifying this intent (key in openPublicIntents mapping)
+    /// @param owner The EOA address that owns this intent
+    /// @param fillAmount The amount filled in this settlement
+    /// @param amountRemaining The remaining amount after this fill (0 = fully filled)
+    event PublicIntentUpdated(
+        bytes32 indexed intentHash,
+        address indexed owner,
+        uint256 fillAmount,
+        uint256 amountRemaining
+    );
+
+    /// @notice Emitted when a public intent is explicitly cancelled
+    /// @param intentHash The hash identifying this intent
+    /// @param owner The EOA address that owns this intent
+    /// @param amountRemaining The amount that was remaining (unfilled) at cancellation
+    event PublicIntentCancelled(bytes32 indexed intentHash, address indexed owner, uint256 amountRemaining);
     /// @notice Emitted when a nonce is revoked
     /// @param revokedNonce The nonce that was revoked
     /// @param owner The owner who revoked the nonce

--- a/src/darkpool/v2/libraries/DarkpoolState.sol
+++ b/src/darkpool/v2/libraries/DarkpoolState.sol
@@ -186,14 +186,19 @@ library DarkpoolStateLib {
     /// @param state The darkpool state
     /// @param intentHash The hash of the intent
     /// @param amount The amount to decrement the amount remaining by
+    /// @return previousAmount The amount remaining before the decrement
+    /// @return newAmount The amount remaining after the decrement
     function decrementOpenIntentAmountRemaining(
         DarkpoolState storage state,
         bytes32 intentHash,
         uint256 amount
     )
         internal
+        returns (uint256 previousAmount, uint256 newAmount)
     {
-        state.openPublicIntents[intentHash] -= amount;
+        previousAmount = state.openPublicIntents[intentHash];
+        newAmount = previousAmount - amount;
+        state.openPublicIntents[intentHash] = newAmount;
     }
 
     /// @notice Spend a signature nonce

--- a/src/darkpool/v2/libraries/StateUpdatesLib.sol
+++ b/src/darkpool/v2/libraries/StateUpdatesLib.sol
@@ -113,11 +113,14 @@ library StateUpdatesLib {
             state.spendNullifier(intentNullifier);
         }
 
-        // 5. Zero out the amount remaining (no-op pre-fill, actual effect post-fill)
+        // 5. Get the amount remaining before zeroing (for event emission)
+        uint256 amountRemaining = state.getOpenIntentAmountRemaining(intentHash);
+
+        // 6. Zero out the amount remaining (no-op pre-fill, actual effect post-fill)
         state.setOpenIntentAmountRemaining(intentHash, 0);
 
-        // 6. Emit cancellation event
-        emit IDarkpoolV2.PublicOrderCancelled(intentHash, owner);
+        // 7. Emit cancellation event with amount that was remaining
+        emit IDarkpoolV2.PublicIntentCancelled(intentHash, owner, amountRemaining);
     }
 
     /// @notice Revoke a nonce to invalidate previously signed bundles

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -328,8 +328,17 @@ library NativeSettledPublicIntentLib {
         settlementContext.pushWithdrawal(relayerWithdrawal);
         settlementContext.pushWithdrawal(protocolWithdrawal);
 
-        // Update the amount remaining on the intent
-        state.decrementOpenIntentAmountRemaining(intentHash, obligation.amountIn);
+        // Update the amount remaining on the intent and emit events
+        (uint256 previousAmount, uint256 newAmount) =
+            state.decrementOpenIntentAmountRemaining(intentHash, obligation.amountIn);
+
+        // Emit PublicIntentCreated on first fill (when previous amount equals initial intent amount)
+        if (previousAmount == intent.amountIn) {
+            emit IDarkpoolV2.PublicIntentCreated(intentHash);
+        }
+
+        // Emit PublicIntentUpdated on every fill
+        emit IDarkpoolV2.PublicIntentUpdated(intentHash, intent.owner, obligation.amountIn, newAmount);
     }
 
     /// @notice Compute the fee takes for the match


### PR DESCRIPTION
### Purpose
This PR adds three new events for tracking public intent lifecycle: `PublicIntentCreated` (emitted on first fill), `PublicIntentUpdated` (emitted on every fill with fillAmount and amountRemaining), and `PublicIntentCancelled` (replaces `PublicOrderCancelled`, includes amountRemaining). These events enable external systems (relayers, indexers) to track public intent fills without polling contract state.

### Testing
- [x] All tests pass