### PR TITLE
darkpoolv2: gas-sponsor: Add GasSponsorV2 contract

### DIFF
--- a/src/darkpool/v2/contracts/GasSponsorV2.sol
+++ b/src/darkpool/v2/contracts/GasSponsorV2.sol
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Initializable } from "oz-contracts/proxy/utils/Initializable.sol";
+import { Ownable } from "oz-contracts/access/Ownable.sol";
+import { Ownable2Step } from "oz-contracts/access/Ownable2Step.sol";
+import { Pausable } from "oz-contracts/utils/Pausable.sol";
+
+import { ECDSA } from "oz-contracts/utils/cryptography/ECDSA.sol";
+import { EfficientHashLib } from "solady/utils/EfficientHashLib.sol";
+
+import { IDarkpoolV2 } from "darkpoolv2-interfaces/IDarkpoolV2.sol";
+import { IGasSponsorV2 } from "darkpoolv2-interfaces/IGasSponsorV2.sol";
+import { DarkpoolConstants } from "darkpoolv2-lib/Constants.sol";
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+
+import { IERC20 } from "oz-contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "oz-contracts/token/ERC20/utils/SafeERC20.sol";
+import { SafeTransferLib } from "solmate/src/utils/SafeTransferLib.sol";
+
+/**
+ * @title GasSponsorV2
+ * @author Renegade Eng
+ * @notice A contract used to sponsor gas costs of external matches in DarkpoolV2
+ */
+contract GasSponsorV2 is Initializable, Ownable2Step, Pausable, IGasSponsorV2 {
+    using BoundedMatchResultLib for BoundedMatchResult;
+
+    // -----------
+    // | STORAGE |
+    // -----------
+
+    /// @notice The address of the DarkpoolV2 proxy contract
+    address public darkpoolAddress;
+    /// @notice The public key used to authenticate gas sponsorship, stored as an address
+    address public authAddress;
+    /// @notice The set of used nonces for sponsored matches
+    mapping(uint256 => bool) public usedNonces;
+
+    // ---------------
+    // | CONSTRUCTOR |
+    // ---------------
+
+    /// @notice Constructor that disables initializers for the implementation contract
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() Ownable(msg.sender) {
+        _disableInitializers();
+    }
+
+    // ----------------------
+    // | EXTERNAL FUNCTIONS |
+    // ----------------------
+
+    // --- Initialization --- //
+
+    /**
+     * @notice Initializes the gas sponsor contract with the given darkpool address and auth pubkey
+     * @param initialOwner The initial owner of the gas sponsor contract
+     * @param _darkpoolAddress The address of the DarkpoolV2 proxy contract
+     * @param _authAddress The public key used to authenticate gas sponsorship
+     */
+    function initialize(address initialOwner, address _darkpoolAddress, address _authAddress) public initializer {
+        _transferOwnership(initialOwner);
+        darkpoolAddress = _darkpoolAddress;
+        authAddress = _authAddress;
+    }
+
+    // --- Key Rotation --- //
+
+    /**
+     * @notice Rotates the auth address to the given new address
+     * @param newAuthAddress The new auth address
+     */
+    function rotateAuthAddress(address newAuthAddress) external onlyOwner {
+        authAddress = newAuthAddress;
+        emit AuthAddressRotated(newAuthAddress);
+    }
+
+    // --- Pause Control --- //
+
+    /**
+     * @notice Pauses the gas sponsor contract
+     */
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /**
+     * @notice Unpauses the gas sponsor contract
+     */
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    // --- Funding --- //
+
+    /**
+     * @notice Receives ETH from the caller
+     */
+    receive() external payable { }
+
+    /**
+     * @notice Withdraws ETH from the gas sponsor contract to the given receiver
+     * @param receiver The address to receive the ETH
+     * @param amount The amount of ETH to withdraw
+     */
+    function withdrawEth(address receiver, uint256 amount) external onlyOwner {
+        SafeTransferLib.safeTransferETH(receiver, amount);
+    }
+
+    /**
+     * @notice Withdraws ERC20 tokens from the gas sponsor contract to the given receiver
+     * @param receiver The address to receive the tokens
+     * @param token The token address
+     * @param amount The amount of tokens to withdraw
+     */
+    function withdrawTokens(address receiver, address token, uint256 amount) external onlyOwner {
+        IERC20 tokenContract = IERC20(token);
+        SafeERC20.safeTransfer(tokenContract, receiver, amount);
+    }
+
+    // --- Gas Sponsorship --- //
+
+    /**
+     * @notice Sponsor the gas costs of an external match settlement on DarkpoolV2
+     * @param externalPartyAmountIn The input amount for the trade from the external party
+     * @param receiver The address to receive the output tokens (0 = msg.sender)
+     * @param matchResult The bounded match result parameters
+     * @param internalPartySettlementBundle The settlement bundle for the internal party
+     * @param refundAddress The address to refund gas costs to
+     * @param refundNativeEth Whether to refund gas costs in native ETH
+     * @param refundAmount The amount to refund
+     * @param nonce A unique nonce for this sponsorship
+     * @param signature The signature authorizing the sponsorship
+     * @return The amount received by the external party
+     */
+    function sponsorExternalMatchSettle(
+        uint256 externalPartyAmountIn,
+        address receiver,
+        BoundedMatchResult calldata matchResult,
+        SettlementBundle calldata internalPartySettlementBundle,
+        address refundAddress,
+        bool refundNativeEth,
+        uint256 refundAmount,
+        uint256 nonce,
+        bytes calldata signature
+    )
+        external
+        payable
+        returns (uint256)
+    {
+        // Resolve the receiver and verify the sponsorship signature
+        address resolvedReceiver = receiver == address(0) ? msg.sender : receiver;
+        _verifySigSpendNonce(nonce, refundAddress, refundAmount, signature);
+
+        // Execute the external match
+        (address outputTokenAddr, uint256 receivedInMatch) =
+            _doExternalMatch(externalPartyAmountIn, resolvedReceiver, matchResult, internalPartySettlementBundle);
+
+        // If gas sponsorship is paused or refund amount is 0, return early
+        if (paused() || refundAmount == 0) {
+            emit GasSponsorshipSkipped(nonce);
+            emit SponsoredExternalMatchOutput(receivedInMatch, nonce);
+            return receivedInMatch;
+        }
+
+        // Refund the gas costs
+        uint256 receivedAmount = _refundGasCost(
+            refundNativeEth, refundAddress, outputTokenAddr, refundAmount, receivedInMatch, resolvedReceiver, nonce
+        );
+
+        emit SponsoredExternalMatchOutput(receivedAmount, nonce);
+        return receivedAmount;
+    }
+
+    // ----------------------
+    // | INTERNAL FUNCTIONS |
+    // ----------------------
+
+    // --- Authorization --- //
+
+    /**
+     * @notice Verify the sponsorship signature and mark its nonce as used
+     * @param nonce The nonce to verify and mark as used
+     * @param refundAddress The refund address
+     * @param refundAmount The refund amount
+     * @param signature The signature to verify
+     */
+    function _verifySigSpendNonce(
+        uint256 nonce,
+        address refundAddress,
+        uint256 refundAmount,
+        bytes calldata signature
+    )
+        internal
+    {
+        _assertSponsorshipSignature(nonce, refundAddress, refundAmount, signature);
+        _markNonceUsed(nonce);
+    }
+
+    /**
+     * @notice Verify the signature over the nonce, refund address, and refund amount
+     * @param nonce The nonce to verify
+     * @param refundAddress The refund address
+     * @param refundAmount The refund amount
+     * @param signature The signature to verify
+     */
+    function _assertSponsorshipSignature(
+        uint256 nonce,
+        address refundAddress,
+        uint256 refundAmount,
+        bytes calldata signature
+    )
+        internal
+        view
+    {
+        // Create message hash directly from encoded tuple
+        bytes32 messageHash = EfficientHashLib.hash(abi.encode(nonce, refundAddress, refundAmount));
+
+        // Split the signature into r, s and v
+        if (signature.length != 65) revert InvalidSignatureLength();
+        bytes32 r = bytes32(signature[:32]);
+        bytes32 s = bytes32(signature[32:64]);
+        uint8 v = uint8(signature[64]);
+
+        // Clients sometimes use v = 0 or 1, the ecrecover precompile expects 27 or 28
+        if (v < 27) {
+            v += 27;
+        }
+
+        address recoveredAddress = ECDSA.recover(messageHash, v, r, s);
+        if (recoveredAddress != authAddress) revert InvalidSignature();
+    }
+
+    /**
+     * @notice Marks the given nonce as used
+     * @param nonce The nonce to mark as used
+     */
+    function _markNonceUsed(uint256 nonce) internal {
+        if (usedNonces[nonce]) revert NonceAlreadyUsed();
+        usedNonces[nonce] = true;
+        emit NonceUsed(nonce);
+    }
+
+    // --- External Match Helpers --- //
+
+    /**
+     * @notice Executes an external match on the darkpool
+     * @param externalPartyAmountIn The amount the external party is providing
+     * @param receiver The address to receive tokens
+     * @param matchResult The bounded match result parameters
+     * @param internalPartySettlementBundle The settlement bundle for the internal party
+     * @return outputTokenAddr The token address received by the external party
+     * @return receivedInMatch The amount received by the external party in the match
+     */
+    function _doExternalMatch(
+        uint256 externalPartyAmountIn,
+        address receiver,
+        BoundedMatchResult calldata matchResult,
+        SettlementBundle calldata internalPartySettlementBundle
+    )
+        internal
+        returns (address, uint256)
+    {
+        // Process tokens based on external match parameters
+        _custodySendTokens(matchResult, externalPartyAmountIn);
+
+        // Call the darkpool contract
+        IDarkpoolV2 darkpool = IDarkpoolV2(darkpoolAddress);
+        darkpool.settleExternalMatch(externalPartyAmountIn, receiver, matchResult, internalPartySettlementBundle);
+
+        // Compute the amount received by the external party
+        // The external party receives the internal party's input amount (minus fees handled by darkpool)
+        address outputTokenAddr = matchResult.internalPartyInputToken;
+        uint256 receivedInMatch = BoundedMatchResultLib.computeInternalPartyAmountIn(matchResult, externalPartyAmountIn);
+
+        return (outputTokenAddr, receivedInMatch);
+    }
+
+    // --- Transfer Helpers --- //
+
+    /**
+     * @notice Takes custody of the trader's tokens to proxy the match
+     * @param matchResult The bounded match result containing token and price details
+     * @param externalPartyAmountIn The amount the external party is providing
+     */
+    function _custodySendTokens(BoundedMatchResult calldata matchResult, uint256 externalPartyAmountIn) internal {
+        address sender = msg.sender;
+        address sponsor = address(this);
+
+        // The external party's input token is the internal party's output token
+        address inputToken = matchResult.internalPartyOutputToken;
+
+        // Only execute ERC20 transfer if not native ETH
+        if (!DarkpoolConstants.isNativeToken(inputToken)) {
+            IERC20 token = IERC20(inputToken);
+            SafeERC20.safeIncreaseAllowance(token, darkpoolAddress, externalPartyAmountIn);
+            SafeERC20.safeTransferFrom(token, sender, sponsor, externalPartyAmountIn);
+        }
+    }
+
+    // --- Refund Helpers --- //
+
+    /**
+     * @notice Resolves the refund address to use
+     * @param refundNativeEth Whether to refund in native ETH
+     * @param refundAddress The explicitly specified refund address
+     * @param receiver The receiver of the match output
+     * @return The resolved refund address
+     */
+    function _resolveRefundAddress(
+        bool refundNativeEth,
+        address refundAddress,
+        address receiver
+    )
+        internal
+        view
+        returns (address)
+    {
+        // If the refund address is explicitly set, use it
+        if (refundAddress != address(0)) {
+            return refundAddress;
+        } else if (refundNativeEth) {
+            // If refunding through native ETH, default to tx.origin
+            // solhint-disable-next-line avoid-tx-origin
+            return tx.origin;
+        } else {
+            // Otherwise default to the receiver
+            return receiver;
+        }
+    }
+
+    /**
+     * @notice Refunds gas costs through native ETH
+     * @param refundAddress The address to receive the refund
+     * @param refundAmount The amount to refund in native ETH
+     * @param nonce The nonce of the sponsorship
+     * @return The amount actually refunded (0 if balance insufficient)
+     */
+    function _refundThroughNativeEth(
+        address refundAddress,
+        uint256 refundAmount,
+        uint256 nonce
+    )
+        internal
+        returns (uint256)
+    {
+        // Check balance, do not revert if insufficient
+        if (address(this).balance < refundAmount) {
+            emit InsufficientSponsorBalance(nonce);
+            return 0;
+        }
+
+        // Transfer ETH
+        SafeTransferLib.safeTransferETH(refundAddress, refundAmount);
+        emit SponsoredExternalMatch(refundAmount, address(0), nonce);
+        return refundAmount;
+    }
+
+    /**
+     * @notice Refunds gas costs through the output token
+     * @param refundAddress The address to receive the refund
+     * @param outputTokenAddr The token address to use for refund
+     * @param refundAmount The amount to refund in the output token
+     * @param nonce The nonce of the sponsorship
+     * @return The amount actually refunded (0 if balance insufficient)
+     */
+    function _refundThroughOutputToken(
+        address refundAddress,
+        address outputTokenAddr,
+        uint256 refundAmount,
+        uint256 nonce
+    )
+        internal
+        returns (uint256)
+    {
+        // Check balance, do not revert if insufficient
+        IERC20 outputToken = IERC20(outputTokenAddr);
+        if (outputToken.balanceOf(address(this)) < refundAmount) {
+            emit InsufficientSponsorBalance(nonce);
+            return 0;
+        }
+
+        // Transfer tokens
+        SafeERC20.safeTransfer(outputToken, refundAddress, refundAmount);
+        emit SponsoredExternalMatch(refundAmount, outputTokenAddr, nonce);
+        return refundAmount;
+    }
+
+    /**
+     * @notice Refunds the user's gas costs
+     * @param refundNativeEth Whether to refund in native ETH
+     * @param refundAddress The address to receive the refund
+     * @param outputTokenAddr The output token address from the match
+     * @param refundAmount The amount to refund
+     * @param receivedInMatch The amount received from the match
+     * @param receiver The receiver of the match output
+     * @param nonce The nonce of the sponsorship
+     * @return The total amount received including refund
+     */
+    function _refundGasCost(
+        bool refundNativeEth,
+        address refundAddress,
+        address outputTokenAddr,
+        uint256 refundAmount,
+        uint256 receivedInMatch,
+        address receiver,
+        uint256 nonce
+    )
+        internal
+        returns (uint256)
+    {
+        address resolvedRefundAddress = _resolveRefundAddress(refundNativeEth, refundAddress, receiver);
+        bool isNativeEthOutput = DarkpoolConstants.isNativeToken(outputTokenAddr);
+
+        // Refund through appropriate method
+        uint256 refundedAmount;
+        if (refundNativeEth || isNativeEthOutput) {
+            refundedAmount = _refundThroughNativeEth(resolvedRefundAddress, refundAmount, nonce);
+        } else {
+            refundedAmount = _refundThroughOutputToken(resolvedRefundAddress, outputTokenAddr, refundAmount, nonce);
+        }
+
+        // Calculate total received amount
+        uint256 receivedAmount;
+        if (isNativeEthOutput || !refundNativeEth) {
+            // If output token is ETH or refunding in-kind, include refund in total
+            receivedAmount = receivedInMatch + refundedAmount;
+        } else {
+            receivedAmount = receivedInMatch;
+        }
+
+        return receivedAmount;
+    }
+}

--- a/src/darkpool/v2/interfaces/IGasSponsorV2.sol
+++ b/src/darkpool/v2/interfaces/IGasSponsorV2.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { BoundedMatchResult } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+
+/// @title IGasSponsorV2
+/// @author Renegade Eng
+/// @notice Interface for the GasSponsorV2 contract, exposing sponsorship methods for DarkpoolV2
+interface IGasSponsorV2 {
+    // ------------------
+    // | ERROR MESSAGES |
+    // ------------------
+
+    /// @notice Thrown when a sponsorship nonce has already been used
+    error NonceAlreadyUsed();
+    /// @notice Thrown when the signature length is invalid
+    error InvalidSignatureLength();
+    /// @notice Thrown when the signature is invalid
+    error InvalidSignature();
+    /// @notice Thrown when an address parameter is zero
+    error AddressZero();
+
+    // ----------
+    // | EVENTS |
+    // ----------
+
+    /// @notice Emitted when a nonce is used
+    /// @param nonce The nonce that was used
+    event NonceUsed(uint256 indexed nonce);
+
+    /// @notice Emitted when the auth address is rotated
+    /// @param newAuthAddress The new auth address
+    event AuthAddressRotated(address indexed newAuthAddress);
+
+    /// @notice Emitted when the sponsor balance is insufficient for a refund
+    /// @param nonce The nonce of the sponsorship attempt
+    event InsufficientSponsorBalance(uint256 indexed nonce);
+
+    /// @notice Emitted when an external match is successfully sponsored
+    /// @param refundAmount The amount refunded
+    /// @param token The token used for refund (address(0) for native ETH)
+    /// @param nonce The nonce of the sponsorship
+    event SponsoredExternalMatch(uint256 refundAmount, address token, uint256 indexed nonce);
+
+    /// @notice Emitted with the output amount of a sponsored match
+    /// @param receivedAmount The amount received by the external party
+    /// @param nonce The nonce of the sponsorship
+    event SponsoredExternalMatchOutput(uint256 receivedAmount, uint256 indexed nonce);
+
+    /// @notice Emitted when gas sponsorship is skipped (paused or zero refund)
+    /// @param nonce The nonce of the sponsorship
+    event GasSponsorshipSkipped(uint256 indexed nonce);
+
+    // ----------------------
+    // | EXTERNAL FUNCTIONS |
+    // ----------------------
+
+    /// @notice Initializes the gas sponsor contract with the given darkpool address and auth pubkey
+    /// @param initialOwner The initial owner of the gas sponsor contract
+    /// @param _darkpoolAddress The address of the DarkpoolV2 proxy contract
+    /// @param _authAddress The public key used to authenticate gas sponsorship
+    function initialize(address initialOwner, address _darkpoolAddress, address _authAddress) external;
+
+    /// @notice Rotates the auth address to the given new address
+    /// @param newAuthAddress The new auth address
+    function rotateAuthAddress(address newAuthAddress) external;
+
+    /// @notice Pauses the gas sponsor contract
+    function pause() external;
+
+    /// @notice Unpauses the gas sponsor contract
+    function unpause() external;
+
+    /// @notice Withdraws ETH from the gas sponsor contract to the given receiver
+    /// @param receiver The address to receive the ETH
+    /// @param amount The amount of ETH to withdraw
+    function withdrawEth(address receiver, uint256 amount) external;
+
+    /// @notice Withdraws ERC20 tokens from the gas sponsor contract to the given receiver
+    /// @param receiver The address to receive the tokens
+    /// @param token The token address
+    /// @param amount The amount of tokens to withdraw
+    function withdrawTokens(address receiver, address token, uint256 amount) external;
+
+    /// @notice Sponsor the gas costs of an external match settlement on DarkpoolV2
+    /// @param externalPartyAmountIn The input amount for the trade from the external party
+    /// @param recipient The address to receive the output tokens (0 = msg.sender)
+    /// @param matchResult The bounded match result parameters
+    /// @param internalPartySettlementBundle The settlement bundle for the internal party
+    /// @param refundAddress The address to refund gas costs to
+    /// @param refundNativeEth Whether to refund gas costs in native ETH
+    /// @param refundAmount The amount to refund
+    /// @param nonce A unique nonce for this sponsorship
+    /// @param signature The signature authorizing the sponsorship
+    /// @return receivedAmount The amount received by the external party
+    function sponsorExternalMatchSettle(
+        uint256 externalPartyAmountIn,
+        address recipient,
+        BoundedMatchResult calldata matchResult,
+        SettlementBundle calldata internalPartySettlementBundle,
+        address refundAddress,
+        bool refundNativeEth,
+        uint256 refundAmount,
+        uint256 nonce,
+        bytes calldata signature
+    )
+        external
+        payable
+        returns (uint256 receivedAmount);
+
+    // -----------
+    // | GETTERS |
+    // -----------
+
+    /// @notice Returns the address of the DarkpoolV2 proxy contract
+    function darkpoolAddress() external view returns (address);
+
+    /// @notice Returns the public key used to authenticate gas sponsorship
+    function authAddress() external view returns (address);
+
+    /// @notice Returns whether a nonce has been used
+    /// @param nonce The nonce to check
+    function usedNonces(uint256 nonce) external view returns (bool);
+}

--- a/src/darkpool/v2/proxies/GasSponsorV2Proxy.sol
+++ b/src/darkpool/v2/proxies/GasSponsorV2Proxy.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { TransparentUpgradeableProxy } from "oz-contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { IGasSponsorV2 } from "darkpoolv2-interfaces/IGasSponsorV2.sol";
+
+/// @title GasSponsorV2Proxy
+/// @author Renegade Eng
+/// @notice This contract is a TransparentUpgradeableProxy for the GasSponsorV2 contract.
+/// It simplifies deployment by accepting GasSponsorV2-specific initialization parameters
+/// and encoding them appropriately.
+contract GasSponsorV2Proxy is TransparentUpgradeableProxy {
+    /// @notice Initializes a TransparentUpgradeableProxy for a GasSponsorV2 implementation.
+    /// @param implementation The GasSponsorV2 implementation address
+    /// @param admin The admin address - serves as both ProxyAdmin owner and can manage proxy upgrades
+    /// @param darkpoolAddress The address of the DarkpoolV2 proxy contract
+    /// @param authAddress The public key used to authenticate gas sponsorship
+    constructor(
+        address implementation,
+        address admin,
+        // GasSponsorV2-specific initialization parameters
+        address darkpoolAddress,
+        address authAddress
+    )
+        payable
+        TransparentUpgradeableProxy(
+            implementation,
+            admin,
+            abi.encodeWithSelector(IGasSponsorV2.initialize.selector, admin, darkpoolAddress, authAddress)
+        )
+    { }
+}

--- a/test/darkpool/v2/GasSponsorV2.t.sol
+++ b/test/darkpool/v2/GasSponsorV2.t.sol
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+/* solhint-disable func-name-mixedcase */
+
+import { Vm } from "forge-std/Vm.sol";
+import { ERC20Mock } from "oz-contracts/mocks/token/ERC20Mock.sol";
+
+import { FixedPoint, FixedPointLib } from "renegade-lib/FixedPoint.sol";
+import { BoundedMatchResult, BoundedMatchResultLib } from "darkpoolv2-types/BoundedMatchResult.sol";
+import { SettlementObligation } from "darkpoolv2-types/Obligation.sol";
+import { SettlementBundle } from "darkpoolv2-types/settlement/SettlementBundle.sol";
+import { Intent } from "darkpoolv2-types/Intent.sol";
+
+import { GasSponsorV2 } from "darkpoolv2-contracts/GasSponsorV2.sol";
+import { GasSponsorV2Proxy } from "darkpoolv2-proxies/GasSponsorV2Proxy.sol";
+import { IGasSponsorV2 } from "darkpoolv2-interfaces/IGasSponsorV2.sol";
+
+import { PublicIntentExternalMatchTestUtils } from "./settlement/external-match/native-settled-public-intents/Utils.sol";
+
+contract GasSponsorV2Test is PublicIntentExternalMatchTestUtils {
+    using BoundedMatchResultLib for BoundedMatchResult;
+    using FixedPointLib for FixedPoint;
+
+    uint256 constant REFUND_AMT = 100_000;
+
+    IGasSponsorV2 public gasSponsorV2;
+    GasSponsorV2 public gasSponsorV2Impl;
+
+    address public gasSponsorV2Owner;
+    address public gasSponsorV2AuthAddress;
+    uint256 public gasSponsorV2AuthPrivateKey;
+
+    struct SponsorshipParams {
+        uint256 nonce;
+        address refundAddress;
+        bool refundNativeEth;
+        uint256 refundAmount;
+        bytes signature;
+    }
+
+    function setUp() public override {
+        super.setUp();
+        deployGasSponsorV2();
+    }
+
+    /// @notice Deploy the GasSponsorV2 contract
+    function deployGasSponsorV2() internal {
+        // Set gas sponsor owner
+        gasSponsorV2Owner = vm.randomAddress();
+
+        // Create a wallet for gas sponsor auth with a known private key
+        Vm.Wallet memory wallet = vm.createWallet("gas_sponsor_v2_auth");
+        gasSponsorV2AuthPrivateKey = wallet.privateKey;
+        gasSponsorV2AuthAddress = wallet.addr;
+
+        // Deploy gas sponsor implementation contract
+        gasSponsorV2Impl = new GasSponsorV2();
+
+        // Deploy gas sponsor proxy, pointing to the darkpool
+        GasSponsorV2Proxy gasSponsorV2ProxyContract = new GasSponsorV2Proxy(
+            address(gasSponsorV2Impl),
+            gasSponsorV2Owner,
+            address(darkpool),
+            gasSponsorV2AuthAddress
+        );
+        gasSponsorV2 = IGasSponsorV2(address(gasSponsorV2ProxyContract));
+
+        // Fund the gas sponsor with ETH and tokens for refunds
+        vm.deal(address(gasSponsorV2), REFUND_AMT * 10);
+        quoteToken.mint(address(gasSponsorV2), REFUND_AMT * 10);
+        baseToken.mint(address(gasSponsorV2), REFUND_AMT * 10);
+    }
+
+    // ---------------------------
+    // | External Match Sponsorship Tests |
+    // ---------------------------
+
+    /// @notice Test sponsoring an external match with external party on buy side (internal party sells base)
+    function test_sponsorExternalMatchSettle_externalPartyBuySide() public {
+        // Create match data where internal party sells base for quote
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartySells();
+
+        // Execute the sponsorship and verify results
+        _executeSponsorshipAndVerify(matchResult, internalPartySettlementBundle, externalPartyAmountIn, false);
+    }
+
+    /// @notice Test sponsoring an external match with external party on sell side (internal party buys base)
+    function test_sponsorExternalMatchSettle_externalPartySellSide() public {
+        // Create match data where internal party buys base for quote
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartyBuys();
+
+        // Execute the sponsorship and verify results
+        _executeSponsorshipAndVerify(matchResult, internalPartySettlementBundle, externalPartyAmountIn, false);
+    }
+
+    /// @notice Test native ETH refund path with zero refund amount (early return)
+    function test_sponsorExternalMatchSettle_zeroRefund_nativeEth() public {
+        // Create match data
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartySells();
+
+        // Sponsor ETH balance before (should not change when refundAmount == 0)
+        uint256 sponsorEthBalance1 = address(gasSponsorV2).balance;
+
+        // Create sponsorship params with zero refund
+        SponsorshipParams memory params = _createSponsorshipParams(0, true);
+
+        // Capitalize the external party and approve the gas sponsor
+        _capitalizeAndApproveExternalParty(matchResult, externalPartyAmountIn);
+
+        // Execute the sponsorship
+        vm.prank(externalParty.addr);
+        gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn,
+            externalParty.addr,
+            matchResult,
+            internalPartySettlementBundle,
+            params.refundAddress,
+            params.refundNativeEth,
+            params.refundAmount,
+            params.nonce,
+            params.signature
+        );
+
+        // Verify the sponsor's ETH balance (no native refund transfer occurs)
+        uint256 sponsorEthBalance2 = address(gasSponsorV2).balance;
+        assertEq(sponsorEthBalance2, sponsorEthBalance1, "Sponsor ETH balance changed (zero native refund)");
+    }
+
+    /// @notice Test in-kind refund path with zero refund amount (early return)
+    function test_sponsorExternalMatchSettle_zeroRefund_inKind() public {
+        // Create match data
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartySells();
+
+        // Sponsor token balances before (should not change when refundAmount == 0)
+        (uint256 sponsorBaseBalance1, uint256 sponsorQuoteBalance1) = baseQuoteBalances(address(gasSponsorV2));
+
+        // Create sponsorship params with zero refund, in-kind
+        SponsorshipParams memory params = _createSponsorshipParams(0, false);
+
+        // Capitalize the external party and approve the gas sponsor
+        _capitalizeAndApproveExternalParty(matchResult, externalPartyAmountIn);
+
+        // Execute the sponsorship
+        vm.prank(externalParty.addr);
+        gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn,
+            externalParty.addr,
+            matchResult,
+            internalPartySettlementBundle,
+            params.refundAddress,
+            params.refundNativeEth,
+            params.refundAmount,
+            params.nonce,
+            params.signature
+        );
+
+        // Verify the sponsor's token balances (no in-kind refund transfer occurs)
+        (uint256 sponsorBaseBalance2, uint256 sponsorQuoteBalance2) = baseQuoteBalances(address(gasSponsorV2));
+        assertEq(sponsorBaseBalance2, sponsorBaseBalance1, "Sponsor base balance changed (zero in-kind refund)");
+        assertEq(sponsorQuoteBalance2, sponsorQuoteBalance1, "Sponsor quote balance changed (zero in-kind refund)");
+    }
+
+    /// @notice Test that nonce replay is prevented
+    function test_sponsorExternalMatchSettle_revertOnNonceReplay() public {
+        // Create match data
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartySells();
+
+        // Create sponsorship params
+        SponsorshipParams memory params = _createSponsorshipParams(REFUND_AMT, false);
+
+        // Capitalize the external party and approve the gas sponsor (with extra for second attempt)
+        _capitalizeAndApproveExternalParty(matchResult, externalPartyAmountIn * 2);
+
+        // Execute the first sponsorship (should succeed)
+        vm.prank(externalParty.addr);
+        gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn,
+            externalParty.addr,
+            matchResult,
+            internalPartySettlementBundle,
+            params.refundAddress,
+            params.refundNativeEth,
+            params.refundAmount,
+            params.nonce,
+            params.signature
+        );
+
+        // Create new match data for second attempt (need fresh settlement bundle)
+        (
+            BoundedMatchResult memory matchResult2,
+            SettlementBundle memory internalPartySettlementBundle2,
+            uint256 externalPartyAmountIn2
+        ) = _createMatchDataInternalPartySells();
+
+        // Capitalize for the second attempt
+        _capitalizeAndApproveExternalParty(matchResult2, externalPartyAmountIn2);
+
+        // Second attempt with the same nonce should fail
+        vm.prank(externalParty.addr);
+        vm.expectRevert(IGasSponsorV2.NonceAlreadyUsed.selector);
+        gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn2,
+            externalParty.addr,
+            matchResult2,
+            internalPartySettlementBundle2,
+            params.refundAddress,
+            params.refundNativeEth,
+            params.refundAmount,
+            params.nonce, // Same nonce
+            params.signature
+        );
+    }
+
+    /// @notice Test that invalid signature is rejected
+    function test_sponsorExternalMatchSettle_revertOnInvalidSignature() public {
+        // Create match data
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartySells();
+
+        // Create sponsorship params with wrong signer
+        uint256 nonce = randomUint();
+        address refundAddress = externalParty.addr;
+        uint256 refundAmount = REFUND_AMT;
+        // Sign with wrong key
+        bytes memory badSignature = _signGasSponsorshipPayloadWithKey(nonce, refundAddress, refundAmount, wrongSigner.privateKey);
+
+        // Capitalize the external party
+        _capitalizeAndApproveExternalParty(matchResult, externalPartyAmountIn);
+
+        // Should fail with invalid signature
+        vm.prank(externalParty.addr);
+        vm.expectRevert(IGasSponsorV2.InvalidSignature.selector);
+        gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn,
+            externalParty.addr,
+            matchResult,
+            internalPartySettlementBundle,
+            refundAddress,
+            false,
+            refundAmount,
+            nonce,
+            badSignature
+        );
+    }
+
+    /// @notice Test that sponsorship is skipped when paused
+    function test_sponsorExternalMatchSettle_skippedWhenPaused() public {
+        // Pause the gas sponsor
+        vm.prank(gasSponsorV2Owner);
+        gasSponsorV2.pause();
+
+        // Create match data
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartySells();
+
+        // Record sponsor balances before
+        uint256 sponsorEthBalance1 = address(gasSponsorV2).balance;
+        (uint256 sponsorBaseBalance1, uint256 sponsorQuoteBalance1) = baseQuoteBalances(address(gasSponsorV2));
+
+        // Create sponsorship params with refund
+        SponsorshipParams memory params = _createSponsorshipParams(REFUND_AMT, false);
+
+        // Capitalize the external party
+        _capitalizeAndApproveExternalParty(matchResult, externalPartyAmountIn);
+
+        // Execute the sponsorship (should succeed but skip refund)
+        vm.prank(externalParty.addr);
+        gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn,
+            externalParty.addr,
+            matchResult,
+            internalPartySettlementBundle,
+            params.refundAddress,
+            params.refundNativeEth,
+            params.refundAmount,
+            params.nonce,
+            params.signature
+        );
+
+        // Verify sponsor balances unchanged (refund was skipped)
+        uint256 sponsorEthBalance2 = address(gasSponsorV2).balance;
+        (uint256 sponsorBaseBalance2, uint256 sponsorQuoteBalance2) = baseQuoteBalances(address(gasSponsorV2));
+        assertEq(sponsorEthBalance2, sponsorEthBalance1, "Sponsor ETH balance changed when paused");
+        assertEq(sponsorBaseBalance2, sponsorBaseBalance1, "Sponsor base balance changed when paused");
+        assertEq(sponsorQuoteBalance2, sponsorQuoteBalance1, "Sponsor quote balance changed when paused");
+    }
+
+    /// @notice Test native ETH refund
+    function test_sponsorExternalMatchSettle_nativeEthRefund() public {
+        // Create match data
+        (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        ) = _createMatchDataInternalPartySells();
+
+        // Record balances before
+        uint256 recipientEthBalance1 = externalParty.addr.balance;
+        uint256 sponsorEthBalance1 = address(gasSponsorV2).balance;
+
+        // Create sponsorship params with native ETH refund
+        SponsorshipParams memory params = _createSponsorshipParams(REFUND_AMT, true);
+
+        // Capitalize the external party
+        _capitalizeAndApproveExternalParty(matchResult, externalPartyAmountIn);
+
+        // Execute the sponsorship
+        vm.prank(externalParty.addr);
+        gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn,
+            externalParty.addr,
+            matchResult,
+            internalPartySettlementBundle,
+            params.refundAddress,
+            params.refundNativeEth,
+            params.refundAmount,
+            params.nonce,
+            params.signature
+        );
+
+        // Verify ETH was refunded
+        uint256 recipientEthBalance2 = externalParty.addr.balance;
+        uint256 sponsorEthBalance2 = address(gasSponsorV2).balance;
+        assertEq(recipientEthBalance2, recipientEthBalance1 + REFUND_AMT, "Recipient ETH balance incorrect");
+        assertEq(sponsorEthBalance2, sponsorEthBalance1 - REFUND_AMT, "Sponsor ETH balance incorrect");
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// @notice Create match data where internal party sells base for quote (external party buys base)
+    function _createMatchDataInternalPartySells()
+        internal
+        returns (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        )
+    {
+        // Create obligations for the trade
+        FixedPoint memory price;
+        (SettlementObligation memory internalPartyObligation, SettlementObligation memory externalPartyObligation, FixedPoint memory tradePrice) =
+            createTradeObligations();
+        price = tradePrice;
+
+        // Create internal party intent: sell base for quote
+        uint256 minPriceRepr = price.repr / 2;
+        uint256 internalPartyAmountIn = vm.randomUint(internalPartyObligation.amountIn, internalPartyObligation.amountIn * 2);
+        Intent memory internalPartyIntent = Intent({
+            inToken: address(baseToken),
+            outToken: address(quoteToken),
+            owner: internalParty.addr,
+            minPrice: FixedPointLib.wrap(minPriceRepr),
+            amountIn: internalPartyAmountIn
+        });
+
+        // Create bounded match result
+        matchResult = createBoundedMatchResultForObligation(internalPartyObligation, price);
+
+        // Create settlement bundle
+        internalPartySettlementBundle = createBoundedMatchSettlementBundleWithSigners(
+            internalPartyIntent, matchResult, internalParty.privateKey, executor.privateKey
+        );
+
+        // Capitalize the internal party
+        capitalizeParty(internalParty.addr, internalPartyObligation);
+
+        // Generate random external party amount in
+        (externalPartyAmountIn,) = randomExternalPartyAmountIn(externalPartyObligation, price);
+        // Ensure non-zero amount
+        if (externalPartyAmountIn == 0) {
+            externalPartyAmountIn = 1;
+        }
+    }
+
+    /// @notice Create match data where internal party buys base for quote (external party sells base)
+    function _createMatchDataInternalPartyBuys()
+        internal
+        returns (
+            BoundedMatchResult memory matchResult,
+            SettlementBundle memory internalPartySettlementBundle,
+            uint256 externalPartyAmountIn
+        )
+    {
+        // Create obligations for the trade (reversed)
+        FixedPoint memory price;
+        (SettlementObligation memory baseSellerObligation, SettlementObligation memory quoteBuyerObligation, FixedPoint memory tradePrice) =
+            createTradeObligations();
+        price = tradePrice;
+
+        // Internal party buys base (sells quote), so use the quoteBuyerObligation
+        SettlementObligation memory internalPartyObligation = quoteBuyerObligation;
+        SettlementObligation memory externalPartyObligation = baseSellerObligation;
+
+        // Compute the inverse price for internal party (quote/base -> base/quote)
+        FixedPoint memory inversePrice = FixedPointLib.divIntegers(1, 1);
+        inversePrice = FixedPointLib.divIntegers(internalPartyObligation.amountOut, internalPartyObligation.amountIn);
+
+        // Create internal party intent: sell quote for base
+        uint256 minPriceRepr = inversePrice.repr / 2;
+        uint256 internalPartyAmountIn = vm.randomUint(internalPartyObligation.amountIn, internalPartyObligation.amountIn * 2);
+        Intent memory internalPartyIntent = Intent({
+            inToken: address(quoteToken),
+            outToken: address(baseToken),
+            owner: internalParty.addr,
+            minPrice: FixedPointLib.wrap(minPriceRepr),
+            amountIn: internalPartyAmountIn
+        });
+
+        // Create bounded match result from internal party's perspective
+        matchResult = BoundedMatchResult({
+            internalPartyInputToken: address(quoteToken),
+            internalPartyOutputToken: address(baseToken),
+            price: inversePrice,
+            minInternalPartyAmountIn: 0,
+            maxInternalPartyAmountIn: internalPartyObligation.amountIn,
+            blockDeadline: block.number + 100
+        });
+
+        // Create settlement bundle
+        internalPartySettlementBundle = createBoundedMatchSettlementBundleWithSigners(
+            internalPartyIntent, matchResult, internalParty.privateKey, executor.privateKey
+        );
+
+        // Capitalize the internal party
+        capitalizeParty(internalParty.addr, internalPartyObligation);
+
+        // Generate external party amount in (base tokens)
+        externalPartyAmountIn = vm.randomUint(1, externalPartyObligation.amountIn);
+    }
+
+    /// @notice Capitalize and approve the external party for the gas sponsor
+    function _capitalizeAndApproveExternalParty(BoundedMatchResult memory matchResult, uint256 amount) internal {
+        // The external party's input token is the internal party's output token
+        address externalInputToken = matchResult.internalPartyOutputToken;
+
+        // Mint tokens to external party
+        ERC20Mock(externalInputToken).mint(externalParty.addr, amount);
+
+        // Approve the gas sponsor to spend tokens
+        vm.prank(externalParty.addr);
+        ERC20Mock(externalInputToken).approve(address(gasSponsorV2), amount);
+    }
+
+    /// @notice Create sponsorship parameters
+    function _createSponsorshipParams(
+        uint256 refundAmount,
+        bool refundNativeEth
+    )
+        internal
+        returns (SponsorshipParams memory params)
+    {
+        params.nonce = randomUint();
+        params.refundAddress = externalParty.addr;
+        params.refundNativeEth = refundNativeEth;
+        params.refundAmount = refundAmount;
+        params.signature = _signGasSponsorshipPayload(params.nonce, params.refundAddress, params.refundAmount);
+    }
+
+    /// @notice Sign a gas sponsorship payload
+    function _signGasSponsorshipPayload(
+        uint256 nonce,
+        address refundAddress,
+        uint256 refundAmount
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        return _signGasSponsorshipPayloadWithKey(nonce, refundAddress, refundAmount, gasSponsorV2AuthPrivateKey);
+    }
+
+    /// @notice Sign a gas sponsorship payload with a specific key
+    function _signGasSponsorshipPayloadWithKey(
+        uint256 nonce,
+        address refundAddress,
+        uint256 refundAmount,
+        uint256 privateKey
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        // Create message hash directly from encoded tuple (same as in GasSponsorV2._assertSponsorshipSignature)
+        bytes32 messageHash = keccak256(abi.encode(nonce, refundAddress, refundAmount));
+
+        // Sign the message hash with the private key
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, messageHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /// @notice Execute sponsorship and verify results
+    function _executeSponsorshipAndVerify(
+        BoundedMatchResult memory matchResult,
+        SettlementBundle memory internalPartySettlementBundle,
+        uint256 externalPartyAmountIn,
+        bool refundNativeEth
+    )
+        internal
+    {
+        // Record balances before
+        (uint256 recipientBaseBalance1, uint256 recipientQuoteBalance1) = baseQuoteBalances(externalParty.addr);
+
+        // Create sponsorship params
+        SponsorshipParams memory params = _createSponsorshipParams(REFUND_AMT, refundNativeEth);
+
+        // Capitalize the external party and approve the gas sponsor
+        _capitalizeAndApproveExternalParty(matchResult, externalPartyAmountIn);
+
+        // Execute the sponsorship
+        vm.prank(externalParty.addr);
+        uint256 receivedAmount = gasSponsorV2.sponsorExternalMatchSettle(
+            externalPartyAmountIn,
+            externalParty.addr,
+            matchResult,
+            internalPartySettlementBundle,
+            params.refundAddress,
+            params.refundNativeEth,
+            params.refundAmount,
+            params.nonce,
+            params.signature
+        );
+
+        // Compute expected received amount using external call for memory-to-calldata conversion
+        uint256 internalPartyAmountIn = this._computeInternalPartyAmountInCalldata(matchResult, externalPartyAmountIn);
+
+        // Verify the received amount is non-zero and reasonable
+        assertTrue(receivedAmount > 0, "Received amount should be non-zero");
+
+        // Record balances after
+        (uint256 recipientBaseBalance2, uint256 recipientQuoteBalance2) = baseQuoteBalances(externalParty.addr);
+
+        // Verify balances changed appropriately
+        // External party should have received the internal party's input token
+        address outputToken = matchResult.internalPartyInputToken;
+        if (outputToken == address(baseToken)) {
+            assertTrue(recipientBaseBalance2 > recipientBaseBalance1, "Recipient should have received base tokens");
+        } else {
+            assertTrue(recipientQuoteBalance2 > recipientQuoteBalance1, "Recipient should have received quote tokens");
+        }
+    }
+
+    /// @notice Wrapper to convert memory to calldata for BoundedMatchResultLib.computeInternalPartyAmountIn
+    function _computeInternalPartyAmountInCalldata(
+        BoundedMatchResult calldata matchResult,
+        uint256 externalPartyAmountIn
+    )
+        external
+        pure
+        returns (uint256)
+    {
+        return BoundedMatchResultLib.computeInternalPartyAmountIn(matchResult, externalPartyAmountIn);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds the GasSponsorV2 contract, which allows sponsored external match settlements with gas refunds. The contract custodies external party tokens, executes settlements through the darkpool, and refunds gas costs to a specified address (either in native ETH or in-kind tokens).

### Testing
- [x] Unit tests were added and they pass