### PR TITLE
darkpoolv2: settlement: Split up settlement contracts

### DIFF
--- a/script/v2/Deploy.s.sol
+++ b/script/v2/Deploy.s.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @notice This script must be run with the --ffi flag to enable external commands.
+ * Example: forge script script/v2/Deploy.s.sol --rpc-url http://localhost:8545 --sig "run(address,uint256,uint256,uint256,address,address,address)"
+ * <owner> <protocolFeeKeyX> <protocolFeeKeyY> <protocolFeeRate> <protocolFeeAddr> <permit2> <weth> --ffi --broadcast --sender <sender> --unlocked
+ */
+import { Script } from "forge-std/Script.sol";
+
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { BabyJubJubPoint, EncryptionKey } from "renegade-lib/Ciphertext.sol";
+import { IPermit2 } from "permit2-lib/interfaces/IPermit2.sol";
+import { IWETH9 } from "renegade-lib/interfaces/IWETH9.sol";
+import { DeployV2Utils } from "./DeployV2Utils.sol";
+
+/// @title DeployScript
+/// @author Renegade Eng
+/// @notice Deployment script for the Renegade darkpool v2
+contract DeployScript is Script, DeployV2Utils {
+    /// @notice Deploy the darkpool with the given parameters
+    /// @param owner The owner of the darkpool
+    /// @param protocolFeeKeyX The X coordinate of the protocol fee encryption key
+    /// @param protocolFeeKeyY The Y coordinate of the protocol fee encryption key
+    /// @param protocolFeeRate The protocol fee rate
+    /// @param protocolFeeAddr The address to receive protocol fees
+    /// @param permit2Address The address of the Permit2 contract
+    /// @param wethAddress The address of the WETH9 contract
+    function run(
+        address owner,
+        uint256 protocolFeeKeyX,
+        uint256 protocolFeeKeyY,
+        uint256 protocolFeeRate,
+        address protocolFeeAddr,
+        address permit2Address,
+        address wethAddress
+    )
+        public
+    {
+        vm.startBroadcast();
+        EncryptionKey memory protocolFeeKey = EncryptionKey({
+            point: BabyJubJubPoint({ x: BN254.ScalarField.wrap(protocolFeeKeyX), y: BN254.ScalarField.wrap(protocolFeeKeyY) })
+        });
+
+        deployCore(
+            owner, protocolFeeRate, protocolFeeAddr, protocolFeeKey, IPermit2(permit2Address), IWETH9(wethAddress), vm
+        );
+        vm.stopBroadcast();
+    }
+}

--- a/src/darkpool/v2/types/VerificationList.sol
+++ b/src/darkpool/v2/types/VerificationList.sol
@@ -70,6 +70,39 @@ library VerificationListLib {
         list.vks[list.nextIndex] = vk;
         ++list.nextIndex;
     }
+
+    /// @notice Merge two verification lists into a new list
+    /// @dev Creates a new list with capacity for both inputs and copies all elements
+    /// @param a The first list to merge
+    /// @param b The second list to merge
+    /// @return result A new list containing all elements from both inputs
+    function merge(
+        VerificationList memory a,
+        VerificationList memory b
+    )
+        internal
+        pure
+        returns (VerificationList memory result)
+    {
+        uint256 totalLength = a.nextIndex + b.nextIndex;
+        result = newList(totalLength);
+
+        // Copy elements from list a
+        for (uint256 i = 0; i < a.nextIndex; ++i) {
+            result.proofs[i] = a.proofs[i];
+            result.publicInputs[i] = a.publicInputs[i];
+            result.vks[i] = a.vks[i];
+        }
+
+        // Copy elements from list b
+        for (uint256 i = 0; i < b.nextIndex; ++i) {
+            result.proofs[a.nextIndex + i] = b.proofs[i];
+            result.publicInputs[a.nextIndex + i] = b.publicInputs[i];
+            result.vks[a.nextIndex + i] = b.vks[i];
+        }
+
+        result.nextIndex = totalLength;
+    }
 }
 
 /// @title Proof Linking List
@@ -116,5 +149,34 @@ library ProofLinkingListLib {
         }
         list.instances[list.nextIndex] = instance;
         ++list.nextIndex;
+    }
+
+    /// @notice Merge two proof linking lists into a new list
+    /// @dev Creates a new list with capacity for both inputs and copies all elements
+    /// @param a The first list to merge
+    /// @param b The second list to merge
+    /// @return result A new list containing all elements from both inputs
+    function merge(
+        ProofLinkingList memory a,
+        ProofLinkingList memory b
+    )
+        internal
+        pure
+        returns (ProofLinkingList memory result)
+    {
+        uint256 totalLength = a.nextIndex + b.nextIndex;
+        result = newList(totalLength);
+
+        // Copy elements from list a
+        for (uint256 i = 0; i < a.nextIndex; ++i) {
+            result.instances[i] = a.instances[i];
+        }
+
+        // Copy elements from list b
+        for (uint256 i = 0; i < b.nextIndex; ++i) {
+            result.instances[a.nextIndex + i] = b.instances[i];
+        }
+
+        result.nextIndex = totalLength;
     }
 }

--- a/src/darkpool/v2/types/settlement/SettlementContext.sol
+++ b/src/darkpool/v2/types/settlement/SettlementContext.sol
@@ -130,4 +130,26 @@ library SettlementContextLib {
     {
         context.proofLinkingArguments.push(proofLinkingArgument);
     }
+
+    // --- Merge --- //
+
+    /// @notice Merge two settlement contexts into a new context
+    /// @dev Creates a new context with combined capacity and copies all elements from both inputs
+    /// @param a The first context to merge
+    /// @param b The second context to merge
+    /// @return result A new context containing all elements from both inputs
+    function merge(
+        SettlementContext memory a,
+        SettlementContext memory b
+    )
+        internal
+        pure
+        returns (SettlementContext memory result)
+    {
+        result = SettlementContext({
+            transfers: SettlementTransfersLib.merge(a.transfers, b.transfers),
+            verifications: VerificationListLib.merge(a.verifications, b.verifications),
+            proofLinkingArguments: ProofLinkingListLib.merge(a.proofLinkingArguments, b.proofLinkingArguments)
+        });
+    }
 }

--- a/src/darkpool/v2/types/transfers/TransfersList.sol
+++ b/src/darkpool/v2/types/transfers/TransfersList.sol
@@ -54,6 +54,35 @@ library SettlementTransfersListLib {
         list.transfers[list.nextIndex] = transfer;
         ++list.nextIndex;
     }
+
+    /// @notice Merge two transfer lists into a new list
+    /// @dev Creates a new list with capacity for both inputs and copies all elements
+    /// @param a The first list to merge
+    /// @param b The second list to merge
+    /// @return result A new list containing all elements from both inputs
+    function merge(
+        SettlementTransfersList memory a,
+        SettlementTransfersList memory b
+    )
+        internal
+        pure
+        returns (SettlementTransfersList memory result)
+    {
+        uint256 totalLength = a.nextIndex + b.nextIndex;
+        result = newList(totalLength);
+
+        // Copy elements from list a
+        for (uint256 i = 0; i < a.nextIndex; ++i) {
+            result.transfers[i] = a.transfers[i];
+        }
+
+        // Copy elements from list b
+        for (uint256 i = 0; i < b.nextIndex; ++i) {
+            result.transfers[a.nextIndex + i] = b.transfers[i];
+        }
+
+        result.nextIndex = totalLength;
+    }
 }
 
 /// @notice A list of deposits and withdrawals to settle after a match
@@ -107,5 +136,24 @@ library SettlementTransfersLib {
     /// @param withdrawal The withdrawal to push
     function pushWithdrawal(SettlementTransfers memory transfers, SimpleTransfer memory withdrawal) internal pure {
         SettlementTransfersListLib.push(transfers.withdrawals, withdrawal);
+    }
+
+    /// @notice Merge two settlement transfers into a new one
+    /// @dev Creates a new SettlementTransfers with combined capacity and copies all elements from both inputs
+    /// @param a The first transfers to merge
+    /// @param b The second transfers to merge
+    /// @return result A new SettlementTransfers containing all elements from both inputs
+    function merge(
+        SettlementTransfers memory a,
+        SettlementTransfers memory b
+    )
+        internal
+        pure
+        returns (SettlementTransfers memory result)
+    {
+        result = SettlementTransfers({
+            deposits: SettlementTransfersListLib.merge(a.deposits, b.deposits),
+            withdrawals: SettlementTransfersListLib.merge(a.withdrawals, b.withdrawals)
+        });
     }
 }

--- a/test/darkpool/v2/settlement/SettlementContextMerge.t.sol
+++ b/test/darkpool/v2/settlement/SettlementContextMerge.t.sol
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import { Test } from "forge-std/Test.sol";
+import { BN254 } from "solidity-bn254/BN254.sol";
+import { BN254Helpers } from "renegade-lib/verifier/BN254Helpers.sol";
+import {
+    PlonkProof,
+    VerificationKey,
+    LinkingProof,
+    ProofLinkingInstance,
+    ProofLinkingVK
+} from "renegade-lib/verifier/Types.sol";
+import { SettlementContext, SettlementContextLib } from "darkpoolv2-types/settlement/SettlementContext.sol";
+import { SimpleTransfer, SimpleTransferType } from "darkpoolv2-types/transfers/SimpleTransfer.sol";
+import { SignedPermitSingle } from "darkpoolv2-types/transfers/SignedPermitSingle.sol";
+import { IAllowanceTransfer } from "permit2-lib/interfaces/IAllowanceTransfer.sol";
+import {
+    SettlementTransfers,
+    SettlementTransfersLib,
+    SettlementTransfersList,
+    SettlementTransfersListLib
+} from "darkpoolv2-types/transfers/TransfersList.sol";
+import {
+    VerificationList,
+    VerificationListLib,
+    ProofLinkingList,
+    ProofLinkingListLib
+} from "darkpoolv2-types/VerificationList.sol";
+
+/// @title SettlementContextMergeTest
+/// @notice Tests for the SettlementContext merge functionality
+contract SettlementContextMergeTest is Test {
+    using SettlementContextLib for SettlementContext;
+    using SettlementTransfersLib for SettlementTransfers;
+    using SettlementTransfersListLib for SettlementTransfersList;
+    using VerificationListLib for VerificationList;
+    using ProofLinkingListLib for ProofLinkingList;
+
+    // --- Helpers --- //
+
+    /// @notice Create a dummy simple transfer for testing
+    /// @param account The account address
+    /// @param mint The token address
+    /// @param amount The amount
+    function createDummyTransfer(
+        address account,
+        address mint,
+        uint256 amount
+    )
+        internal
+        pure
+        returns (SimpleTransfer memory)
+    {
+        return SimpleTransfer({
+            account: account,
+            mint: mint,
+            amount: amount,
+            transferType: SimpleTransferType.Withdrawal,
+            allowancePermit: _emptyPermit()
+        });
+    }
+
+    /// @notice Create an empty permit for testing
+    function _emptyPermit() internal pure returns (SignedPermitSingle memory) {
+        return SignedPermitSingle({
+            permitSingle: IAllowanceTransfer.PermitSingle({
+                details: IAllowanceTransfer.PermitDetails({ token: address(0), amount: 0, expiration: 0, nonce: 0 }),
+                spender: address(0),
+                sigDeadline: 0
+            }),
+            signature: ""
+        });
+    }
+
+    /// @notice Create a dummy PlonkProof for testing
+    function createDummyProof() internal pure returns (PlonkProof memory) {
+        BN254.G1Point memory pointZero = BN254.P1();
+
+        BN254.G1Point[5] memory wireComms;
+        BN254.G1Point[5] memory quotientComms;
+        BN254.ScalarField[5] memory wireEvals;
+        BN254.ScalarField[4] memory sigmaEvals;
+
+        for (uint256 i = 0; i < 5; i++) {
+            wireComms[i] = pointZero;
+            quotientComms[i] = pointZero;
+            wireEvals[i] = BN254Helpers.ZERO;
+            if (i < 4) {
+                sigmaEvals[i] = BN254Helpers.ZERO;
+            }
+        }
+
+        return PlonkProof({
+            wireComms: wireComms,
+            zComm: pointZero,
+            quotientComms: quotientComms,
+            wZeta: pointZero,
+            wZetaOmega: pointZero,
+            wireEvals: wireEvals,
+            sigmaEvals: sigmaEvals,
+            zBar: BN254Helpers.ZERO
+        });
+    }
+
+    /// @notice Create a dummy VerificationKey for testing
+    function createDummyVk() internal pure returns (VerificationKey memory) {
+        BN254.G1Point memory g1Zero = BN254.P1();
+        BN254.G2Point memory g2Zero = BN254.P2();
+
+        // NUM_WIRE_TYPES = 5, NUM_SELECTORS = 13
+        BN254.ScalarField[5] memory k;
+        BN254.G1Point[13] memory qComms;
+        BN254.G1Point[5] memory sigmaComms;
+
+        for (uint256 i = 0; i < 5; i++) {
+            k[i] = BN254Helpers.ZERO;
+            sigmaComms[i] = g1Zero;
+        }
+        for (uint256 i = 0; i < 13; i++) {
+            qComms[i] = g1Zero;
+        }
+
+        return VerificationKey({
+            n: 1024,
+            l: 10,
+            k: k,
+            qComms: qComms,
+            sigmaComms: sigmaComms,
+            g: g1Zero,
+            h: g2Zero,
+            xH: g2Zero
+        });
+    }
+
+    /// @notice Create a dummy LinkingProof for testing
+    function createDummyLinkingProof() internal pure returns (LinkingProof memory) {
+        BN254.G1Point memory pointZero = BN254.P1();
+        return LinkingProof({ linkingQuotientPolyComm: pointZero, linkingPolyOpening: pointZero });
+    }
+
+    /// @notice Create a dummy ProofLinkingInstance for testing
+    function createDummyProofLinkingInstance() internal pure returns (ProofLinkingInstance memory) {
+        BN254.G1Point memory pointZero = BN254.P1();
+        return ProofLinkingInstance({
+            wireComm0: pointZero,
+            wireComm1: pointZero,
+            proof: createDummyLinkingProof(),
+            vk: ProofLinkingVK({ linkGroupGenerator: BN254Helpers.ZERO, linkGroupOffset: 0, linkGroupSize: 0 })
+        });
+    }
+
+    // --- Basic Merge Tests --- //
+
+    /// @notice Test merging two empty contexts
+    function test_mergeEmptyContexts() public pure {
+        SettlementContext memory a = SettlementContextLib.newContext(0, 0, 0, 0);
+        SettlementContext memory b = SettlementContextLib.newContext(0, 0, 0, 0);
+
+        SettlementContext memory merged = SettlementContextLib.merge(a, b);
+
+        assertEq(merged.numDeposits(), 0);
+        assertEq(merged.numWithdrawals(), 0);
+        assertEq(merged.numProofs(), 0);
+        assertEq(merged.numProofLinkingArguments(), 0);
+    }
+
+    /// @notice Test merging contexts with deposits and withdrawals
+    function test_mergeTransfers() public {
+        // Create context a with 2 deposits
+        SettlementContext memory a = SettlementContextLib.newContext(2, 0, 0, 0);
+        SimpleTransfer memory deposit1 = createDummyTransfer(address(1), address(100), 1000);
+        SimpleTransfer memory deposit2 = createDummyTransfer(address(2), address(200), 2000);
+        a.pushDeposit(deposit1);
+        a.pushDeposit(deposit2);
+
+        // Create context b with 1 deposit and 2 withdrawals
+        SettlementContext memory b = SettlementContextLib.newContext(1, 2, 0, 0);
+        SimpleTransfer memory deposit3 = createDummyTransfer(address(3), address(300), 3000);
+        SimpleTransfer memory withdrawal1 = createDummyTransfer(address(4), address(400), 4000);
+        SimpleTransfer memory withdrawal2 = createDummyTransfer(address(5), address(500), 5000);
+        b.pushDeposit(deposit3);
+        b.pushWithdrawal(withdrawal1);
+        b.pushWithdrawal(withdrawal2);
+
+        // Merge and verify
+        SettlementContext memory merged = SettlementContextLib.merge(a, b);
+
+        assertEq(merged.numDeposits(), 3);
+        assertEq(merged.numWithdrawals(), 2);
+
+        // Verify deposit order (a's deposits first, then b's)
+        assertEq(merged.transfers.deposits.transfers[0].account, address(1));
+        assertEq(merged.transfers.deposits.transfers[1].account, address(2));
+        assertEq(merged.transfers.deposits.transfers[2].account, address(3));
+
+        // Verify withdrawal order
+        assertEq(merged.transfers.withdrawals.transfers[0].account, address(4));
+        assertEq(merged.transfers.withdrawals.transfers[1].account, address(5));
+    }
+
+    /// @notice Test that merge does not modify the original contexts
+    function test_mergeDoesNotModifyOriginals() public {
+        // Create context a with data
+        SettlementContext memory a = SettlementContextLib.newContext(1, 1, 0, 0);
+        SimpleTransfer memory deposit = createDummyTransfer(address(1), address(100), 1000);
+        SimpleTransfer memory withdrawal = createDummyTransfer(address(2), address(200), 2000);
+        a.pushDeposit(deposit);
+        a.pushWithdrawal(withdrawal);
+
+        // Create context b with data
+        SettlementContext memory b = SettlementContextLib.newContext(1, 0, 0, 0);
+        SimpleTransfer memory deposit2 = createDummyTransfer(address(3), address(300), 3000);
+        b.pushDeposit(deposit2);
+
+        // Store original lengths
+        uint256 aDepositsLen = a.numDeposits();
+        uint256 aWithdrawalsLen = a.numWithdrawals();
+        uint256 bDepositsLen = b.numDeposits();
+
+        // Merge
+        SettlementContext memory merged = SettlementContextLib.merge(a, b);
+
+        // Verify originals are unchanged
+        assertEq(a.numDeposits(), aDepositsLen);
+        assertEq(a.numWithdrawals(), aWithdrawalsLen);
+        assertEq(b.numDeposits(), bDepositsLen);
+
+        // Verify merged has combined data
+        assertEq(merged.numDeposits(), aDepositsLen + bDepositsLen);
+        assertEq(merged.numWithdrawals(), aWithdrawalsLen);
+    }
+
+    /// @notice Test merging a full context with an empty context
+    function test_mergeWithEmptyContext() public {
+        // Create a context with data
+        SettlementContext memory a = SettlementContextLib.newContext(2, 1, 0, 0);
+        a.pushDeposit(createDummyTransfer(address(1), address(100), 1000));
+        a.pushDeposit(createDummyTransfer(address(2), address(200), 2000));
+        a.pushWithdrawal(createDummyTransfer(address(3), address(300), 3000));
+
+        // Create empty context
+        SettlementContext memory b = SettlementContextLib.newContext(0, 0, 0, 0);
+
+        // Merge a with empty b
+        SettlementContext memory merged = SettlementContextLib.merge(a, b);
+
+        assertEq(merged.numDeposits(), 2);
+        assertEq(merged.numWithdrawals(), 1);
+
+        // Merge empty b with a
+        SettlementContext memory merged2 = SettlementContextLib.merge(b, a);
+
+        assertEq(merged2.numDeposits(), 2);
+        assertEq(merged2.numWithdrawals(), 1);
+    }
+
+    /// @notice Test merging three contexts together (simulating obligation + party0 + party1)
+    function test_mergeThreeContexts() public {
+        // Create obligation context (e.g., with proof for private obligations)
+        SettlementContext memory obligationCtx = SettlementContextLib.newContext(0, 0, 0, 0);
+
+        // Create party0 context
+        SettlementContext memory party0Ctx = SettlementContextLib.newContext(1, 2, 0, 0);
+        party0Ctx.pushDeposit(createDummyTransfer(address(10), address(100), 1000));
+        party0Ctx.pushWithdrawal(createDummyTransfer(address(11), address(100), 900));
+        party0Ctx.pushWithdrawal(createDummyTransfer(address(12), address(100), 100));
+
+        // Create party1 context
+        SettlementContext memory party1Ctx = SettlementContextLib.newContext(1, 2, 0, 0);
+        party1Ctx.pushDeposit(createDummyTransfer(address(20), address(200), 2000));
+        party1Ctx.pushWithdrawal(createDummyTransfer(address(21), address(200), 1800));
+        party1Ctx.pushWithdrawal(createDummyTransfer(address(22), address(200), 200));
+
+        // Merge all three (simulating the settleMatch flow)
+        SettlementContext memory merged =
+            SettlementContextLib.merge(obligationCtx, SettlementContextLib.merge(party0Ctx, party1Ctx));
+
+        // Verify totals
+        assertEq(merged.numDeposits(), 2);
+        assertEq(merged.numWithdrawals(), 4);
+
+        // Verify order: party0 deposits first, then party1 deposits
+        assertEq(merged.transfers.deposits.transfers[0].account, address(10));
+        assertEq(merged.transfers.deposits.transfers[1].account, address(20));
+
+        // Verify withdrawal order
+        assertEq(merged.transfers.withdrawals.transfers[0].account, address(11));
+        assertEq(merged.transfers.withdrawals.transfers[1].account, address(12));
+        assertEq(merged.transfers.withdrawals.transfers[2].account, address(21));
+        assertEq(merged.transfers.withdrawals.transfers[3].account, address(22));
+    }
+
+    /// @notice Test merging contexts with proofs and proof linking arguments
+    /// @dev This simulates a RENEGADE_SETTLED_PRIVATE_FILL match where both parties have proofs and linking args
+    function test_mergeWithProofsAndLinking() public {
+        // Create obligation context with 1 settlement proof (for private obligations)
+        SettlementContext memory obligationCtx = SettlementContextLib.newContext(0, 0, 1, 0);
+        BN254.ScalarField[] memory obligationPublicInputs = new BN254.ScalarField[](2);
+        obligationPublicInputs[0] = BN254.ScalarField.wrap(100);
+        obligationPublicInputs[1] = BN254.ScalarField.wrap(200);
+        obligationCtx.pushProof(obligationPublicInputs, createDummyProof(), createDummyVk());
+
+        // Create party0 context with 2 proofs and 1 proof linking argument
+        // (simulating validity proof + output balance proof with linking between them)
+        SettlementContext memory party0Ctx = SettlementContextLib.newContext(0, 2, 2, 1);
+        party0Ctx.pushWithdrawal(createDummyTransfer(address(11), address(100), 50)); // relayer fee
+        party0Ctx.pushWithdrawal(createDummyTransfer(address(12), address(100), 50)); // protocol fee
+
+        BN254.ScalarField[] memory party0Proof1Inputs = new BN254.ScalarField[](1);
+        party0Proof1Inputs[0] = BN254.ScalarField.wrap(1001);
+        party0Ctx.pushProof(party0Proof1Inputs, createDummyProof(), createDummyVk());
+
+        BN254.ScalarField[] memory party0Proof2Inputs = new BN254.ScalarField[](1);
+        party0Proof2Inputs[0] = BN254.ScalarField.wrap(1002);
+        party0Ctx.pushProof(party0Proof2Inputs, createDummyProof(), createDummyVk());
+
+        party0Ctx.pushProofLinkingArgument(createDummyProofLinkingInstance());
+
+        // Create party1 context with 2 proofs and 1 proof linking argument
+        SettlementContext memory party1Ctx = SettlementContextLib.newContext(0, 2, 2, 1);
+        party1Ctx.pushWithdrawal(createDummyTransfer(address(21), address(200), 100)); // relayer fee
+        party1Ctx.pushWithdrawal(createDummyTransfer(address(22), address(200), 100)); // protocol fee
+
+        BN254.ScalarField[] memory party1Proof1Inputs = new BN254.ScalarField[](1);
+        party1Proof1Inputs[0] = BN254.ScalarField.wrap(2001);
+        party1Ctx.pushProof(party1Proof1Inputs, createDummyProof(), createDummyVk());
+
+        BN254.ScalarField[] memory party1Proof2Inputs = new BN254.ScalarField[](1);
+        party1Proof2Inputs[0] = BN254.ScalarField.wrap(2002);
+        party1Ctx.pushProof(party1Proof2Inputs, createDummyProof(), createDummyVk());
+
+        party1Ctx.pushProofLinkingArgument(createDummyProofLinkingInstance());
+
+        // Merge all three contexts (exactly as settleMatch does)
+        SettlementContext memory merged =
+            SettlementContextLib.merge(obligationCtx, SettlementContextLib.merge(party0Ctx, party1Ctx));
+
+        // Verify totals
+        assertEq(merged.numDeposits(), 0);
+        assertEq(merged.numWithdrawals(), 4); // 2 from party0 + 2 from party1
+        assertEq(merged.numProofs(), 5); // 1 from obligation + 2 from party0 + 2 from party1
+        assertEq(merged.numProofLinkingArguments(), 2); // 1 from party0 + 1 from party1
+
+        // Verify proof order (obligation first, then party0, then party1)
+        assertEq(
+            BN254.ScalarField.unwrap(merged.verifications.publicInputs[0][0]), 100, "First proof should be obligation"
+        );
+        assertEq(
+            BN254.ScalarField.unwrap(merged.verifications.publicInputs[1][0]), 1001, "Second proof should be party0 #1"
+        );
+        assertEq(
+            BN254.ScalarField.unwrap(merged.verifications.publicInputs[2][0]), 1002, "Third proof should be party0 #2"
+        );
+        assertEq(
+            BN254.ScalarField.unwrap(merged.verifications.publicInputs[3][0]), 2001, "Fourth proof should be party1 #1"
+        );
+        assertEq(
+            BN254.ScalarField.unwrap(merged.verifications.publicInputs[4][0]), 2002, "Fifth proof should be party1 #2"
+        );
+
+        // Verify withdrawal order
+        assertEq(merged.transfers.withdrawals.transfers[0].account, address(11));
+        assertEq(merged.transfers.withdrawals.transfers[1].account, address(12));
+        assertEq(merged.transfers.withdrawals.transfers[2].account, address(21));
+        assertEq(merged.transfers.withdrawals.transfers[3].account, address(22));
+    }
+
+    // --- Cross-Boundary Merge Tests --- //
+
+    /// @notice Test merging contexts across external call boundaries
+    /// @dev This simulates how the settlement flow works with external library calls
+    function test_mergeAcrossExternalBoundary() public {
+        // Create a context in this contract
+        SettlementContext memory localContext = SettlementContextLib.newContext(1, 0, 0, 0);
+        localContext.pushDeposit(createDummyTransfer(address(1), address(100), 1000));
+
+        // Call an external function that creates and returns its own context
+        SettlementContext memory externalContext = this.externalCreateContext();
+
+        // Merge the two contexts
+        SettlementContext memory merged = SettlementContextLib.merge(localContext, externalContext);
+
+        // Verify the merged context has data from both
+        assertEq(merged.numDeposits(), 2); // 1 local + 1 from external
+        assertEq(merged.numWithdrawals(), 2); // 2 from external
+        assertEq(merged.transfers.deposits.transfers[0].account, address(1)); // local deposit
+        assertEq(merged.transfers.deposits.transfers[1].account, address(10)); // external deposit
+    }
+
+    /// @notice External function that allocates and returns a settlement context
+    /// @dev Simulates how NativeSettledPublicIntentLib.execute works with external visibility
+    function externalCreateContext() external view returns (SettlementContext memory) {
+        SettlementContext memory ctx = SettlementContextLib.newContext(1, 2, 0, 0);
+        ctx.pushDeposit(createDummyTransfer(address(10), address(100), 1000));
+        ctx.pushWithdrawal(createDummyTransfer(address(11), address(100), 800));
+        ctx.pushWithdrawal(createDummyTransfer(address(12), address(100), 200));
+        return ctx;
+    }
+
+    /// @notice Test merging multiple contexts from external calls (simulating full settlement flow)
+    function test_mergeMultipleExternalContexts() public {
+        // Simulate: obligation context (from validateObligationBundle)
+        SettlementContext memory obligationContext = SettlementContextLib.newContext(0, 0, 0, 0);
+
+        // Simulate: party0 context (from executeSettlementBundle -> NativeSettledPublicIntentLib.execute)
+        SettlementContext memory party0Context = this.externalCreateParty0Context();
+
+        // Simulate: party1 context (from executeSettlementBundle -> RenegadeSettledPrivateIntentLib.execute)
+        SettlementContext memory party1Context = this.externalCreateParty1Context();
+
+        // Merge all three (exactly as settleMatch does)
+        SettlementContext memory merged =
+            SettlementContextLib.merge(obligationContext, SettlementContextLib.merge(party0Context, party1Context));
+
+        // Verify combined counts
+        assertEq(merged.numDeposits(), 2); // 1 from party0 + 1 from party1
+        assertEq(merged.numWithdrawals(), 4); // 2 from party0 + 2 from party1
+
+        // Verify order is preserved (party0 first, then party1)
+        assertEq(merged.transfers.deposits.transfers[0].account, address(100)); // party0 deposit
+        assertEq(merged.transfers.deposits.transfers[1].account, address(200)); // party1 deposit
+        assertEq(merged.transfers.withdrawals.transfers[0].account, address(101)); // party0 withdrawal
+        assertEq(merged.transfers.withdrawals.transfers[1].account, address(102)); // party0 withdrawal
+        assertEq(merged.transfers.withdrawals.transfers[2].account, address(201)); // party1 withdrawal
+        assertEq(merged.transfers.withdrawals.transfers[3].account, address(202)); // party1 withdrawal
+    }
+
+    /// @notice External helper to create party0 context
+    function externalCreateParty0Context() external view returns (SettlementContext memory) {
+        SettlementContext memory ctx = SettlementContextLib.newContext(1, 2, 0, 0);
+        ctx.pushDeposit(createDummyTransfer(address(100), address(10), 1000));
+        ctx.pushWithdrawal(createDummyTransfer(address(101), address(20), 900));
+        ctx.pushWithdrawal(createDummyTransfer(address(102), address(20), 100));
+        return ctx;
+    }
+
+    /// @notice External helper to create party1 context
+    function externalCreateParty1Context() external view returns (SettlementContext memory) {
+        SettlementContext memory ctx = SettlementContextLib.newContext(1, 2, 0, 0);
+        ctx.pushDeposit(createDummyTransfer(address(200), address(20), 2000));
+        ctx.pushWithdrawal(createDummyTransfer(address(201), address(10), 1800));
+        ctx.pushWithdrawal(createDummyTransfer(address(202), address(10), 200));
+        return ctx;
+    }
+}

--- a/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-private-intents/IntentAuthorization.t.sol
@@ -40,12 +40,9 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
         external
         returns (SettlementContext memory)
     {
-        SettlementContext memory settlementContext = _createSettlementContext();
         DarkpoolContracts memory contracts = getSettlementContracts();
-        SettlementLib.executeSettlementBundle(
-            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, contracts, darkpoolState
-        );
-        return settlementContext;
+        return
+            SettlementLib.executeSettlementBundle(PartyId.PARTY_0, obligationBundle, bundle, contracts, darkpoolState);
     }
 
     /// @notice Helper that accepts memory and calls library with calldata
@@ -94,9 +91,7 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
     function test_invalidIntentCommitmentSignature_wrongSigner() public {
         // Create bundle and replace the intent commitment signature with a signature from wrong signer
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
-            createSamplePrivateIntentBundle(
-                true /* isFirstFill */
-            );
+            createSamplePrivateIntentBundle(true /* isFirstFill */ );
         PrivateIntentPublicBalanceFirstFillBundle memory bundleData =
             abi.decode(bundle.data, (PrivateIntentPublicBalanceFirstFillBundle));
         PrivateIntentAuthBundleFirstFill memory authBundle = bundleData.auth;
@@ -136,9 +131,7 @@ contract PrivateIntentAuthorizationTest is PrivateIntentSettlementTestUtils {
     function test_invalidMerkleRoot() public {
         // Create bundle for subsequent fill (not first fill)
         (ObligationBundle memory obligationBundle, SettlementBundle memory bundle) =
-            createSamplePrivateIntentBundle(
-                false /* isFirstFill */
-            );
+            createSamplePrivateIntentBundle(false /* isFirstFill */ );
 
         // Decode the bundle data
         PrivateIntentPublicBalanceBundle memory bundleData = abi.decode(bundle.data, (PrivateIntentPublicBalanceBundle));

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -42,11 +42,7 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         external
         returns (SettlementContext memory)
     {
-        SettlementContext memory settlementContext = _createSettlementContext();
-        NativeSettledPublicIntentLib.execute(
-            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, darkpoolState
-        );
-        return settlementContext;
+        return NativeSettledPublicIntentLib.execute(PartyId.PARTY_0, obligationBundle, bundle, darkpoolState);
     }
 
     /// @notice Helper that accepts memory and calls library with calldata

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentConstraints.t.sol
@@ -33,9 +33,9 @@ contract IntentConstraintsTest is PublicIntentSettlementTestUtils {
         SettlementBundle calldata bundle
     )
         external
+        returns (SettlementContext memory)
     {
-        SettlementContext memory settlementContext = _createSettlementContext();
-        NativeSettledPublicIntentLib.execute(partyId, obligationBundle, bundle, settlementContext, darkpoolState);
+        return NativeSettledPublicIntentLib.execute(partyId, obligationBundle, bundle, darkpoolState);
     }
 
     // ---------

--- a/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/ObligationCompatibility.t.sol
@@ -20,12 +20,11 @@ contract ObligationCompatibilityTest is PublicIntentSettlementTestUtils {
     // -----------
 
     /// @notice Wrapper to convert memory to calldata for library call
-    function _validateObligationBundle(ObligationBundle calldata bundle) public {
-        SettlementContext memory settlementContext = _createSettlementContext();
+    function _validateObligationBundle(ObligationBundle calldata bundle) public returns (SettlementContext memory) {
         // Create a dummy verifier since it's not used in validateObligationBundle
         IVerifier dummyVerifier = new TestVerifierV2();
         DarkpoolContracts memory contracts = getSettlementContracts(dummyVerifier);
-        SettlementLib.validateObligationBundle(bundle, settlementContext, darkpoolState, contracts);
+        return SettlementLib.validateObligationBundle(bundle, darkpoolState, contracts);
     }
 
     /// @notice Helper that accepts memory and calls library with calldata

--- a/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-fills/IntentAuthorization.t.sol
@@ -25,12 +25,9 @@ contract RenegadeSettledPrivateFillAuthorizationTest is RenegadeSettledPrivateFi
         external
         returns (SettlementContext memory)
     {
-        SettlementContext memory settlementContext = _createSettlementContext();
         DarkpoolContracts memory contracts = getSettlementContracts();
-        SettlementLib.executeSettlementBundle(
-            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, contracts, darkpoolState
-        );
-        return settlementContext;
+        return
+            SettlementLib.executeSettlementBundle(PartyId.PARTY_0, obligationBundle, bundle, contracts, darkpoolState);
     }
 
     /// @notice Helper that accepts memory and calls library with calldata

--- a/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/renegade-settled-private-intents/IntentAuthorization.t.sol
@@ -34,12 +34,8 @@ contract RenegadeSettledPrivateIntentAuthorizationTest is RenegadeSettledPrivate
         external
         returns (SettlementContext memory)
     {
-        SettlementContext memory settlementContext = _createSettlementContext();
         DarkpoolContracts memory contracts = getSettlementContracts();
-        SettlementLib.executeSettlementBundle(
-            PartyId.PARTY_0, obligationBundle, bundle, settlementContext, contracts, darkpoolState
-        );
-        return settlementContext;
+        return SettlementLib.executeSettlementBundle(PartyId.PARTY_0, obligationBundle, bundle, contracts, darkpoolState);
     }
 
     /// @notice Helper that accepts memory and calls library with calldata


### PR DESCRIPTION
### Purpose
This PR splits up the settlement contracts by having individual settlement libraries return a settlement context that is merged into the root context.

### Testing
- [x] Unit tests pass