### PR TITLE
abi: Add public intent lifecycle events

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -2617,10 +2617,10 @@
   },
   {
     "type": "event",
-    "name": "PublicOrderCancelled",
+    "name": "PublicIntentCancelled",
     "inputs": [
       {
-        "name": "orderHash",
+        "name": "intentHash",
         "type": "bytes32",
         "indexed": true,
         "internalType": "bytes32"
@@ -2630,6 +2630,56 @@
         "type": "address",
         "indexed": true,
         "internalType": "address"
+      },
+      {
+        "name": "amountRemaining",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PublicIntentCreated",
+    "inputs": [
+      {
+        "name": "intentHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PublicIntentUpdated",
+    "inputs": [
+      {
+        "name": "intentHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "fillAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountRemaining",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
       }
     ],
     "anonymous": false


### PR DESCRIPTION
### Purpose
This PR updates the V1 and V2 ABIs with public intent lifecycle events. Adds `PublicIntentCreated`, `PublicIntentUpdated`, and renames `PublicOrderCancelled` to `PublicIntentCancelled` with additional fields.

### Testing
- [x] All tests pass