### PR TITLE
feat: add per-party relayer fees to Ring0 settlement

### DIFF
--- a/abi/ICombinedV2.json
+++ b/abi/ICombinedV2.json
@@ -13740,7 +13740,31 @@
             ]
           },
           {
-            "name": "relayerFeeRate",
+            "name": "internalRelayerFeeRate",
+            "type": "tuple",
+            "internalType": "struct FeeRate",
+            "components": [
+              {
+                "name": "rate",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "externalRelayerFeeRate",
             "type": "tuple",
             "internalType": "struct FeeRate",
             "components": [
@@ -13921,7 +13945,31 @@
             ]
           },
           {
-            "name": "relayerFeeRate",
+            "name": "internalRelayerFeeRate",
+            "type": "tuple",
+            "internalType": "struct FeeRate",
+            "components": [
+              {
+                "name": "rate",
+                "type": "tuple",
+                "internalType": "struct FixedPoint",
+                "components": [
+                  {
+                    "name": "repr",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                  }
+                ]
+              },
+              {
+                "name": "recipient",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "externalRelayerFeeRate",
             "type": "tuple",
             "internalType": "struct FeeRate",
             "components": [

--- a/abi/src/v2/calldata_bundles.rs
+++ b/abi/src/v2/calldata_bundles.rs
@@ -4,6 +4,16 @@ use alloy::sol_types::SolValue;
 
 use super::IDarkpoolV2::*;
 
+impl FeeRate {
+    /// Create a zero fee rate (no fee, no recipient)
+    pub fn zero() -> Self {
+        Self {
+            rate: FixedPoint { repr: U256::ZERO },
+            recipient: Address::ZERO,
+        }
+    }
+}
+
 /// The public obligation bundle type
 pub const PUBLIC_OBLIGATION_BUNDLE_TYPE: u8 = 0;
 /// The private obligation bundle type
@@ -55,11 +65,13 @@ impl SettlementBundle {
     /// Build a public intent settlement bundle
     pub fn public_intent_settlement(
         auth: PublicIntentAuthBundle,
-        relayer_fee_rate: FeeRate,
+        internal_relayer_fee_rate: FeeRate,
+        external_relayer_fee_rate: FeeRate,
     ) -> Self {
         let inner = PublicIntentPublicBalanceBundle {
             auth,
-            relayerFeeRate: relayer_fee_rate,
+            internalRelayerFeeRate: internal_relayer_fee_rate,
+            externalRelayerFeeRate: external_relayer_fee_rate,
         };
         let data = inner.abi_encode();
 

--- a/abi/src/v2/relayer_types/bounded_match_result.rs
+++ b/abi/src/v2/relayer_types/bounded_match_result.rs
@@ -42,13 +42,14 @@ impl IDarkpoolV2::BoundedMatchResult {
     /// Build an executor signature for the bounded match result
     pub fn create_executor_signature(
         &self,
-        relayer_fee_rate: FeeRate,
+        internal_fee_rate: FeeRate,
+        external_fee_rate: FeeRate,
         chain_id: u64,
         signer: &PrivateKeySigner,
     ) -> Result<SignatureWithNonce, SignerError> {
         use alloy::sol_types::SolValue;
 
-        let payload = (relayer_fee_rate, self.clone()).abi_encode();
+        let payload = (internal_fee_rate, external_fee_rate, self.clone()).abi_encode();
         SignatureWithNonce::sign(payload.as_slice(), chain_id, signer)
     }
 }

--- a/abi/src/v2/relayer_types/obligation.rs
+++ b/abi/src/v2/relayer_types/obligation.rs
@@ -37,16 +37,18 @@ impl From<CircuitObligation> for IDarkpoolV2::SettlementObligation {
 impl SettlementObligation {
     /// Create an executor signature for a settlement obligation
     ///
-    /// This includes the relayer's fee rate in the signed payload
+    /// This includes both relayer fee rates in the signed payload
     pub fn create_executor_signature(
         &self,
-        relayer_fee_rate: &FeeRate,
+        internal_fee_rate: &FeeRate,
+        external_fee_rate: &FeeRate,
         chain_id: u64,
         signer: &PrivateKeySigner,
     ) -> Result<SignatureWithNonce, SignerError> {
         use alloy::sol_types::SolValue;
 
-        let payload = (relayer_fee_rate.clone(), self.clone()).abi_encode();
+        let payload =
+            (internal_fee_rate.clone(), external_fee_rate.clone(), self.clone()).abi_encode();
         SignatureWithNonce::sign(payload.as_slice(), chain_id, signer)
     }
 }

--- a/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
+++ b/src/darkpool/v2/libraries/settlement/NativeSettledPublicIntent.sol
@@ -55,6 +55,8 @@ library NativeSettledPublicIntentLib {
     /// @notice Error thrown when the implied price of the obligation does not meet the
     /// minimum authorized price
     error InvalidObligationPrice(uint256 amountOut, uint256 minAmountOut);
+    /// @notice Error thrown when the external relayer fee rate is nonzero for exact/internal settlement
+    error ExternalFeeRateMustBeZero();
 
     /// @notice Validate and execute a public intent and public balance settlement bundle
     /// @dev Note that in contrast to other settlement bundle types, no balance obligation
@@ -85,6 +87,9 @@ library NativeSettledPublicIntentLib {
         // Decode the settlement bundle data
         PublicIntentPublicBalanceBundle memory bundleData = settlementBundle.decodePublicBundleData();
         SettlementObligation memory obligation = obligationBundle.decodePublicObligation(partyId);
+
+        // For exact/internal settlement, external relayer fee rate must be zero (no external party)
+        if (bundleData.externalRelayerFeeRate.rate.repr != 0) revert ExternalFeeRateMustBeZero();
 
         // Verify that the executor has signed the settlement obligation
         validateObligationAuthorization(bundleData, obligation, state);
@@ -133,7 +138,7 @@ library NativeSettledPublicIntentLib {
         executeInner(bundleData, internalObligation, settlementContext, state);
 
         // Allocate transfers for external party
-        FeeRate memory externalRelayerFeeRate = bundleData.relayerFeeRate;
+        FeeRate memory externalRelayerFeeRate = bundleData.externalRelayerFeeRate;
         receivedAmount = ExternalSettlementLib.allocateExternalPartyTransfers(
             externalPartyRecipient, externalRelayerFeeRate, externalObligation, settlementContext, state
         );
@@ -160,10 +165,17 @@ library NativeSettledPublicIntentLib {
         validateObligationIntentConstraints(amountRemaining, intent, obligation);
 
         // 3. Execute the state updates necessary to settle the bundle
-        FeeRate memory relayerFeeRate = bundleData.relayerFeeRate;
+        FeeRate memory internalRelayerFeeRate = bundleData.internalRelayerFeeRate;
         FeeRate memory protocolFeeRate = state.getProtocolFeeRate(obligation.inputToken, obligation.outputToken);
         executeStateUpdates(
-            intentHash, intent, obligation, bundleData.auth, relayerFeeRate, protocolFeeRate, settlementContext, state
+            intentHash,
+            intent,
+            obligation,
+            bundleData.auth,
+            internalRelayerFeeRate,
+            protocolFeeRate,
+            settlementContext,
+            state
         );
     }
 
@@ -251,8 +263,8 @@ library NativeSettledPublicIntentLib {
     // -------------------------------
 
     /// @notice Validate the authorization of a bounded match result
-    /// @dev We require that the executor signed (relayerFeeRate, boundedMatchResult), which authorizes any obligations
-    /// derived from the match result to be settled at the specified fee rate.
+    /// @dev We require that the executor signed (internalRelayerFeeRate, externalRelayerFeeRate, boundedMatchResult),
+    /// which authorizes any obligations derived from the match result to be settled at the specified fee rates.
     /// @param bundleData The auth bundle data to validate
     /// @param matchResult The bounded match result to validate
     /// @param state The darkpool state containing all storage references
@@ -265,7 +277,7 @@ library NativeSettledPublicIntentLib {
     {
         PublicIntentAuthBundle memory auth = bundleData.auth;
 
-        // Verify that the executor has signed (relayerFeeRate, boundedMatchResult)
+        // Verify that the executor has signed (internalRelayerFeeRate, externalRelayerFeeRate, boundedMatchResult)
         bytes32 executorDigest = bundleData.computeBoundedMatchExecutorDigest(matchResult);
         bool executorValid =
             auth.executorSignature.verifyPrehashedAndSpendNonce(auth.intentPermit.executor, executorDigest, state);
@@ -312,8 +324,8 @@ library NativeSettledPublicIntentLib {
     /// @param intent The intent to update
     /// @param obligation The settlement obligation to update
     /// @param auth The public intent auth bundle containing permit registration data
-    /// @param relayerFeeRate The relayer fee rate to update
-    /// @param protocolFeeRate The protocol fee rate to update
+    /// @param internalRelayerFeeRate The internal relayer fee rate
+    /// @param protocolFeeRate The protocol fee rate
     /// @param settlementContext The settlement context to which we append post-validation updates.
     /// @param state The darkpool state containing all storage references
     function executeStateUpdates(
@@ -321,7 +333,7 @@ library NativeSettledPublicIntentLib {
         Intent memory intent,
         SettlementObligation memory obligation,
         PublicIntentAuthBundle memory auth,
-        FeeRate memory relayerFeeRate,
+        FeeRate memory internalRelayerFeeRate,
         FeeRate memory protocolFeeRate,
         SettlementContext memory settlementContext,
         DarkpoolState storage state
@@ -330,7 +342,7 @@ library NativeSettledPublicIntentLib {
     {
         // Compute the fee takes for the match
         (FeeTake memory relayerFeeTake, FeeTake memory protocolFeeTake) =
-            computeFeeTakes(obligation, relayerFeeRate, protocolFeeRate);
+            computeFeeTakes(obligation, internalRelayerFeeRate, protocolFeeRate);
 
         // Add transfers to settle the obligation
         // Deposit the input token into the darkpool
@@ -364,13 +376,13 @@ library NativeSettledPublicIntentLib {
 
     /// @notice Compute the fee takes for the match
     /// @param obligation The settlement obligation to compute fee takes for
-    /// @param relayerFeeRate The relayer fee rate to compute fee takes for
+    /// @param internalRelayerFeeRate The internal relayer fee rate to compute fee takes for
     /// @param protocolFeeRate The protocol fee rate to compute fee takes for
     /// @return relayerFeeTake The relayer fee take
     /// @return protocolFeeTake The protocol fee take
     function computeFeeTakes(
         SettlementObligation memory obligation,
-        FeeRate memory relayerFeeRate,
+        FeeRate memory internalRelayerFeeRate,
         FeeRate memory protocolFeeRate
     )
         internal
@@ -379,7 +391,7 @@ library NativeSettledPublicIntentLib {
     {
         uint256 receiveAmount = obligation.amountOut;
         address receiveToken = obligation.outputToken;
-        relayerFeeTake = relayerFeeRate.computeFeeTake(receiveToken, receiveAmount);
+        relayerFeeTake = internalRelayerFeeRate.computeFeeTake(receiveToken, receiveAmount);
         protocolFeeTake = protocolFeeRate.computeFeeTake(receiveToken, receiveAmount);
     }
 }

--- a/src/darkpool/v2/types/settlement/SettlementBundle.sol
+++ b/src/darkpool/v2/types/settlement/SettlementBundle.sol
@@ -67,8 +67,11 @@ enum SettlementBundleType {
 struct PublicIntentPublicBalanceBundle {
     /// @dev The public intent authorization payload with signature attached
     PublicIntentAuthBundle auth;
-    /// @dev The relayer's fee take for the match
-    FeeRate relayerFeeRate;
+    /// @dev The relayer fee rate charged to the internal party
+    FeeRate internalRelayerFeeRate;
+    /// @dev The relayer fee rate charged to the external party
+    /// @dev Must be zero for exact/internal settlement (no external party)
+    FeeRate externalRelayerFeeRate;
 }
 
 /// @title Settlement Bundle Library
@@ -166,7 +169,7 @@ library SettlementBundleLib {
     // --- Authorization Validation --- //
 
     /// @notice Compute the digest which the executor must sign for a natively settled public intent bundle
-    /// @dev The digest is the hash of the relayer's fee take and the obligation. The executor authorizes both these
+    /// @dev The digest is the hash of both relayer fee rates and the obligation. The executor authorizes all these
     /// values through a signature.
     /// @param bundleData The bundle data to compute the digest for
     /// @param obligation The settlement obligation to compute the digest for
@@ -179,15 +182,16 @@ library SettlementBundleLib {
         pure
         returns (bytes32 digest)
     {
-        // Encode and hash the fee take with the obligation
-        bytes memory encoded = abi.encode(bundleData.relayerFeeRate, obligation);
+        // Encode and hash both fee rates with the obligation
+        bytes memory encoded =
+            abi.encode(bundleData.internalRelayerFeeRate, bundleData.externalRelayerFeeRate, obligation);
         digest = EfficientHashLib.hash(encoded);
     }
 
     /// @notice Compute the digest which the executor must sign for a bounded match
-    /// @dev The digest is the hash of the relayer's fee take and the bounded match result. The executor authorizes both
+    /// @dev The digest is the hash of both relayer fee rates and the bounded match result. The executor authorizes all
     /// these values through a signature.
-    /// @param bundleData The bundle data containing the relayer fee rate
+    /// @param bundleData The bundle data containing the relayer fee rates
     /// @param matchResult The bounded match result
     /// @return digest The digest which the executor must sign
     function computeBoundedMatchExecutorDigest(
@@ -198,7 +202,8 @@ library SettlementBundleLib {
         pure
         returns (bytes32 digest)
     {
-        bytes memory encoded = abi.encode(bundleData.relayerFeeRate, matchResult);
+        bytes memory encoded =
+            abi.encode(bundleData.internalRelayerFeeRate, bundleData.externalRelayerFeeRate, matchResult);
         digest = EfficientHashLib.hash(encoded);
     }
 

--- a/test/darkpool/v2/settlement/external-match/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/Utils.sol
@@ -21,12 +21,14 @@ contract ExternalMatchTestUtils is SettlementTestUtils {
     // --- Bounded Match Result --- //
 
     /// @dev Create executor signature for bounded match
-    /// @param feeRate The relayer fee rate
+    /// @param internalFeeRate The internal relayer fee rate
+    /// @param externalFeeRate The external relayer fee rate
     /// @param matchResult The bounded match result
     /// @param signerPrivateKey The private key to sign with
     /// @return The executor signature
     function createBoundedMatchExecutorSignature(
-        FeeRate memory feeRate,
+        FeeRate memory internalFeeRate,
+        FeeRate memory externalFeeRate,
         BoundedMatchResult memory matchResult,
         uint256 signerPrivateKey
     )
@@ -34,19 +36,22 @@ contract ExternalMatchTestUtils is SettlementTestUtils {
         returns (SignatureWithNonce memory)
     {
         // Use the calldata version via external call for memory-to-calldata conversion
-        return this._createBoundedMatchExecutorSignatureCalldata(feeRate, matchResult, signerPrivateKey);
+        return this._createBoundedMatchExecutorSignatureCalldata(
+            internalFeeRate, externalFeeRate, matchResult, signerPrivateKey
+        );
     }
 
     /// @dev Create executor signature for bounded match (calldata version)
     function _createBoundedMatchExecutorSignatureCalldata(
-        FeeRate memory feeRate,
+        FeeRate memory internalFeeRate,
+        FeeRate memory externalFeeRate,
         BoundedMatchResult calldata matchResult,
         uint256 signerPrivateKey
     )
         external
         returns (SignatureWithNonce memory)
     {
-        bytes memory encoded = abi.encode(feeRate, matchResult);
+        bytes memory encoded = abi.encode(internalFeeRate, externalFeeRate, matchResult);
         bytes32 digest = EfficientHashLib.hash(encoded);
 
         uint256 nonce = randomUint();

--- a/test/darkpool/v2/settlement/external-match/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/external-match/native-settled-public-intents/Utils.sol
@@ -51,7 +51,8 @@ contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
 
     /// @dev Sign an obligation (memory version)
     function createExecutorSignature(
-        FeeRate memory feeRate,
+        FeeRate memory internalFeeRate,
+        FeeRate memory externalFeeRate,
         SettlementObligation memory obligation,
         uint256 signerPrivateKey
     )
@@ -59,20 +60,21 @@ contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
         returns (SignatureWithNonce memory)
     {
         // Use the calldata version via external call for memory-to-calldata conversion
-        return this._createExecutorSignatureCalldata(obligation, feeRate, signerPrivateKey);
+        return this._createExecutorSignatureCalldata(obligation, internalFeeRate, externalFeeRate, signerPrivateKey);
     }
 
     /// @dev Sign an obligation (calldata version)
     function _createExecutorSignatureCalldata(
         SettlementObligation memory obligation,
-        FeeRate memory feeRate,
+        FeeRate memory internalFeeRate,
+        FeeRate memory externalFeeRate,
         uint256 signerPrivateKey
     )
         external
         returns (SignatureWithNonce memory)
     {
-        // Hash the fee with obligation
-        bytes memory encoded = abi.encode(feeRate, obligation);
+        // Hash both fee rates with obligation
+        bytes memory encoded = abi.encode(internalFeeRate, externalFeeRate, obligation);
         bytes32 digest = EfficientHashLib.hash(encoded);
 
         // Sign with the private key
@@ -98,9 +100,12 @@ contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
         PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
         SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
 
-        // Create relayer fee rate and sign the executor digest with the executor key
-        FeeRate memory feeRate = relayerFeeRate();
-        SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
+        // Create relayer fee rates and sign the executor digest with the executor key
+        // For exact/internal settlement, external fee must be zero
+        FeeRate memory internalFeeRate = relayerFeeRate();
+        FeeRate memory externalFeeRate = FeeRate({ rate: FixedPointLib.wrap(0), recipient: address(0) });
+        SignatureWithNonce memory executorSignature =
+            createExecutorSignature(internalFeeRate, externalFeeRate, obligation, executorPrivateKey);
 
         // Create auth bundle with empty permit (no first-fill permit)
         SignedPermitSingle memory emptyPermit;
@@ -110,8 +115,11 @@ contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
             executorSignature: executorSignature,
             allowancePermit: emptyPermit
         });
-        PublicIntentPublicBalanceBundle memory bundleData =
-            PublicIntentPublicBalanceBundle({ auth: auth, relayerFeeRate: feeRate });
+        PublicIntentPublicBalanceBundle memory bundleData = PublicIntentPublicBalanceBundle({
+            auth: auth,
+            internalRelayerFeeRate: internalFeeRate,
+            externalRelayerFeeRate: externalFeeRate
+        });
 
         // Create the complete settlement bundle
         return SettlementBundle({
@@ -141,10 +149,11 @@ contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
         PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
         SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
 
-        // Create relayer fee rate and sign (feeRate, matchResult) with the executor key
-        FeeRate memory feeRate = relayerFeeRate();
+        // Create relayer fee rates and sign (fees, matchResult) with the executor key
+        FeeRate memory internalFeeRate = relayerFeeRate();
+        FeeRate memory externalFeeRate = relayerFeeRate();
         SignatureWithNonce memory executorSignature =
-            createBoundedMatchExecutorSignature(feeRate, matchResult, executorPrivateKey);
+            createBoundedMatchExecutorSignature(internalFeeRate, externalFeeRate, matchResult, executorPrivateKey);
 
         // Create auth bundle with empty permit (no first-fill permit)
         SignedPermitSingle memory emptyPermit;
@@ -154,8 +163,11 @@ contract PublicIntentExternalMatchTestUtils is ExternalMatchTestUtils {
             executorSignature: executorSignature,
             allowancePermit: emptyPermit
         });
-        PublicIntentPublicBalanceBundle memory bundleData =
-            PublicIntentPublicBalanceBundle({ auth: auth, relayerFeeRate: feeRate });
+        PublicIntentPublicBalanceBundle memory bundleData = PublicIntentPublicBalanceBundle({
+            auth: auth,
+            internalRelayerFeeRate: internalFeeRate,
+            externalRelayerFeeRate: externalFeeRate
+        });
 
         // Create the complete settlement bundle
         return SettlementBundle({

--- a/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/IntentAuthorization.t.sol
@@ -113,8 +113,9 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         SettlementObligation memory obligation0 = obligationBundle.decodePublicObligationMemory(PartyId.PARTY_0);
 
         // Corrupt the executor signature by signing with wrong signer
-        SignatureWithNonce memory sig =
-            createExecutorSignature(bundleData.relayerFeeRate, obligation0, wrongSigner.privateKey);
+        SignatureWithNonce memory sig = createExecutorSignature(
+            bundleData.internalRelayerFeeRate, bundleData.externalRelayerFeeRate, obligation0, wrongSigner.privateKey
+        );
         bundleData.auth.executorSignature = sig;
         bundle.data = abi.encode(bundleData);
 
@@ -149,12 +150,17 @@ contract IntentAuthorizationTest is PublicIntentSettlementTestUtils {
         uint256 minAmountOut = authBundle2.intentPermit.intent.minPrice.unsafeFixedPointMul(obligation0.amountIn);
         obligation0.amountOut = minAmountOut + 1;
         FeeRate memory feeRate2 = relayerFeeRate();
-        authBundle2.executorSignature = createExecutorSignature(feeRate2, obligation0, executor.privateKey);
+        FeeRate memory zeroFeeRate = FeeRate({ rate: FixedPointLib.wrap(0), recipient: address(0) });
+        authBundle2.executorSignature =
+            createExecutorSignature(feeRate2, zeroFeeRate, obligation0, executor.privateKey);
         ObligationBundle memory obligationBundle2 = buildObligationBundle(obligation0, obligation1);
 
         // Create the second bundle
-        PublicIntentPublicBalanceBundle memory bundleData2 =
-            PublicIntentPublicBalanceBundle({ auth: authBundle2, relayerFeeRate: feeRate2 });
+        PublicIntentPublicBalanceBundle memory bundleData2 = PublicIntentPublicBalanceBundle({
+            auth: authBundle2,
+            internalRelayerFeeRate: feeRate2,
+            externalRelayerFeeRate: zeroFeeRate
+        });
         SettlementBundle memory bundle2 = SettlementBundle({
             isFirstFill: false,
             bundleType: SettlementBundleType.NATIVELY_SETTLED_PUBLIC_INTENT,

--- a/test/darkpool/v2/settlement/native-settled-public-intents/PermitSingle.t.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/PermitSingle.t.sol
@@ -93,8 +93,10 @@ contract PermitSingleTests is PublicIntentSettlementTestUtils {
         PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
         SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
 
-        FeeRate memory feeRate = relayerFeeRate();
-        SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
+        FeeRate memory internalFeeRate = relayerFeeRate();
+        FeeRate memory externalFeeRate = FeeRate({ rate: FixedPointLib.wrap(0), recipient: address(0) });
+        SignatureWithNonce memory executorSignature =
+            createExecutorSignature(internalFeeRate, externalFeeRate, obligation, executorPrivateKey);
 
         return SettlementBundle({
             isFirstFill: false,
@@ -107,7 +109,8 @@ contract PermitSingleTests is PublicIntentSettlementTestUtils {
                         executorSignature: executorSignature,
                         allowancePermit: allowancePermit
                     }),
-                    relayerFeeRate: feeRate
+                    internalRelayerFeeRate: internalFeeRate,
+                    externalRelayerFeeRate: externalFeeRate
                 })
             )
         });

--- a/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
+++ b/test/darkpool/v2/settlement/native-settled-public-intents/Utils.sol
@@ -52,7 +52,8 @@ contract PublicIntentSettlementTestUtils is SettlementTestUtils {
 
     /// @dev Sign an obligation (memory version)
     function createExecutorSignature(
-        FeeRate memory feeRate,
+        FeeRate memory internalFeeRate,
+        FeeRate memory externalFeeRate,
         SettlementObligation memory obligation,
         uint256 signerPrivateKey
     )
@@ -60,20 +61,21 @@ contract PublicIntentSettlementTestUtils is SettlementTestUtils {
         returns (SignatureWithNonce memory)
     {
         // Use the calldata version via external call for memory-to-calldata conversion
-        return this._createExecutorSignatureCalldata(obligation, feeRate, signerPrivateKey);
+        return this._createExecutorSignatureCalldata(obligation, internalFeeRate, externalFeeRate, signerPrivateKey);
     }
 
     /// @dev Sign an obligation (calldata version)
     function _createExecutorSignatureCalldata(
         SettlementObligation memory obligation,
-        FeeRate memory feeRate,
+        FeeRate memory internalFeeRate,
+        FeeRate memory externalFeeRate,
         uint256 signerPrivateKey
     )
         external
         returns (SignatureWithNonce memory)
     {
-        // Hash the fee with obligation
-        bytes memory encoded = abi.encode(feeRate, obligation);
+        // Hash both fee rates with obligation
+        bytes memory encoded = abi.encode(internalFeeRate, externalFeeRate, obligation);
         bytes32 digest = EfficientHashLib.hash(encoded);
 
         // Sign with the private key
@@ -134,9 +136,12 @@ contract PublicIntentSettlementTestUtils is SettlementTestUtils {
         PublicIntentPermit memory permit = PublicIntentPermit({ intent: intent, executor: executor.addr });
         SignatureWithNonce memory intentSignature = signIntentPermit(permit, intentOwnerPrivateKey);
 
-        // Create relayer fee rate and sign the executor digest with the executor key
-        FeeRate memory feeRate = relayerFeeRate();
-        SignatureWithNonce memory executorSignature = createExecutorSignature(feeRate, obligation, executorPrivateKey);
+        // Create relayer fee rates and sign the executor digest with the executor key
+        // For exact/internal settlement, external fee must be zero
+        FeeRate memory internalFeeRate = relayerFeeRate();
+        FeeRate memory externalFeeRate = FeeRate({ rate: FixedPointLib.wrap(0), recipient: address(0) });
+        SignatureWithNonce memory executorSignature =
+            createExecutorSignature(internalFeeRate, externalFeeRate, obligation, executorPrivateKey);
 
         // Create auth bundle with empty permit (no first-fill permit)
         SignedPermitSingle memory emptyPermit;
@@ -146,8 +151,11 @@ contract PublicIntentSettlementTestUtils is SettlementTestUtils {
             executorSignature: executorSignature,
             allowancePermit: emptyPermit
         });
-        PublicIntentPublicBalanceBundle memory bundleData =
-            PublicIntentPublicBalanceBundle({ auth: auth, relayerFeeRate: feeRate });
+        PublicIntentPublicBalanceBundle memory bundleData = PublicIntentPublicBalanceBundle({
+            auth: auth,
+            internalRelayerFeeRate: internalFeeRate,
+            externalRelayerFeeRate: externalFeeRate
+        });
 
         // Create the complete settlement bundle
         return SettlementBundle({


### PR DESCRIPTION
## Summary

Ring0 external bounded settlement (`NATIVELY_SETTLED_PUBLIC_INTENT`) previously used a single `relayerFeeRate` for both the internal and external party. This PR splits it into `internalRelayerFeeRate` + `externalRelayerFeeRate`, bringing Ring0 to parity with Ring1 and Ring2 bounded external settlement.

## Changes

- **`SettlementBundle.sol`**: Replace `relayerFeeRate` with `internalRelayerFeeRate` + `externalRelayerFeeRate` on `PublicIntentPublicBalanceBundle`. Update both executor digest functions to sign both fees.
- **`NativeSettledPublicIntent.sol`**: Use `internalRelayerFeeRate` for internal party settlement, `externalRelayerFeeRate` for external party allocation. Require external fee == 0 for exact/internal settlement.
- **ABI**: Regenerate `ICombinedV2.json`. Update Rust extension traits (`public_intent_settlement`, `create_executor_signature`) to take two `FeeRate` args. Add `FeeRate::zero()`.
- **Tests**: Update all Ring0 test utils and test files for new two-fee struct and signing format.

## Breaking Change

This changes the Ring0 bundle encoding and executor digest format. Requires coordinated deploy with relayer changes in https://github.com/renegade-fi/renegade.

## Ticket

`renegade-map/tickets/add-per-party-relayer-fees-to-ring0-external-matches/`