### PR TITLE
darkpoolv2: state: Add recovery ID nullifier set

### DIFF
--- a/script/v2/DeployDarkpoolImpl.s.sol
+++ b/script/v2/DeployDarkpoolImpl.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import { Script } from "forge-std/Script.sol";
+import { DeployV2Utils } from "./DeployV2Utils.sol";
+
+/// @title DeployDarkpoolV2ImplementationScript
+/// @author Renegade Eng
+/// @notice Deploys only the DarkpoolV2 implementation contract for proxy upgrades.
+/// @dev After deploying, use `cast send` to upgrade the proxy via the ProxyAdmin.
+/// Usage:
+///   forge script script/v2/UpgradeDarkpool.s.sol \
+///     --rpc-url <rpc> --ffi --broadcast --sender <deployer>
+contract DeployDarkpoolV2ImplementationScript is Script, DeployV2Utils {
+    /// @notice Deploy the new DarkpoolV2 implementation contract
+    function run() public {
+        vm.startBroadcast();
+        deployDarkpoolImplementation(vm);
+        vm.stopBroadcast();
+    }
+}

--- a/src/darkpool/v2/contracts/DarkpoolV2.sol
+++ b/src/darkpool/v2/contracts/DarkpoolV2.sol
@@ -142,6 +142,11 @@ contract DarkpoolV2 is Initializable, Ownable2Step, Pausable, IDarkpoolV2 {
     }
 
     /// @inheritdoc IDarkpoolV2
+    function recoveryIdSpent(BN254.ScalarField recoveryId) public view returns (bool) {
+        return _state.isRecoveryIdSpent(recoveryId);
+    }
+
+    /// @inheritdoc IDarkpoolV2
     function getMerkleRoot(uint256 depth) public view returns (BN254.ScalarField) {
         return _state.getMerkleRoot(depth);
     }

--- a/src/darkpool/v2/interfaces/IDarkpoolV2.sol
+++ b/src/darkpool/v2/interfaces/IDarkpoolV2.sol
@@ -128,6 +128,8 @@ interface IDarkpoolV2 {
     error FeeCannotBeZero();
     /// @notice Thrown when a token is not whitelisted
     error TokenNotWhitelisted(address token);
+    /// @notice Thrown when a recovery ID has already been used
+    error RecoveryIdAlreadyUsed();
 
     // --- Events --- //
 
@@ -221,6 +223,11 @@ interface IDarkpoolV2 {
     /// @param nullifier The nullifier to check
     /// @return True if the nullifier has been spent, false otherwise
     function nullifierSpent(BN254.ScalarField nullifier) external view returns (bool);
+
+    /// @notice Check if a recovery ID has been spent
+    /// @param recoveryId The recovery ID to check
+    /// @return True if the recovery ID has been spent, false otherwise
+    function recoveryIdSpent(BN254.ScalarField recoveryId) external view returns (bool);
 
     /// @notice Get the current Merkle root
     /// @param depth The depth of the Merkle tree to get the root of

--- a/src/darkpool/v2/libraries/DarkpoolState.sol
+++ b/src/darkpool/v2/libraries/DarkpoolState.sol
@@ -47,6 +47,9 @@ struct DarkpoolState {
     /// elements in the Merkle state
     /// @dev The nullifier is computed deterministically from the shares of the pre-update state element
     NullifierLib.NullifierSet nullifierSet;
+    /// @notice The nullifier set for recovery IDs
+    /// @dev Ensures that a recovery ID is never reused across state transitions
+    NullifierLib.NullifierSet recoveryIdNullifierSet;
 }
 
 /// @title DarkpoolState
@@ -251,6 +254,31 @@ library DarkpoolStateLib {
     /// @return Whether the nullifier has been spent
     function isNullifierSpent(DarkpoolState storage state, BN254.ScalarField nullifier) internal view returns (bool) {
         return state.nullifierSet.isSpent(nullifier);
+    }
+
+    /// @notice Spend a recovery ID nullifier, preventing the same recovery ID from being used twice
+    /// @param state The darkpool state
+    /// @param recoveryId The recovery ID to spend
+    function spendRecoveryIdNullifier(DarkpoolState storage state, BN254.ScalarField recoveryId) internal {
+        state.recoveryIdNullifierSet.spend(recoveryId);
+
+        // Emit the recovery ID registered event
+        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+    }
+
+    /// @notice Check if a recovery ID has been spent
+    /// @param state The darkpool state
+    /// @param recoveryId The recovery ID to check
+    /// @return Whether the recovery ID has been spent
+    function isRecoveryIdSpent(
+        DarkpoolState storage state,
+        BN254.ScalarField recoveryId
+    )
+        internal
+        view
+        returns (bool)
+    {
+        return state.recoveryIdNullifierSet.isSpent(recoveryId);
     }
 
     /// @notice Insert a leaf into the Merkle mountain range at the given depth

--- a/src/darkpool/v2/libraries/StateUpdatesLib.sol
+++ b/src/darkpool/v2/libraries/StateUpdatesLib.sol
@@ -197,8 +197,8 @@ library StateUpdatesLib {
         state.spendNullifier(balanceNullifier);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
 
-        // Emit the recovery id
-        emit IDarkpoolV2.RecoveryIdRegistered(depositProofBundle.statement.recoveryId);
+        // Spend the recovery id nullifier
+        state.spendRecoveryIdNullifier(depositProofBundle.statement.recoveryId);
     }
 
     /// @notice Deposit a new balance into the darkpool
@@ -236,8 +236,8 @@ library StateUpdatesLib {
         uint256 merkleDepth = newBalanceProofBundle.merkleDepth;
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
 
-        // Emit the recovery id
-        emit IDarkpoolV2.RecoveryIdRegistered(newBalanceProofBundle.statement.recoveryId);
+        // Spend the recovery id nullifier
+        state.spendRecoveryIdNullifier(newBalanceProofBundle.statement.recoveryId);
     }
 
     // --- Withdrawal --- //
@@ -276,8 +276,8 @@ library StateUpdatesLib {
         state.spendNullifier(balanceNullifier);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
 
-        // Emit the recovery id
-        emit IDarkpoolV2.RecoveryIdRegistered(withdrawalProofBundle.statement.recoveryId);
+        // Spend the recovery id nullifier
+        state.spendRecoveryIdNullifier(withdrawalProofBundle.statement.recoveryId);
     }
 
     // --- Fees --- //
@@ -316,8 +316,8 @@ library StateUpdatesLib {
         SimpleTransfer memory transfer = note.buildTransfer();
         ExternalTransferLib.executeTransfer(transfer, contracts.weth, contracts.permit2);
 
-        // Emit the recovery id
-        emit IDarkpoolV2.RecoveryIdRegistered(proofBundle.statement.recoveryId);
+        // Spend the recovery id nullifier
+        state.spendRecoveryIdNullifier(proofBundle.statement.recoveryId);
     }
 
     /// @notice Pay relayer fees publicly on a balance
@@ -350,8 +350,8 @@ library StateUpdatesLib {
         SimpleTransfer memory transfer = note.buildTransfer();
         ExternalTransferLib.executeTransfer(transfer, contracts.weth, contracts.permit2);
 
-        // Emit the recovery id
-        emit IDarkpoolV2.RecoveryIdRegistered(proofBundle.statement.recoveryId);
+        // Spend the recovery id nullifier
+        state.spendRecoveryIdNullifier(proofBundle.statement.recoveryId);
     }
 
     /// @notice Pay protocol fees privately on a balance
@@ -394,8 +394,8 @@ library StateUpdatesLib {
         // Emit the note posted event
         emit IDarkpoolV2.NotePosted(BN254.ScalarField.unwrap(noteCommitment));
 
-        // Emit the recovery id
-        emit IDarkpoolV2.RecoveryIdRegistered(proofBundle.statement.recoveryId);
+        // Spend the recovery id nullifier
+        state.spendRecoveryIdNullifier(proofBundle.statement.recoveryId);
     }
 
     /// @notice Pay relayer fees privately on a balance
@@ -439,8 +439,8 @@ library StateUpdatesLib {
         // Emit the note posted event
         emit IDarkpoolV2.NotePosted(BN254.ScalarField.unwrap(noteCommitment));
 
-        // Emit the recovery id
-        emit IDarkpoolV2.RecoveryIdRegistered(proofBundle.statement.recoveryId);
+        // Spend the recovery id nullifier
+        state.spendRecoveryIdNullifier(proofBundle.statement.recoveryId);
     }
 
     // --- Note Redemption --- //

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBoundedLib.sol
@@ -241,10 +241,10 @@ library PrivateIntentPrivateBalanceBoundedLib {
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
 
-        // 3. Emit recovery IDs for the intent and balance
+        // 3. Spend recovery ID nullifiers for the intent and balance
         IntentAndBalanceValidityStatementFirstFill memory authStatement = bundle.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.intentRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.balanceRecoveryId);
     }
 
     /// @notice Update the intent and input balance on a subsequent fill
@@ -273,10 +273,10 @@ library PrivateIntentPrivateBalanceBoundedLib {
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
 
-        // 3. Emit recovery IDs for the intent and balance
+        // 3. Spend recovery ID nullifiers for the intent and balance
         IntentAndBalanceValidityStatement memory authStatement = bundle.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.intentRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.balanceRecoveryId);
     }
 
     // --------------------------------
@@ -451,9 +451,8 @@ library PrivateIntentPrivateBalanceBoundedLib {
             computeFullNewOutputBalanceCommitment(netReceiveAmount, bundle, settlementStatement, hasher);
         state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, newBalanceCommitment, hasher);
 
-        // Emit a recovery ID for the output balance
-        BN254.ScalarField recoveryId = bundle.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+        // Spend the recovery ID nullifier for the output balance
+        state.spendRecoveryIdNullifier(bundle.statement.recoveryId);
     }
 
     /// @notice Update an existing output balance's contract state
@@ -483,9 +482,8 @@ library PrivateIntentPrivateBalanceBoundedLib {
             computeFullExistingOutputBalanceCommitment(netReceiveAmount, bundle, settlementStatement, hasher);
         state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, newBalanceCommitment, hasher);
 
-        // Emit a recovery ID for the output balance
-        BN254.ScalarField recoveryId = bundle.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+        // Spend the recovery ID nullifier for the output balance
+        state.spendRecoveryIdNullifier(bundle.statement.recoveryId);
     }
 
     // ---------------------------

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol
@@ -232,10 +232,10 @@ library PrivateIntentPrivateBalanceBundleLib {
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
 
-        // 3. Emit recovery IDs for the intent and balance
+        // 3. Spend recovery ID nullifiers for the intent and balance
         IntentAndBalanceValidityStatementFirstFill memory authStatement = bundle.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.intentRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.balanceRecoveryId);
     }
 
     /// @notice Update the intent and input balance on a subsequent fill
@@ -262,10 +262,10 @@ library PrivateIntentPrivateBalanceBundleLib {
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
 
-        // 3. Emit recovery IDs for the intent and balance
+        // 3. Spend recovery ID nullifiers for the intent and balance
         IntentAndBalanceValidityStatement memory authStatement = bundle.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.intentRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.balanceRecoveryId);
     }
 
     // --------------------------------
@@ -440,9 +440,8 @@ library PrivateIntentPrivateBalanceBundleLib {
             computeFullNewOutputBalanceCommitment(netReceiveAmount, bundle, settlementStatement, hasher);
         state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, newBalanceCommitment, hasher);
 
-        // Emit a recovery ID for the output balance
-        BN254.ScalarField recoveryId = bundle.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+        // Spend the recovery ID nullifier for the output balance
+        state.spendRecoveryIdNullifier(bundle.statement.recoveryId);
     }
 
     /// @notice Update an existing output balance's contract state
@@ -472,9 +471,8 @@ library PrivateIntentPrivateBalanceBundleLib {
             computeFullExistingOutputBalanceCommitment(netReceiveAmount, bundle, settlementStatement, hasher);
         state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, newBalanceCommitment, hasher);
 
-        // Emit a recovery ID for the output balance
-        BN254.ScalarField recoveryId = bundle.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+        // Spend the recovery ID nullifier for the output balance
+        state.spendRecoveryIdNullifier(bundle.statement.recoveryId);
     }
 
     // ---------------------------

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBoundedLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBoundedLib.sol
@@ -280,8 +280,8 @@ library PrivateIntentPublicBalanceBoundedLib {
         // Allocate trader's ERC20 transfers: deposit + net withdrawal
         _addSettlementTransfers(intentOwner, internalObligation, netReceiveAmount, settlementContext);
 
-        // Emit recovery ID for the intent
-        emit IDarkpoolV2.RecoveryIdRegistered(bundleData.auth.statement.recoveryId);
+        // Spend the recovery ID nullifier for the intent
+        state.spendRecoveryIdNullifier(bundleData.auth.statement.recoveryId);
     }
 
     /// @notice Authorize and update the intent for a bounded match settlement on subsequent fill
@@ -329,8 +329,8 @@ library PrivateIntentPublicBalanceBoundedLib {
         address intentOwner = bundleData.auth.statement.intentOwner;
         _addSettlementTransfers(intentOwner, internalObligation, netReceiveAmount, settlementContext);
 
-        // Emit recovery ID for the intent
-        emit IDarkpoolV2.RecoveryIdRegistered(bundleData.auth.statement.recoveryId);
+        // Spend the recovery ID nullifier for the intent
+        state.spendRecoveryIdNullifier(bundleData.auth.statement.recoveryId);
     }
 
     /// @notice Allocate the trader's ERC20 transfers (deposit + net withdrawal)

--- a/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/PrivateIntentPublicBalanceBundleLib.sol
@@ -273,8 +273,8 @@ library PrivateIntentPublicBalanceBundleLib {
         // Allocate trader's ERC20 transfers: deposit + net withdrawal
         _addSettlementTransfers(intentOwner, obligation, netReceiveAmount, settlementContext);
 
-        // Emit recovery ID for the intent
-        emit IDarkpoolV2.RecoveryIdRegistered(bundleData.auth.statement.recoveryId);
+        // Spend the recovery ID nullifier for the intent
+        state.spendRecoveryIdNullifier(bundleData.auth.statement.recoveryId);
     }
 
     /// @notice Authorize and update the intent for an exact match settlement on subsequent fill
@@ -319,8 +319,8 @@ library PrivateIntentPublicBalanceBundleLib {
         address intentOwner = bundleData.auth.statement.intentOwner;
         _addSettlementTransfers(intentOwner, obligation, netReceiveAmount, settlementContext);
 
-        // Emit recovery ID for the intent
-        emit IDarkpoolV2.RecoveryIdRegistered(bundleData.auth.statement.recoveryId);
+        // Spend the recovery ID nullifier for the intent
+        state.spendRecoveryIdNullifier(bundleData.auth.statement.recoveryId);
     }
 
     /// @notice Allocate the trader's ERC20 transfers (deposit + net withdrawal)

--- a/src/darkpool/v2/libraries/settlement/bundles/RenegadeSettledPrivateFillLib.sol
+++ b/src/darkpool/v2/libraries/settlement/bundles/RenegadeSettledPrivateFillLib.sol
@@ -33,9 +33,8 @@ import { DarkpoolContracts } from "darkpoolv2-contracts/DarkpoolV2.sol";
 import { IVkeys } from "darkpoolv2-interfaces/IVkeys.sol";
 import { IHasher } from "renegade-lib/interfaces/IHasher.sol";
 import { DarkpoolState, DarkpoolStateLib } from "darkpoolv2-lib/DarkpoolState.sol";
-import {
-    PrivateIntentPrivateBalanceBundleLib
-} from "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
+import { PrivateIntentPrivateBalanceBundleLib } from
+    "darkpoolv2-lib/settlement/bundles/PrivateIntentPrivateBalanceBundleLib.sol";
 import {
     OutputBalanceBundle,
     OutputBalanceBundleType,
@@ -98,8 +97,7 @@ library RenegadeSettledPrivateFillLib {
         pure
         returns (RenegadeSettledPrivateFirstFillBundle memory bundleData)
     {
-        bool validType =
-            bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
+        bool validType = bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
         require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFirstFillBundle));
     }
@@ -112,8 +110,7 @@ library RenegadeSettledPrivateFillLib {
         pure
         returns (RenegadeSettledPrivateFillBundle memory bundleData)
     {
-        bool validType =
-            !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
+        bool validType = !bundle.isFirstFill && bundle.bundleType == SettlementBundleType.RENEGADE_SETTLED_PRIVATE_FILL;
         require(validType, IDarkpoolV2.InvalidSettlementBundleType());
         bundleData = abi.decode(bundle.data, (RenegadeSettledPrivateFillBundle));
     }
@@ -240,10 +237,10 @@ library RenegadeSettledPrivateFillLib {
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
 
-        // 3. Emit recovery IDs for the intent and balance
+        // 3. Spend recovery ID nullifiers for the intent and balance
         IntentAndBalanceValidityStatementFirstFill memory authStatement = bundleData.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.intentRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.balanceRecoveryId);
     }
 
     /// @notice Update the intent and input balance after authorization on a subsequent fill
@@ -291,10 +288,10 @@ library RenegadeSettledPrivateFillLib {
         state.insertMerkleLeaf(merkleDepth, newBalanceCommitment, hasher);
         state.insertMerkleLeaf(merkleDepth, newIntentCommitment, hasher);
 
-        // 3. Emit recovery IDs for the intent and balance
+        // 3. Spend recovery ID nullifiers for the intent and balance
         IntentAndBalanceValidityStatement memory authStatement = bundleData.auth.statement;
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.intentRecoveryId);
-        emit IDarkpoolV2.RecoveryIdRegistered(authStatement.balanceRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.intentRecoveryId);
+        state.spendRecoveryIdNullifier(authStatement.balanceRecoveryId);
     }
 
     // --------------------------------
@@ -446,9 +443,8 @@ library RenegadeSettledPrivateFillLib {
             computeFullBalanceCommitment(newOutBalancePublicShares, partialCommitment, hasher);
         state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, balCommitment, hasher);
 
-        // Emit a recovery ID for the output balance
-        BN254.ScalarField recoveryId = newBalanceBundle.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+        // Spend the recovery ID nullifier for the output balance
+        state.spendRecoveryIdNullifier(newBalanceBundle.statement.recoveryId);
     }
 
     /// @notice Update an existing output balance bundle in the Renegade state
@@ -486,9 +482,8 @@ library RenegadeSettledPrivateFillLib {
             computeFullBalanceCommitment(newOutBalancePublicShares, partialCommitment, hasher);
         state.insertMerkleLeaf(outputBalanceBundle.merkleDepth, balCommitment, hasher);
 
-        // Emit a recovery ID for the output balance
-        BN254.ScalarField recoveryId = existingBalanceBundle.statement.recoveryId;
-        emit IDarkpoolV2.RecoveryIdRegistered(recoveryId);
+        // Spend the recovery ID nullifier for the output balance
+        state.spendRecoveryIdNullifier(existingBalanceBundle.statement.recoveryId);
     }
 
     // --------------------------

--- a/tools/deploy/src/main.rs
+++ b/tools/deploy/src/main.rs
@@ -179,6 +179,10 @@ struct DeployDarkpoolImplementationArgs {
     /// Common arguments
     #[command(flatten)]
     common: CommonArgs,
+
+    /// Deploy the V1 version of the Darkpool implementation (V2 is deployed by default)
+    #[arg(long)]
+    v1: bool,
 }
 
 /// Arguments for deploying only the GasSponsor implementation contract
@@ -354,20 +358,29 @@ fn deploy_gas_sponsor(mut args: DeployGasSponsorArgs) -> Result<()> {
 
 /// Deploy only the Darkpool implementation contract (no proxy, no libraries)
 fn deploy_darkpool_implementation(args: DeployDarkpoolImplementationArgs) -> Result<()> {
+    let version = if args.v1 { "v1" } else { "v2" };
     println!(
-        "Deploying Darkpool implementation to RPC URL: {}",
+        "Deploying {version} Darkpool implementation to RPC URL: {}",
         args.common.rpc_url
     );
+
+    // Select the deploy script based on version
+    let deploy_script = if args.v1 {
+        "script/v1/DeployDarkpoolImplementation.s.sol:DeployDarkpoolImplementationScript"
+    } else {
+        "script/v2/DeployDarkpoolImpl.s.sol:DeployDarkpoolV2ImplementationScript"
+    };
 
     // Build the forge script command
     let mut cmd = Command::new("forge");
     cmd.arg("script")
-        .arg("script/v1/DeployDarkpoolImplementation.s.sol:DeployDarkpoolImplementationScript")
+        .arg(deploy_script)
         .arg("--rpc-url")
         .arg(&args.common.rpc_url)
         .arg("--sig")
         .arg(DARKPOOL_IMPLEMENTATION_RUN_SIGNATURE)
-        .arg("--broadcast") // Always use broadcast
+        .arg("--ffi") // Required for huffc (hasher deployment)
+        .arg("--broadcast")
         .arg("--private-key")
         .arg(&args.common.private_key)
         .arg(format!("-{}", args.common.verbosity));
@@ -375,7 +388,7 @@ fn deploy_darkpool_implementation(args: DeployDarkpoolImplementationArgs) -> Res
     // Execute the command
     run_command(cmd)?;
 
-    println!("\nDarkpool implementation deployment completed successfully!");
+    println!("\n{version} Darkpool implementation deployment completed successfully!");
     Ok(())
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a recovery ID nullifier set to the contracts to ensure that a recovery ID is not used twice.

### Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Tested on testnet 