### PR TITLE
abi: relayer-types: bounded-match-result: Add helper for executor signature

### DIFF
--- a/abi/src/v2/calldata_bundles.rs
+++ b/abi/src/v2/calldata_bundles.rs
@@ -347,7 +347,7 @@ impl BoundedMatchResult {
         Self {
             internalPartyInputToken: internal_party_input_token,
             internalPartyOutputToken: internal_party_output_token,
-            price: price,
+            price,
             minInternalPartyAmountIn: min_internal_party_amt_in,
             maxInternalPartyAmountIn: max_internal_party_amt_in,
             blockDeadline: block_deadline,

--- a/abi/src/v2/relayer_types/bounded_match_result.rs
+++ b/abi/src/v2/relayer_types/bounded_match_result.rs
@@ -1,6 +1,10 @@
 //! Conversion for bounded match result types
 
+#[cfg(feature = "v2-auth-helpers")]
+use crate::v2::IDarkpoolV2::{FeeRate, SignatureWithNonce};
 use crate::v2::{relayer_types::u128_to_u256, IDarkpoolV2};
+#[cfg(feature = "v2-auth-helpers")]
+use alloy::signers::{local::PrivateKeySigner, Error as SignerError};
 use darkpool_types::bounded_match_result::BoundedMatchResult as CircuitBoundedMatchResult;
 
 impl From<CircuitBoundedMatchResult> for IDarkpoolV2::BoundedMatchResult {
@@ -17,5 +21,21 @@ impl From<CircuitBoundedMatchResult> for IDarkpoolV2::BoundedMatchResult {
             ),
             blockDeadline: u128_to_u256(bounded_match_result.block_deadline as u128),
         }
+    }
+}
+
+#[cfg(feature = "v2-auth-helpers")]
+impl IDarkpoolV2::BoundedMatchResult {
+    /// Build an executor signature for the bounded match result
+    pub fn create_executor_signature(
+        &self,
+        relayer_fee_rate: FeeRate,
+        chain_id: u64,
+        signer: &PrivateKeySigner,
+    ) -> Result<SignatureWithNonce, SignerError> {
+        use alloy::sol_types::SolValue;
+
+        let payload = (relayer_fee_rate, self.clone()).abi_encode();
+        SignatureWithNonce::sign(payload.as_slice(), chain_id, signer)
     }
 }

--- a/integration/v2/src/tests/settlement/external_match/public_intent_public_balance.rs
+++ b/integration/v2/src/tests/settlement/external_match/public_intent_public_balance.rs
@@ -39,16 +39,10 @@ async fn test_bounded_settlement__native_settled_public_intent(args: TestArgs) -
     let chain_id = args.chain_id().await?;
     let executor_signer = &args.relayer_signer;
 
-    // ABI-encode the payload to sign
-    let payload = (
-        relayer_fee_rate.clone(),
-        BoundedMatchResult::from(bounded_match_result.clone()),
-    )
-        .abi_encode();
-
-    // Sign the payload and chain ID
+    // Generate an executor signature for the bounded match result
+    let match_res = BoundedMatchResult::from(bounded_match_result.clone());
     let executor_signature =
-        SignatureWithNonce::sign(payload.as_slice(), chain_id, executor_signer)?;
+        match_res.create_executor_signature(relayer_fee_rate.clone(), chain_id, executor_signer)?;
 
     // Generate the auth bundle
     let permit = PublicIntentPermit {

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -156,10 +156,7 @@ interface IDarkpoolV2 {
     /// @param fillAmount The amount filled in this settlement
     /// @param amountRemaining The remaining amount after this fill (0 = fully filled)
     event PublicIntentUpdated(
-        bytes32 indexed intentHash,
-        address indexed owner,
-        uint256 fillAmount,
-        uint256 amountRemaining
+        bytes32 indexed intentHash, address indexed owner, uint256 fillAmount, uint256 amountRemaining
     );
 
     /// @notice Emitted when a public intent is explicitly cancelled


### PR DESCRIPTION
### Purpose
This PR adds a helper for constructing executor signatures for bounded match results.