### PR TITLE
feat(abi): impl conversion into circuit BoundedMatchResult type

### DIFF
--- a/abi/src/v2/relayer_types/bounded_match_result.rs
+++ b/abi/src/v2/relayer_types/bounded_match_result.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "v2-auth-helpers")]
 use crate::v2::IDarkpoolV2::{FeeRate, SignatureWithNonce};
-use crate::v2::{relayer_types::u128_to_u256, IDarkpoolV2};
+use crate::v2::{relayer_types::{u128_to_u256, u256_to_u128}, IDarkpoolV2};
 #[cfg(feature = "v2-auth-helpers")]
 use alloy::signers::{local::PrivateKeySigner, Error as SignerError};
 use darkpool_types::bounded_match_result::BoundedMatchResult as CircuitBoundedMatchResult;
@@ -20,6 +20,19 @@ impl From<CircuitBoundedMatchResult> for IDarkpoolV2::BoundedMatchResult {
                 bounded_match_result.max_internal_party_amount_in,
             ),
             blockDeadline: u128_to_u256(bounded_match_result.block_deadline as u128),
+        }
+    }
+}
+
+impl From<IDarkpoolV2::BoundedMatchResult> for CircuitBoundedMatchResult {
+    fn from(bounded_match_result: IDarkpoolV2::BoundedMatchResult) -> Self {
+        Self {
+            internal_party_input_token: bounded_match_result.internalPartyInputToken,
+            internal_party_output_token: bounded_match_result.internalPartyOutputToken,
+            price: bounded_match_result.price.into(),
+            min_internal_party_amount_in: u256_to_u128(bounded_match_result.minInternalPartyAmountIn),
+            max_internal_party_amount_in: u256_to_u128(bounded_match_result.maxInternalPartyAmountIn),
+            block_deadline: u256_to_u128(bounded_match_result.blockDeadline) as u64,
         }
     }
 }


### PR DESCRIPTION
In this PR, we implement conversion from the Solidity `BoundedMatchResult` Rust binding type to the relayer analogue.
