### PR TITLE
darkpoolv2: vkeys: Remove redundant vkeys

### DIFF
--- a/src/darkpool/v2/contracts/vkeys/WalletUpdateVKeys.sol
+++ b/src/darkpool/v2/contracts/vkeys/WalletUpdateVKeys.sol
@@ -62,48 +62,6 @@ contract WalletUpdateVKeys {
         return __deserializeKey(VerificationKeys.VALID_PUBLIC_RELAYER_FEE_PAYMENT_VKEY);
     }
 
-    /// @notice Get the verification key for `INTENT ONLY FIRST FILL VALIDITY`
-    /// @return The verification key for `INTENT ONLY FIRST FILL VALIDITY`
-    function intentOnlyFirstFillValidityKeys() external pure returns (VerificationKey memory) {
-        return __deserializeKey(VerificationKeys.INTENT_ONLY_FIRST_FILL_VALIDITY_VKEY);
-    }
-
-    /// @notice Get the verification key for `INTENT ONLY VALIDITY`
-    /// @return The verification key for `INTENT ONLY VALIDITY`
-    function intentOnlyValidityKeys() external pure returns (VerificationKey memory) {
-        return __deserializeKey(VerificationKeys.INTENT_ONLY_VALIDITY_VKEY);
-    }
-
-    /// @notice Get the verification key for `INTENT AND BALANCE FIRST FILL VALIDITY`
-    /// @return The verification key for `INTENT AND BALANCE FIRST FILL VALIDITY`
-    function intentAndBalanceFirstFillValidityKeys() external pure returns (VerificationKey memory) {
-        return __deserializeKey(VerificationKeys.INTENT_AND_BALANCE_FIRST_FILL_VALIDITY_VKEY);
-    }
-
-    /// @notice Get the verification key for `INTENT AND BALANCE VALIDITY`
-    /// @return The verification key for `INTENT AND BALANCE VALIDITY`
-    function intentAndBalanceValidityKeys() external pure returns (VerificationKey memory) {
-        return __deserializeKey(VerificationKeys.INTENT_AND_BALANCE_VALIDITY_VKEY);
-    }
-
-    /// @notice Get the verification key for `INTENT ONLY PUBLIC SETTLEMENT`
-    /// @return The verification key for `INTENT ONLY PUBLIC SETTLEMENT`
-    function intentOnlyPublicSettlementKeys() external pure returns (VerificationKey memory) {
-        return __deserializeKey(VerificationKeys.INTENT_ONLY_PUBLIC_SETTLEMENT_VKEY);
-    }
-
-    /// @notice Get the verification key for `INTENT AND BALANCE PUBLIC SETTLEMENT`
-    /// @return The verification key for `INTENT AND BALANCE PUBLIC SETTLEMENT`
-    function intentAndBalancePublicSettlementKeys() external pure returns (VerificationKey memory) {
-        return __deserializeKey(VerificationKeys.INTENT_AND_BALANCE_PUBLIC_SETTLEMENT_VKEY);
-    }
-
-    /// @notice Get the verification key for `INTENT AND BALANCE PRIVATE SETTLEMENT`
-    /// @return The verification key for `INTENT AND BALANCE PRIVATE SETTLEMENT`
-    function intentAndBalancePrivateSettlementKeys() external pure returns (VerificationKey memory) {
-        return __deserializeKey(VerificationKeys.INTENT_AND_BALANCE_PRIVATE_SETTLEMENT_VKEY);
-    }
-
     /// @notice Deserialize a verification key
     /// @param vkeyBytes The bytes of the verification key
     /// @return vk The verification key


### PR DESCRIPTION
### Purpose
This PR removed vkeys that are redundantly copied into the `WalletUpdateVkeys.sol` library.